### PR TITLE
Enhance Studio server with CSRF protection and token validation

### DIFF
--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { serve } from "@hono/node-server";
 import open from "open";
 import { fetchCliConfig } from "../../core/auth0";
@@ -64,7 +65,11 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   await ensureCredentialsForStudio();
 
   const port = options.port ?? 4000;
-  const app = buildStudioApp({ autoAnonymous: false });
+  // Per-launch CSRF token: injected into index.html as <meta>, required on
+  // every /api/* request. Prevents another tab on the same machine from
+  // hitting `arkor train` (and therefore RCE via dynamic import).
+  const studioToken = randomBytes(32).toString("base64url");
+  const app = buildStudioApp({ autoAnonymous: false, studioToken });
   const url = `http://127.0.0.1:${port}`;
   serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
   process.stdout.write(`Arkor Studio running on ${url}\n`);

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -108,8 +108,22 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   // every /api/* request. Prevents another tab on the same machine from
   // hitting `arkor train` (and therefore RCE via dynamic import).
   const studioToken = randomBytes(32).toString("base64url");
-  const tokenPath = await persistStudioToken(studioToken);
-  scheduleStudioTokenCleanup(tokenPath);
+
+  // Persisting the token to disk is *only* needed for the Vite SPA dev
+  // workflow. The bundled `:port` flow injects the meta tag at request time
+  // via `buildStudioApp`, so a failure here (read-only $HOME on Docker /
+  // locked-down CI / restrictive umask) must not block the server.
+  try {
+    const tokenPath = await persistStudioToken(studioToken);
+    scheduleStudioTokenCleanup(tokenPath);
+  } catch (err) {
+    ui.log.warn(
+      `Could not write ${studioTokenPath()} (${
+        err instanceof Error ? err.message : String(err)
+      }). The Studio at http://127.0.0.1:${port} is unaffected, but the Vite SPA dev workflow will see 403s on /api/*.`,
+    );
+  }
+
   const app = buildStudioApp({ autoAnonymous: false, studioToken });
   const url = `http://127.0.0.1:${port}`;
   serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -1,10 +1,14 @@
 import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { serve } from "@hono/node-server";
 import open from "open";
 import { fetchCliConfig } from "../../core/auth0";
 import {
   defaultArkorCloudApiUrl,
   readCredentials,
+  studioTokenPath,
   writeCredentials,
   requestAnonymousToken,
   type AnonymousCredentials,
@@ -61,6 +65,41 @@ async function ensureCredentialsForStudio(): Promise<void> {
   ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
 }
 
+/**
+ * Persist the per-launch token to `~/.arkor/studio-token` (mode 0600) so the
+ * studio-app Vite dev server can pick it up via its `transformIndexHtml`
+ * plugin. The bundled `arkor dev` flow doesn't need the file (it injects via
+ * `buildStudioApp`), but the SPA dev workflow (`pnpm --filter @arkor/studio-app dev`)
+ * proxies `/api/*` to :4000 and would otherwise serve a token-less index.html.
+ */
+async function persistStudioToken(token: string): Promise<string> {
+  const path = studioTokenPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, token, { mode: 0o600 });
+  await chmod(path, 0o600);
+  return path;
+}
+
+function scheduleStudioTokenCleanup(path: string): void {
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    try {
+      unlinkSync(path);
+    } catch {
+      // best-effort
+    }
+  };
+  process.on("exit", cleanup);
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(sig, () => {
+      cleanup();
+      process.exit(0);
+    });
+  }
+}
+
 export async function runDev(options: DevOptions = {}): Promise<void> {
   await ensureCredentialsForStudio();
 
@@ -69,6 +108,8 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   // every /api/* request. Prevents another tab on the same machine from
   // hitting `arkor train` (and therefore RCE via dynamic import).
   const studioToken = randomBytes(32).toString("base64url");
+  const tokenPath = await persistStudioToken(studioToken);
+  scheduleStudioTokenCleanup(tokenPath);
   const app = buildStudioApp({ autoAnonymous: false, studioToken });
   const url = `http://127.0.0.1:${port}`;
   serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });

--- a/packages/arkor/src/core/credentials.ts
+++ b/packages/arkor/src/core/credentials.ts
@@ -33,6 +33,18 @@ export function credentialsPath(): string {
   return join(credentialsDir(), "credentials.json");
 }
 
