### PR TITLE
fix(studio): resolve symlinks before /api/train containment check

### DIFF
--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
 
@@ -159,19 +165,27 @@ describe("Studio server", () => {
   });
 
   it("rejects /api/train with a file path that escapes cwd", async () => {
-    const app = build();
-    const res = await app.request("/api/train", {
-      method: "POST",
-      headers: {
-        host: "127.0.0.1:4000",
-        "x-arkor-studio-token": STUDIO_TOKEN,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ file: "../escape.ts" }),
-    });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toMatch(/inside the project directory/);
+    // Create the escape target so we exercise the containment check, not the
+    // does-not-exist gate added in ENG-404.
+    const escapePath = resolve(trainCwd, "../escape.ts");
+    writeFileSync(escapePath, "// outside\n");
+    try {
+      const app = build();
+      const res = await app.request("/api/train", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ file: "../escape.ts" }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toMatch(/inside the project directory/);
+    } finally {
+      rmSync(escapePath, { force: true });
+    }
   });
 
   it("rejects /api/train with an absolute file path outside cwd", async () => {
@@ -186,6 +200,64 @@ describe("Studio server", () => {
       body: JSON.stringify({ file: "/etc/passwd" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  // Regression for ENG-404 — `path.resolve` doesn't follow symlinks, so a
+  // link inside the project directory pointing outside it would previously
+  // pass the containment check and be handed to `arkor train` (which would
+  // then dlopen the link's target).
+  it("rejects /api/train when body.file is a symlink to a path outside cwd", async () => {
+    await writeCredentials(ANON_CREDS);
+    symlinkSync("/etc/passwd", join(trainCwd, "evil.ts"));
+    const app = build();
+    const res = await app.request("/api/train", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ file: "evil.ts" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/inside the project directory/);
+  });
+
+  it("rejects /api/train when body.file does not exist", async () => {
+    await writeCredentials(ANON_CREDS);
+    const app = build();
+    const res = await app.request("/api/train", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ file: "missing.ts" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/does not exist/);
+  });
+
+  it("rejects /api/train when body.file is a broken symlink", async () => {
+    await writeCredentials(ANON_CREDS);
+    // Loop symlink: realpath throws ELOOP. Treated like ENOENT.
+    symlinkSync(join(trainCwd, "loop.ts"), join(trainCwd, "loop.ts"));
+    const app = build();
+    const res = await app.request("/api/train", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ file: "loop.ts" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/does not exist/);
   });
 
   // Regression for ENG-356 — `/api/train` previously resolved the bundled

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { createClient } from "@arkor/cloud-api-client";
@@ -209,8 +209,21 @@ export function buildStudioApp(options: StudioServerOptions) {
     const body = (await c.req.json().catch(() => ({}))) as { file?: string };
     let trainFile: string | undefined;
     if (body.file) {
-      const baseAbs = resolve(trainCwd);
-      const abs = resolve(baseAbs, body.file);
+      // Resolve symlinks before the containment check — `path.resolve` is purely
+      // lexical, so a symlink under the project directory pointing at e.g.
+      // `/etc/passwd` would otherwise pass `startsWith(baseAbs + sep)`. The
+      // bin spawned below would then dlopen the link's target.
+      let baseAbs: string;
+      let abs: string;
+      try {
+        baseAbs = await realpath(resolve(trainCwd));
+        abs = await realpath(resolve(baseAbs, body.file));
+      } catch {
+        return c.json(
+          { error: "file does not exist or is not accessible" },
+          400,
+        );
+      }
       if (abs !== baseAbs && !abs.startsWith(baseAbs + sep)) {
         return c.json(
           { error: "file must be inside the project directory" },


### PR DESCRIPTION
## Summary

- `/api/train` validated `body.file` with `path.resolve`, which is purely lexical. A symlink under the project directory pointing at e.g. `/etc/passwd` therefore passed the `startsWith(baseAbs + sep)` check, and `arkor train` then dlopen'd the link's target.
- Resolve both `trainCwd` and the requested file with `fs.realpath` before the containment check, so symlinks are followed to their actual targets.
- Unresolvable paths (`ENOENT`, `ELOOP`, etc.) are now rejected up front with a `400 file does not exist or is not accessible`, instead of being forwarded to the spawned bin and surfacing later in the response stream.

## Test plan

- [x] `pnpm --filter arkor typecheck`
- [x] `pnpm --filter arkor test` — 47/47 passing on Node 24
- [x] New: symlink to a path outside cwd → `400` with `inside the project directory`
- [x] New: missing file → `400` with `does not exist`
- [x] New: loop symlink (`ELOOP`) → `400` with `does not exist`
- [x] Updated the existing "escapes cwd" test to materialize the escape target so it exercises the containment check, not the does-not-exist gate.