### PR TITLE
Fix /api/train ENOENT in built installs

### DIFF
--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -5,6 +5,14 @@ import { join } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
 
+const ANON_CREDS = {
+  mode: "anon" as const,
+  token: "tok",
+  anonymousId: "anon-id",
+  arkorCloudApiUrl: "http://mock",
+  orgSlug: "anon-org",
+};
+
 const STUDIO_TOKEN = "test-studio-token-0123456789";
 
 let fakeHome: string;
@@ -178,5 +186,75 @@ describe("Studio server", () => {
       body: JSON.stringify({ file: "/etc/passwd" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  // Regression for ENG-356 — `/api/train` previously resolved the bundled
+  // bin at `<pkg>/bin.mjs` (one level above `dist/`), which never existed.
+  // The DI'd `binPath` lets us assert (a) a working bin streams its stdout
+  // through the response, and (b) a missing bin surfaces ENOENT-grade errors
+  // rather than silently succeeding.
+  describe("/api/train spawn (binPath DI)", () => {
+    it("streams a real spawn's stdout and exits cleanly when binPath is valid", async () => {
+      await writeCredentials(ANON_CREDS);
+      const fakeBin = join(trainCwd, "fake-bin.mjs");
+      writeFileSync(
+        fakeBin,
+        `#!/usr/bin/env node
+process.stdout.write("[fake-bin] argv=" + JSON.stringify(process.argv.slice(2)) + "\\n");
+process.exit(0);
+`,
+      );
+
+      const app = buildStudioApp({
+        baseUrl: "http://mock",
+        assetsDir,
+        autoAnonymous: false,
+        studioToken: STUDIO_TOKEN,
+        cwd: trainCwd,
+        binPath: fakeBin,
+      });
+      const res = await app.request("/api/train", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("[fake-bin]");
+      // The bin receives `train` as the first non-flag arg.
+      expect(text).toContain('argv=["train"]');
+      expect(text).toContain("exit=0");
+      expect(text).not.toMatch(/Cannot find module|MODULE_NOT_FOUND|ENOENT/);
+    });
+
+    it("surfaces ENOENT-grade errors when binPath does not exist", async () => {
+      await writeCredentials(ANON_CREDS);
+      const app = buildStudioApp({
+        baseUrl: "http://mock",
+        assetsDir,
+        autoAnonymous: false,
+        studioToken: STUDIO_TOKEN,
+        cwd: trainCwd,
+        binPath: join(trainCwd, "definitely-not-a-bin.mjs"),
+      });
+      const res = await app.request("/api/train", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200); // stream opens; the failure shows up in the body
+      const text = await res.text();
+      expect(text).toMatch(/Cannot find module|MODULE_NOT_FOUND|ENOENT/);
+      expect(text).toContain("exit=");
+      expect(text).not.toContain("exit=0");
+    });
   });
 });

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -38,6 +38,13 @@ export interface StudioServerOptions {
    * Defaults to `process.cwd()`.
    */
   cwd?: string;
+  /**
+   * Absolute path to the `arkor` bin spawned by `/api/train`. Defaults to
+   * `dist/bin.mjs` resolved as a sibling of the bundled studio code (this
+   * file is inlined into `dist/bin.mjs` at build time, so `./bin.mjs` from
+   * here points at the bin itself). Override in tests.
+   */
+  binPath?: string;
 }
 
 function tokensMatch(provided: string, expected: string): boolean {
@@ -74,6 +81,12 @@ export function buildStudioApp(options: StudioServerOptions) {
   const autoAnonymous = options.autoAnonymous ?? true;
   const studioToken = options.studioToken;
   const trainCwd = options.cwd ?? process.cwd();
+  // `studio/server.ts` is bundled into `dist/bin.mjs` (it isn't reachable
+  // from `src/index.ts`, so tsdown doesn't extract it as a shared chunk).
+  // The bin therefore sits *next* to this code at runtime, not one
+  // directory up — `../bin.mjs` would resolve to the package root.
+  const trainBinPath =
+    options.binPath ?? fileURLToPath(new URL("./bin.mjs", import.meta.url));
 
   if (!studioToken || studioToken.length < 16) {
     throw new Error(
@@ -207,12 +220,7 @@ export function buildStudioApp(options: StudioServerOptions) {
       trainFile = abs;
     }
     const args = ["--experimental-strip-types", "--no-warnings=ExperimentalWarning"];
-    // `studio/server.ts` is bundled into `dist/bin.mjs` (it isn't reachable
-    // from `src/index.ts`, so tsdown doesn't extract it as a shared chunk).
-    // The bin therefore sits *next* to this code at runtime, not one
-    // directory up — `../bin.mjs` would resolve to the package root.
-    const pkgBinPath = fileURLToPath(new URL("./bin.mjs", import.meta.url));
-    args.push(pkgBinPath, "train");
+    args.push(trainBinPath, "train");
     if (trainFile) args.push(trainFile);
     const child = spawn(process.execPath, args, {
       stdio: "pipe",

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -207,7 +207,11 @@ export function buildStudioApp(options: StudioServerOptions) {
       trainFile = abs;
     }
     const args = ["--experimental-strip-types", "--no-warnings=ExperimentalWarning"];
-    const pkgBinPath = new URL("../bin.mjs", import.meta.url).pathname;
+    // `studio/server.ts` is bundled into `dist/bin.mjs` (it isn't reachable
+    // from `src/index.ts`, so tsdown doesn't extract it as a shared chunk).
+    // The bin therefore sits *next* to this code at runtime, not one
+    // directory up — `../bin.mjs` would resolve to the package root.
+    const pkgBinPath = fileURLToPath(new URL("./bin.mjs", import.meta.url));
     args.push(pkgBinPath, "train");
     if (trainFile) args.push(trainFile);
     const child = spawn(process.execPath, args, {


### PR DESCRIPTION
`new URL("../bin.mjs", import.meta.url)` resolved to the package root (one level above `dist/`), where no `bin.mjs` exists — `/api/train` spawn always ENOENT'd in any built install.

`studio/server.ts` is bundled into `dist/bin.mjs` because nothing in `src/index.ts` imports it, so tsdown inlines it rather than extracting a shared chunk. The bin we want to spawn is therefore a sibling of this code, not one directory up. Switch to `./bin.mjs` and use `fileURLToPath` so Windows drive letters survive.