+/**
+ * Path to the per-launch Studio CSRF token file.
+ *
+ * Source of truth: `arkor dev` writes the token here on start (mode 0600) and
+ * deletes it on exit. The studio-app Vite dev server reads from this same
+ * path via a `transformIndexHtml` plugin so the SPA receives the token even
+ * when served by Vite (which doesn't go through `buildStudioApp`'s injection).
+ */
+export function studioTokenPath(): string {
+  return join(credentialsDir(), "studio-token");
+}
+
 export async function readCredentials(): Promise<Credentials | null> {
   const path = credentialsPath();
   if (!existsSync(path)) return null;

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -5,8 +5,11 @@ import { join } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
 
+const STUDIO_TOKEN = "test-studio-token-0123456789";
+
 let fakeHome: string;
 let assetsDir: string;
+let trainCwd: string;
 const ORIG_HOME = process.env.HOME;
 
 beforeEach(() => {
@@ -14,43 +17,73 @@ beforeEach(() => {
   process.env.HOME = fakeHome;
   assetsDir = mkdtempSync(join(tmpdir(), "arkor-studio-assets-"));
   mkdirSync(assetsDir, { recursive: true });
-  writeFileSync(join(assetsDir, "index.html"), "<title>Studio</title>");
+  writeFileSync(
+    join(assetsDir, "index.html"),
+    "<!doctype html><html><head><title>Studio</title></head><body></body></html>",
+  );
+  trainCwd = mkdtempSync(join(tmpdir(), "arkor-studio-cwd-"));
 });
 
 afterEach(() => {
   process.env.HOME = ORIG_HOME;
   rmSync(fakeHome, { recursive: true, force: true });
   rmSync(assetsDir, { recursive: true, force: true });
+  rmSync(trainCwd, { recursive: true, force: true });
 });
 
+function build() {
+  return buildStudioApp({
+    baseUrl: "http://mock",
+    assetsDir,
+    autoAnonymous: false,
+    studioToken: STUDIO_TOKEN,
+    cwd: trainCwd,
+  });
+}
+
 describe("Studio server", () => {
-  it("serves index.html at /", async () => {
-    const app = buildStudioApp({
-      baseUrl: "http://mock",
-      assetsDir,
-      autoAnonymous: false,
-    });
+  it("requires a studioToken at construction time", () => {
+    expect(() =>
+      buildStudioApp({
+        baseUrl: "http://mock",
+        assetsDir,
+        autoAnonymous: false,
+        // @ts-expect-error — intentionally omitted to assert the runtime guard
+        studioToken: undefined,
+      }),
+    ).toThrow(/studioToken/);
+  });
+
+  it("serves index.html at / with the studio token injected", async () => {
+    const app = build();
     const res = await app.request("/", {
       headers: { host: "127.0.0.1:4000" },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
-    expect(await res.text()).toBe("<title>Studio</title>");
+    const html = await res.text();
+    expect(html).toContain("<title>Studio</title>");
+    expect(html).toContain(
+      `<meta name="arkor-studio-token" content="${STUDIO_TOKEN}">`,
+    );
+    // Injection lands inside <head>, before </head>.
+    expect(html.indexOf("arkor-studio-token")).toBeLessThan(
+      html.indexOf("</head>"),
+    );
   });
 
-  it("rejects non-loopback API requests", async () => {
-    const app = buildStudioApp({
-      baseUrl: "http://mock",
-      assetsDir,
-      autoAnonymous: false,
-    });
+  it("rejects non-loopback API requests (DNS rebinding defense)", async () => {
+    const app = build();
     const res = await app.request("/api/credentials", {
-      headers: { host: "192.168.1.5:4000" },
+      headers: {
+        host: "192.168.1.5:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+      },
     });
     expect(res.status).toBe(403);
   });
 
-  it("returns the current credential token", async () => {
+  it("rejects /api/* without a studio token", async () => {
     await writeCredentials({
       mode: "anon",
       token: "tok",
@@ -58,13 +91,38 @@ describe("Studio server", () => {
       arkorCloudApiUrl: "http://mock",
       orgSlug: "anon-org",
     });
-    const app = buildStudioApp({
-      baseUrl: "http://mock",
-      assetsDir,
-      autoAnonymous: false,
-    });
+    const app = build();
     const res = await app.request("/api/credentials", {
       headers: { host: "127.0.0.1:4000" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects /api/* with a wrong studio token", async () => {
+    const app = build();
+    const res = await app.request("/api/credentials", {
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": "not-the-token",
+      },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the current credential token when the studio token is valid", async () => {
+    await writeCredentials({
+      mode: "anon",
+      token: "tok",
+      anonymousId: "anon-id",
+      arkorCloudApiUrl: "http://mock",
+      orgSlug: "anon-org",
+    });
+    const app = build();
+    const res = await app.request("/api/credentials", {
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+      },
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
@@ -74,5 +132,51 @@ describe("Studio server", () => {
       baseUrl: "http://mock",
       orgSlug: "anon-org",
     });
+  });
+
+  it("accepts the studio token via ?studioToken= for SSE-style requests", async () => {
+    await writeCredentials({
+      mode: "anon",
+      token: "tok",
+      anonymousId: "anon-id",
+      arkorCloudApiUrl: "http://mock",
+      orgSlug: "anon-org",
+    });
+    const app = build();
+    const res = await app.request(
+      `/api/credentials?studioToken=${encodeURIComponent(STUDIO_TOKEN)}`,
+      { headers: { host: "127.0.0.1:4000" } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects /api/train with a file path that escapes cwd", async () => {
+    const app = build();
+    const res = await app.request("/api/train", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ file: "../escape.ts" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/inside the project directory/);
+  });
+
+  it("rejects /api/train with an absolute file path outside cwd", async () => {
+    const app = build();
+    const res = await app.request("/api/train", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ file: "/etc/passwd" }),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -1,11 +1,10 @@
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import { createClient } from "@arkor/cloud-api-client";
 import {
   defaultArkorCloudApiUrl,
-  ensureCredentials,
   readCredentials,
   writeCredentials,
   requestAnonymousToken,
@@ -13,7 +12,7 @@ import {
 } from "../core/credentials";
 import { readState } from "../core/state";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -26,33 +25,92 @@ export interface StudioServerOptions {
    * present. Mirrors the CLI default.
    */
   autoAnonymous?: boolean;
+  /**
+   * Per-launch CSRF token. Every `/api/*` request must include it via header
+   * `X-Arkor-Studio-Token`, or `?studioToken=` for `EventSource` (which can't
+   * carry custom headers). The token is injected into the served `index.html`
+   * as a `<meta>` tag so the same-origin SPA can read it; cross-origin tabs
+   * cannot, so even a "simple" CORS POST without preflight is rejected.
+   */
+  studioToken: string;
+  /**
+   * Working directory used to resolve / validate `body.file` for `/api/train`.
+   * Defaults to `process.cwd()`.
+   */
+  cwd?: string;
 }
 
-export function buildStudioApp(options: StudioServerOptions = {}) {
+function tokensMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function htmlAttrEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) =>
+    ch === "&"
+      ? "&amp;"
+      : ch === "<"
+        ? "&lt;"
+        : ch === ">"
+          ? "&gt;"
+          : ch === '"'
+            ? "&quot;"
+            : "&#39;",
+  );
+}
+
+function injectStudioToken(html: string, token: string): string {
+  const meta = `<meta name="arkor-studio-token" content="${htmlAttrEscape(token)}">`;
+  const idx = html.indexOf("</head>");
+  if (idx === -1) return `${meta}${html}`;
+  return `${html.slice(0, idx)}${meta}${html.slice(idx)}`;
+}
+
+export function buildStudioApp(options: StudioServerOptions) {
   const baseUrl = options.baseUrl ?? defaultArkorCloudApiUrl();
   const assetsDir = options.assetsDir ?? join(__dirname, "assets");
   const autoAnonymous = options.autoAnonymous ?? true;
+  const studioToken = options.studioToken;
+  const trainCwd = options.cwd ?? process.cwd();
+
+  if (!studioToken || studioToken.length < 16) {
+    throw new Error(
+      "buildStudioApp requires a studioToken with at least 16 characters of entropy.",
+    );
+  }
 
   const app = new Hono();
 
-  // Loopback-only guard for credential-sensitive API routes. `arkor dev` binds
-  // to 127.0.0.1, but defence in depth keeps this explicit.
+  // Combined defense for `/api/*`:
+  //   1. Host-header guard (defense against DNS rebinding — a victim navigated
+  //      to `evil.com` rebound onto 127.0.0.1 still sends `Host: evil.com`).
+  //   2. Per-launch CSRF token. CORS is intentionally not configured: the SPA
+  //      is same-origin so CORS adds no value, and reflecting `*` would let
+  //      "simple" cross-origin POSTs (text/plain, urlencoded) skip preflight
+  //      and reach the handler. The token check rejects those — an attacker
+  //      page can't read the SPA's <meta> from another origin.
   app.use("/api/*", async (c, next) => {
     const host = c.req.header("host") ?? "";
     if (!/^(127\.0\.0\.1|localhost)(:\d+)?$/.test(host)) {
       return c.json({ error: "Studio API is loopback-only" }, 403);
     }
+    const provided =
+      c.req.header("x-arkor-studio-token") ??
+      c.req.query("studioToken") ??
+      "";
+    if (!tokensMatch(provided, studioToken)) {
+      return c.json({ error: "Missing or invalid studio token" }, 403);
+    }
     await next();
   });
-  app.use("/api/*", cors({ origin: (origin) => origin ?? "*" }));
 
   async function getCredentials(): Promise<Credentials> {
     const existing = await readCredentials();
     if (existing) return existing;
     if (!autoAnonymous) {
-      throw new Error(
-        "No credentials on file. Run `arkor login` first.",
-      );
+      throw new Error("No credentials on file. Run `arkor login` first.");
     }
     const anon = await requestAnonymousToken(baseUrl, "cli");
     const creds: Credentials = {
@@ -135,16 +193,26 @@ export function buildStudioApp(options: StudioServerOptions = {}) {
   });
 
   app.post("/api/train", async (c) => {
-    const body = (await c.req
-      .json()
-      .catch(() => ({}))) as { file?: string };
+    const body = (await c.req.json().catch(() => ({}))) as { file?: string };
+    let trainFile: string | undefined;
+    if (body.file) {
+      const baseAbs = resolve(trainCwd);
+      const abs = resolve(baseAbs, body.file);
+      if (abs !== baseAbs && !abs.startsWith(baseAbs + sep)) {
+        return c.json(
+          { error: "file must be inside the project directory" },
+          400,
+        );
+      }
+      trainFile = abs;
+    }
     const args = ["--experimental-strip-types", "--no-warnings=ExperimentalWarning"];
     const pkgBinPath = new URL("../bin.mjs", import.meta.url).pathname;
     args.push(pkgBinPath, "train");
-    if (body.file) args.push(body.file);
+    if (trainFile) args.push(trainFile);
     const child = spawn(process.execPath, args, {
       stdio: "pipe",
-      cwd: process.cwd(),
+      cwd: trainCwd,
     });
     const stream = new ReadableStream({
       start(controller) {
@@ -208,6 +276,13 @@ export function buildStudioApp(options: StudioServerOptions = {}) {
     try {
       const file = await readFile(join(assetsDir, cleaned));
       const ext = cleaned.slice(cleaned.lastIndexOf(".") + 1);
+      if (ext === "html") {
+        const html = injectStudioToken(file.toString("utf8"), studioToken);
+        return new Response(html, {
+          status: 200,
+          headers: { "content-type": CONTENT_TYPES.html! },
+        });
+      }
       return new Response(file, {
         status: 200,
         headers: {

--- a/packages/studio-app/src/lib/api.ts
+++ b/packages/studio-app/src/lib/api.ts
@@ -22,32 +22,65 @@ export interface Job {
   config?: Record<string, unknown>;
 }
 
+function readStudioToken(): string {
+  if (typeof document === "undefined") return "";
+  const meta = document.querySelector('meta[name="arkor-studio-token"]');
+  return meta?.getAttribute("content") ?? "";
+}
+
+const STUDIO_TOKEN = readStudioToken();
+
+/**
+ * `fetch` with the per-launch CSRF token attached. The token is read once at
+ * module load from the `<meta>` tag the Studio server injects into
+ * `index.html`; cross-origin tabs cannot read it (same-origin policy on the
+ * HTML body) so the server's `/api/*` middleware rejects forged requests.
+ */
+export async function apiFetch(
+  input: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  if (STUDIO_TOKEN) headers.set("X-Arkor-Studio-Token", STUDIO_TOKEN);
+  return fetch(input, { ...init, headers });
+}
+
+function withStudioToken(url: string): string {
+  if (!STUDIO_TOKEN) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}studioToken=${encodeURIComponent(STUDIO_TOKEN)}`;
+}
+
 async function json<T>(res: Response): Promise<T> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res.json() as Promise<T>;
 }
 
 export async function fetchCredentials(): Promise<Credentials> {
-  return json(await fetch("/api/credentials"));
+  return json(await apiFetch("/api/credentials"));
 }
 
 export async function fetchMe(): Promise<Me> {
-  return json(await fetch("/api/me"));
+  return json(await apiFetch("/api/me"));
 }
 
 export async function fetchJobs(): Promise<{ jobs: Job[] }> {
-  return json(await fetch("/api/jobs"));
+  return json(await apiFetch("/api/jobs"));
 }
 
 export function openJobEvents(jobId: string): EventSource {
-  return new EventSource(`/api/jobs/${encodeURIComponent(jobId)}/events`);
+  // EventSource can't carry custom headers, so the token rides as a query
+  // parameter. The Studio server is loopback-only and access logs are local.
+  return new EventSource(
+    withStudioToken(`/api/jobs/${encodeURIComponent(jobId)}/events`),
+  );
 }
 
 export async function streamTraining(
   onChunk: (text: string) => void,
   file?: string,
 ): Promise<void> {
-  const res = await fetch("/api/train", {
+  const res = await apiFetch("/api/train", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ ...(file ? { file } : {}) }),

--- a/packages/studio-app/src/pages/Playground.tsx
+++ b/packages/studio-app/src/pages/Playground.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { fetchJobs, type Job } from "../lib/api";
+import { apiFetch, fetchJobs, type Job } from "../lib/api";
 
 interface Message {
   role: "system" | "user" | "assistant";
@@ -36,7 +36,7 @@ export function Playground() {
         messages: [...messages, userMsg],
         stream: true,
       };
-      const res = await fetch("/api/inference/chat", {
+      const res = await apiFetch("/api/inference/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/packages/studio-app/vite.config.ts
+++ b/packages/studio-app/vite.config.ts
@@ -28,10 +28,17 @@ function htmlAttrEscape(s: string): string {
  * SPA's `apiFetch` can attach it. `arkor dev` writes the token to
  * `~/.arkor/studio-token` on launch; we re-read on every request so that
  * starting `arkor dev` after Vite is picked up on the next reload.
+ *
+ * `apply: "serve"` constrains this to the dev server. If it ran during
+ * `vite build` it would bake the current per-launch token into `dist/
+ * index.html`, and since `document.querySelector` returns the first match,
+ * the stale baked tag would shadow the runtime tag injected by
+ * `buildStudioApp` and every `/api/*` call would 403.
  */
 function arkorStudioToken(): Plugin {
   return {
     name: "arkor-studio-token",
+    apply: "serve",
     enforce: "pre",
     async transformIndexHtml(html) {
       let token: string;

--- a/packages/studio-app/vite.config.ts
+++ b/packages/studio-app/vite.config.ts
@@ -1,11 +1,61 @@
-import { defineConfig } from "vite";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+
+// Source of truth for this path is `packages/arkor/src/core/credentials.ts`
+// (`studioTokenPath`). Cross-package imports complicate the Vite config build
+// so we mirror the constant here; if it ever changes, update both sides.
+const STUDIO_TOKEN_PATH = join(homedir(), ".arkor", "studio-token");
+
+function htmlAttrEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) =>
+    ch === "&"
+      ? "&amp;"
+      : ch === "<"
+        ? "&lt;"
+        : ch === ">"
+          ? "&gt;"
+          : ch === '"'
+            ? "&quot;"
+            : "&#39;",
+  );
+}
+
+/**
+ * Inject the per-launch Studio CSRF token into served `index.html` so the
+ * SPA's `apiFetch` can attach it. `arkor dev` writes the token to
+ * `~/.arkor/studio-token` on launch; we re-read on every request so that
+ * starting `arkor dev` after Vite is picked up on the next reload.
+ */
+function arkorStudioToken(): Plugin {
+  return {
+    name: "arkor-studio-token",
+    enforce: "pre",
+    async transformIndexHtml(html) {
+      let token: string;
+      try {
+        token = (await readFile(STUDIO_TOKEN_PATH, "utf8")).trim();
+      } catch {
+        // `arkor dev` not running yet — leave the SPA token-less and let
+        // the Studio server's 403 surface the wiring problem on first call.
+        return html;
+      }
+      if (!token) return html;
+      const meta = `<meta name="arkor-studio-token" content="${htmlAttrEscape(token)}">`;
+      const idx = html.indexOf("</head>");
+      if (idx === -1) return `${meta}${html}`;
+      return `${html.slice(0, idx)}${meta}${html.slice(idx)}`;
+    },
+  };
+}
 
 // Vite dev serves on 127.0.0.1:5173 and proxies /api/* to the Studio Hono
 // server on :4000. Production build goes straight to `dist/` and is copied
 // into arkor's package dist/ by `scripts/copy-studio-assets.mjs`.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), arkorStudioToken()],
   server: {
     host: "127.0.0.1",
     port: 5173,


### PR DESCRIPTION
- Introduced a per-launch CSRF token mechanism for `/api/*` requests, requiring the token to be included in headers or as a query parameter.
- Updated the `buildStudioApp` function to enforce token presence and validate its integrity.
- Modified the server response to inject the CSRF token into the served `index.html` for client-side access.
- Enhanced tests to cover scenarios for token validation and API request handling, ensuring robust security against unauthorized access.