### PR TITLE
Stop showing raw SSE frames in the Playground

### DIFF
--- a/packages/studio-app/package.json
+++ b/packages/studio-app/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "build": "tsc --noEmit && vite build",
     "dev": "vite",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "eventsource-parser": "^3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -17,6 +20,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/studio-app/src/lib/api.test.ts
+++ b/packages/studio-app/src/lib/api.test.ts
@@ -117,6 +117,28 @@ describe("streamInferenceContent (regression for ENG-358)", () => {
     expect(fragments).toEqual(["first"]);
   });
 
+  it("throws when /api/inference/chat returns 2xx with no body (regression for codex review)", async () => {
+    // A successful response without a body (e.g. 204, or an upstream that
+    // closed cleanly without writing any frames) used to surface as
+    // `Error("No response body")` in the Playground. After the SSE rewrite
+    // the silent-exit branch in `iterateSseFrames` would have left the
+    // assistant bubble empty with no feedback — guard against that.
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    ) as typeof fetch;
+
+    const consume = (async () => {
+      for await (const _ of streamInferenceContent({
+        messages: [],
+        stream: true,
+      })) {
+        // not expected to yield
+      }
+    })();
+
+    await expect(consume).rejects.toThrow(/no body/i);
+  });
+
   it("throws with the upstream body when /api/inference/chat returns non-2xx", async () => {
     globalThis.fetch = vi.fn(
       async () => new Response("upstream blew up", { status: 502 }),

--- a/packages/studio-app/src/lib/api.test.ts
+++ b/packages/studio-app/src/lib/api.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { extractInferenceDelta, streamInferenceContent } from "./api";
+
+describe("extractInferenceDelta", () => {
+  it("pulls OpenAI-style streaming deltas from choices[0].delta.content", () => {
+    const data = JSON.stringify({
+      choices: [{ delta: { content: "hello" } }],
+    });
+    expect(extractInferenceDelta(data)).toBe("hello");
+  });
+
+  it("falls back to top-level `content` when present", () => {
+    expect(extractInferenceDelta(JSON.stringify({ content: "hi" }))).toBe("hi");
+  });
+
+  it("falls back to top-level `text` when present", () => {
+    expect(extractInferenceDelta(JSON.stringify({ text: "hey" }))).toBe("hey");
+  });
+
+  it("returns the raw data when it isn't JSON (so users still see something)", () => {
+    expect(extractInferenceDelta("not-json")).toBe("not-json");
+  });
+
+  it("returns null for an empty data line", () => {
+    expect(extractInferenceDelta("")).toBeNull();
+  });
+
+  it("returns null for a JSON object with no recognised content field", () => {
+    expect(extractInferenceDelta(JSON.stringify({ usage: {} }))).toBeNull();
+  });
+
+  it("ignores empty choices arrays", () => {
+    expect(extractInferenceDelta(JSON.stringify({ choices: [] }))).toBeNull();
+  });
+
+  it("ignores choices entries that aren't objects", () => {
+    expect(
+      extractInferenceDelta(JSON.stringify({ choices: ["nope"] })),
+    ).toBeNull();
+  });
+});
+
+// Mount a SSE-shaped Response from a list of frames and let the SPA's
+// stream consumer assemble the assistant text. Regression for ENG-358 —
+// the previous Playground code concatenated raw `data: …\n\n` frames
+// straight into the message bubble.
+describe("streamInferenceContent (regression for ENG-358)", () => {
+  const ORIG_FETCH = globalThis.fetch;
+
+  function mockSseResponse(frames: string[]): Response {
+    const enc = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const f of frames) controller.enqueue(enc.encode(f));
+        controller.close();
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  beforeEach(() => {
+    // The token meta tag isn't present in the vitest DOM; apiFetch will
+    // still send a request without the header, which is fine for a fetch
+    // mock that doesn't check it.
+    globalThis.fetch = vi.fn(async () =>
+      mockSseResponse([
+        `event: token\ndata: ${JSON.stringify({
+          choices: [{ delta: { content: "Hel" } }],
+        })}\n\n`,
+        `event: token\ndata: ${JSON.stringify({
+          choices: [{ delta: { content: "lo" } }],
+        })}\n\n`,
+        `event: end\ndata: \n\n`,
+      ]),
+    ) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIG_FETCH;
+  });
+
+  it("yields decoded text fragments, never raw SSE frame text", async () => {
+    const fragments: string[] = [];
+    for await (const f of streamInferenceContent({
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    })) {
+      fragments.push(f);
+    }
+    expect(fragments).toEqual(["Hel", "lo"]);
+    // The bug emitted things like `data: {"choices":...}` into the bubble.
+    for (const f of fragments) {
+      expect(f).not.toMatch(/^data:|^event:/);
+    }
+  });
+
+  it("stops cleanly on the `end` sentinel", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockSseResponse([
+        `event: token\ndata: ${JSON.stringify({ content: "first" })}\n\n`,
+        `event: end\ndata: \n\n`,
+        // anything after `end` should be ignored
+        `event: token\ndata: ${JSON.stringify({ content: "should-not-appear" })}\n\n`,
+      ]),
+    ) as typeof fetch;
+
+    const fragments: string[] = [];
+    for await (const f of streamInferenceContent({
+      messages: [],
+      stream: true,
+    })) {
+      fragments.push(f);
+    }
+    expect(fragments).toEqual(["first"]);
+  });
+
+  it("throws with the upstream body when /api/inference/chat returns non-2xx", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("upstream blew up", { status: 502 }),
+    ) as typeof fetch;
+
+    const consume = (async () => {
+      const fragments: string[] = [];
+      for await (const f of streamInferenceContent({
+        messages: [],
+        stream: true,
+      })) {
+        fragments.push(f);
+      }
+      return fragments;
+    })();
+
+    await expect(consume).rejects.toThrow(/upstream blew up/);
+  });
+});

