### PR TITLE
fix(create-arkor): use dirname for parent directory creation

### DIFF
--- a/packages/create-arkor/src/scaffold.ts
+++ b/packages/create-arkor/src/scaffold.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { STARTER_CONFIG, STARTER_README, TEMPLATES, type TemplateId } from "./templates";
 
 export type FileAction = "created" | "kept" | "patched" | "ok";
@@ -42,7 +42,7 @@ async function ensureFile(
   contents: string,
 ): Promise<FileAction> {
   if (existsSync(absPath)) return "kept";
-  await mkdir(join(absPath, "..").replace(/\/\.$/, ""), { recursive: true });
+  await mkdir(dirname(absPath), { recursive: true });
   await writeFile(absPath, contents);
   return "created";
 }


### PR DESCRIPTION
### Motivation
- Make parent-directory creation in scaffolding robust by using a proper path API instead of ad-hoc string manipulation.

### Description
- Update `packages/create-arkor/src/scaffold.ts` to import `dirname` from `node:path` and use `dirname(absPath)` when creating the parent directory in `ensureFile`.

### Testing
- Ran `pnpm --filter create-arkor test` which passed.
- Ran `pnpm --filter create-arkor typecheck` (`tsc --noEmit`) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba2cd13dc83238711beb042f243eb)