--- a/packages/studio-app/src/lib/api.test.ts
+++ b/packages/studio-app/src/lib/api.test.ts
@@ -21,6 +21,15 @@ describe("extractInferenceDelta", () => {
     expect(extractInferenceDelta("not-json")).toBe("not-json");
   });
 
+  it("treats JSON-string frames as token content (regression for codex review)", () => {
+    // Some providers/proxies serialize token chunks as `data: "Hel"`
+    // (a JSON string, not an object). Previously these parsed as a
+    // string, hit the `typeof parsed !== "object"` branch, and returned
+    // null — leaving the assistant bubble silently empty.
+    expect(extractInferenceDelta('"Hel"')).toBe("Hel");
+    expect(extractInferenceDelta('""')).toBe("");
+  });
+
   it("returns null for an empty data line", () => {
     expect(extractInferenceDelta("")).toBeNull();
   });

--- a/packages/studio-app/src/lib/api.ts
+++ b/packages/studio-app/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { createParser, type EventSourceMessage } from "eventsource-parser";
+
 export interface Credentials {
   token: string;
   mode: "auth0" | "anon";
@@ -74,6 +76,115 @@ export function openJobEvents(jobId: string): EventSource {
   return new EventSource(
     withStudioToken(`/api/jobs/${encodeURIComponent(jobId)}/events`),
   );
+}
+
+export interface ChatRequestBody {
+  messages: Array<{
+    role: "system" | "user" | "assistant";
+    content: string;
+  }>;
+  adapter?: { kind: "final" | "checkpoint"; jobId: string; step?: number };
+  baseModel?: string;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  stream?: boolean;
+}
+
+/**
+ * Stream assistant text deltas from `/api/inference/chat`.
+ *
+ * The Studio server proxies cloud-api's `/v1/inference/chat` SSE stream
+ * verbatim, so the body is `event: …\ndata: {…}\n\n` frames — not plain
+ * text. We parse the frames with `eventsource-parser` (the same parser
+ * the SDK's `iterateEvents` uses) and pull the assistant text out of
+ * each frame's `data` payload.
+ *
+ * Yields the per-frame text fragment so callers can append directly to
+ * the assistant message bubble.
+ */
+export async function* streamInferenceContent(
+  body: ChatRequestBody,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
+  const res = await apiFetch("/api/inference/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `HTTP ${res.status}`);
+  }
+
+  for await (const sse of iterateSseFrames(res)) {
+    if (sse.event === "ping") continue;
+    if (sse.event === "end" || sse.data === "[DONE]") return;
+    const fragment = extractInferenceDelta(sse.data);
+    if (fragment) yield fragment;
+  }
+}
+
+/**
+ * Mirrors `iterateEvents` from `@arkor/cloud-api-client`, inlined here
+ * because that package's main entry pulls in Node-only modules and can't
+ * be bundled into the SPA. The parser itself (eventsource-parser) is a
+ * direct dependency of cloud-api-client, so they stay in sync.
+ */
+async function* iterateSseFrames(
+  response: Response,
+): AsyncGenerator<EventSourceMessage> {
+  if (!response.body) return;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const pending: EventSourceMessage[] = [];
+  const parser = createParser({
+    onEvent(msg) {
+      pending.push(msg);
+    },
+  });
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      parser.feed(decoder.decode(value, { stream: true }));
+      while (pending.length > 0) yield pending.shift()!;
+    }
+    parser.feed(decoder.decode());
+    while (pending.length > 0) yield pending.shift()!;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Best-effort extraction of the assistant text fragment from a single SSE
+ * frame's `data:` payload. Handles the OpenAI-style streaming envelope
+ * (`choices[0].delta.content`) and a couple of reasonable fallbacks. If
+ * `data` isn't JSON, surface it as-is so the user still sees *something*
+ * instead of silent emptiness.
+ *
+ * Exported for unit tests; not part of the SPA's public surface.
+ */
+export function extractInferenceDelta(data: string): string | null {
+  if (!data) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return data;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  const choices = obj.choices;
+  if (Array.isArray(choices) && choices[0] && typeof choices[0] === "object") {
+    const delta = (choices[0] as { delta?: { content?: unknown } }).delta;
+    if (delta && typeof delta.content === "string") return delta.content;
+  }
+  if (typeof obj.content === "string") return obj.content;
+  if (typeof obj.text === "string") return obj.text;
+  return null;
 }
 
 export async function streamTraining(

--- a/packages/studio-app/src/lib/api.ts
+++ b/packages/studio-app/src/lib/api.ts
@@ -182,6 +182,10 @@ export function extractInferenceDelta(data: string): string | null {
   } catch {
     return data;
   }
+  // Some providers/proxies serialize token chunks as plain JSON strings
+  // (`data: "Hel"`) rather than objects — surface those directly so we
+  // don't end up with a silently empty assistant bubble.
+  if (typeof parsed === "string") return parsed;
   if (!parsed || typeof parsed !== "object") return null;
   const obj = parsed as Record<string, unknown>;
   const choices = obj.choices;

--- a/packages/studio-app/src/lib/api.ts
+++ b/packages/studio-app/src/lib/api.ts
@@ -117,6 +117,13 @@ export async function* streamInferenceContent(
     const text = await res.text().catch(() => "");
     throw new Error(text || `HTTP ${res.status}`);
   }
+  // `iterateSseFrames` mirrors cloud-api-client's `iterateEvents` and silently
+  // exits when there's no body. That's fine for the SDK but in the Playground
+  // it would leave an empty assistant bubble with no error surfaced — make
+  // the missing-body case loud here instead.
+  if (!res.body) {
+    throw new Error("Inference response has no body");
+  }
 
   for await (const sse of iterateSseFrames(res)) {
     if (sse.event === "ping") continue;

--- a/packages/studio-app/src/pages/Playground.tsx
+++ b/packages/studio-app/src/pages/Playground.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { apiFetch, fetchJobs, type Job } from "../lib/api";
+import { fetchJobs, streamInferenceContent, type Job } from "../lib/api";
 
 interface Message {
   role: "system" | "user" | "assistant";
@@ -31,24 +31,13 @@ export function Playground() {
     responseRef.current = "";
 
     try {
-      const body = {
+      const stream = streamInferenceContent({
         adapter: { kind: "final", jobId: selected },
         messages: [...messages, userMsg],
         stream: true,
-      };
-      const res = await apiFetch("/api/inference/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
       });
-      if (!res.body) throw new Error("No response body");
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        const chunk = decoder.decode(value, { stream: true });
-        responseRef.current += chunk;
+      for await (const fragment of stream) {
+        responseRef.current += fragment;
         const current = responseRef.current;
         setMessages((prev) => {
           const out = prev.slice();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
 
   packages/studio-app:
     dependencies:
+      eventsource-parser:
+        specifier: ^3.0.0
+        version: 3.0.8
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -125,6 +128,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@24.12.2)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2))
 
 packages:
 


### PR DESCRIPTION
## Summary
- Studio's Playground was reading the proxied `/api/inference/chat` body byte-for-byte and concatenating it into the assistant bubble — users saw `data: {"choices":[{"delta":{"content":"..."}}]}` instead of the decoded reply.
- Add `streamInferenceContent` in `lib/api.ts` that parses SSE frames with `eventsource-parser` and yields the per-frame text fragment (OpenAI envelope first, with `content` / `text` / raw-string fallbacks).
- Switch `Playground.send` to consume the async iterator.

## Why not just import `iterateEvents` from `@arkor/cloud-api-client`?
That package's main entry pulls in `node:fs` / `node:os` (via `auth.mjs`) and can't be bundled into the SPA — Vite's externalisation warning, then a Rollup error during build. `eventsource-parser` is a direct dep of `cloud-api-client` itself, so adding it to the SPA + inlining a tiny `iterateSseFrames` generator keeps the parser in sync without bringing Node-only modules along.

A separate cleanup (tree-shakeable cloud-api-client / browser-safe entry) is worth tracking but is out of scope here.