### PR TITLE
fix(cli): tolerate cloud-api outage during arkor dev anonymous bootstrap

### DIFF
--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -151,6 +151,23 @@ describe("ensureCredentialsForStudio", () => {
     expect(await readCredentials()).toBeNull();
   });
 
+  // Codex review on PR #10 (round 2) flagged that filtering by
+  // `instanceof TypeError` alone also swallows config errors (Node's
+  // fetch raises `TypeError("Invalid URL")` for malformed
+  // ARKOR_CLOUD_API_URL, "URL scheme must be a HTTP(S) scheme" for
+  // missing scheme, etc.). Those keep failing on every retry, so they
+  // must surface at startup instead of being silently warned.
+  it("re-throws when ARKOR_CLOUD_API_URL is malformed (config error)", async () => {
+    process.env.ARKOR_CLOUD_API_URL = "";
+    // No fetch mock — let real fetch raise the URL parse error so we
+    // exercise the actual undici contract, not a synthetic TypeError.
+    await expect(ensureCredentialsForStudio()).rejects.toThrow(TypeError);
+    await expect(ensureCredentialsForStudio()).rejects.not.toThrow(
+      /^fetch failed$/,
+    );
+    expect(await readCredentials()).toBeNull();
+  });
+
   it("re-throws when the cloud-api responds with a body that fails schema validation", async () => {
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);

--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -118,4 +118,64 @@ describe("ensureCredentialsForStudio", () => {
     await expect(ensureCredentialsForStudio()).resolves.toBeUndefined();
     expect(await readCredentials()).toBeNull();
   });
+
+  // Codex review on PR #10 (ENG-403) flagged that the original try/catch
+  // swallowed every error, which meant non-transport failures (cloud-api
+  // 5xx, schema mismatches, fs errors writing credentials.json) would
+  // start Studio in a broken state where `getCredentials()` keeps failing
+  // on /api/credentials. Only `TypeError` (undici's fetch transport
+  // failure marker) should be swallowed.
+  it("re-throws when the cloud-api is reachable but returns non-2xx", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/v1/auth/cli/config")) {
+        return new Response(
+          JSON.stringify({
+            auth0Domain: null,
+            clientId: null,
+            audience: null,
+            callbackPorts: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/v1/auth/anonymous")) {
+        return new Response("internal error", { status: 500 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await expect(ensureCredentialsForStudio()).rejects.toThrow(
+      /Failed to acquire anonymous token \(500\)/,
+    );
+    expect(await readCredentials()).toBeNull();
+  });
+
+  it("re-throws when the cloud-api responds with a body that fails schema validation", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/v1/auth/cli/config")) {
+        return new Response(
+          JSON.stringify({
+            auth0Domain: null,
+            clientId: null,
+            audience: null,
+            callbackPorts: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/v1/auth/anonymous")) {
+        // Missing `personalOrg` — anonymousTokenResponseSchema rejects.
+        return new Response(
+          JSON.stringify({ token: "t", anonymousId: "a", kind: "cli" }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await expect(ensureCredentialsForStudio()).rejects.toThrow();
+    expect(await readCredentials()).toBeNull();
+  });
 });

--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -110,12 +110,18 @@ describe("ensureCredentialsForStudio", () => {
     expect(await readCredentials()).toBeNull();
   });
 
-  it("does not throw when the cloud-api is fully unreachable", async () => {
+  // Codex review on PR #10 (round 3) flagged that swallowing transport
+  // failures when fetchCliConfig itself failed is unsafe: in Auth0-only
+  // deployments we can't tell from a network outage that /v1/auth/anonymous
+  // would have been rejected, and the server-side retry path never re-
+  // enters runLogin. So when cfg fetch fails AND the anon attempt also
+  // transport-fails, we now fail fast.
+  it("re-throws when cloud-api is fully unreachable (deployment mode unknown)", async () => {
     globalThis.fetch = vi.fn(async () => {
       throw new TypeError("fetch failed");
     }) as typeof fetch;
 
-    await expect(ensureCredentialsForStudio()).resolves.toBeUndefined();
+    await expect(ensureCredentialsForStudio()).rejects.toThrow(TypeError);
     expect(await readCredentials()).toBeNull();
   });
 

--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureCredentialsForStudio } from "./dev";
+import {
+  readCredentials,
+  writeCredentials,
+  type AnonymousCredentials,
+} from "../../core/credentials";
+
+let fakeHome: string;
+const ORIG_HOME = process.env.HOME;
+const ORIG_FETCH = globalThis.fetch;
+const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(join(tmpdir(), "arkor-dev-test-"));
+  process.env.HOME = fakeHome;
+  process.env.ARKOR_CLOUD_API_URL = "http://mock-cloud-api";
+});
+
+afterEach(() => {
+  process.env.HOME = ORIG_HOME;
+  if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;
+  else delete process.env.ARKOR_CLOUD_API_URL;
+  globalThis.fetch = ORIG_FETCH;
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+describe("ensureCredentialsForStudio", () => {
+  it("returns immediately when credentials already exist", async () => {
+    const creds: AnonymousCredentials = {
+      mode: "anon",
+      token: "tok",
+      anonymousId: "aid",
+      arkorCloudApiUrl: "http://mock-cloud-api",
+      orgSlug: "anon-aid",
+    };
+    await writeCredentials(creds);
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await expect(ensureCredentialsForStudio()).resolves.toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await readCredentials()).toEqual(creds);
+  });
+
+  it("bootstraps anonymous credentials when Auth0 isn't configured", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/v1/auth/cli/config")) {
+        return new Response(
+          JSON.stringify({
+            auth0Domain: null,
+            clientId: null,
+            audience: null,
+            callbackPorts: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/v1/auth/anonymous")) {
+        return new Response(
+          JSON.stringify({
+            token: "anon-tok",
+            anonymousId: "anon-aid",
+            kind: "cli",
+            personalOrg: { id: "o", slug: "anon-aid", name: "Anon" },
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await ensureCredentialsForStudio();
+    expect(await readCredentials()).toMatchObject({
+      mode: "anon",
+      token: "anon-tok",
+      anonymousId: "anon-aid",
+      orgSlug: "anon-aid",
+    });
+  });
+
+  // Regression for ENG-403 — when the cloud-api is unreachable, `arkor dev`
+  // previously failed to start because the anonymous bootstrap's network
+  // error wasn't caught.
+  it("does not throw when the anonymous bootstrap fails after a successful config fetch", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/v1/auth/cli/config")) {
+        return new Response(
+          JSON.stringify({
+            auth0Domain: null,
+            clientId: null,
+            audience: null,
+            callbackPorts: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/v1/auth/anonymous")) {
+        throw new TypeError("fetch failed");
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await expect(ensureCredentialsForStudio()).resolves.toBeUndefined();
+    expect(await readCredentials()).toBeNull();
+  });
+
+  it("does not throw when the cloud-api is fully unreachable", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+
+    await expect(ensureCredentialsForStudio()).resolves.toBeUndefined();
+    expect(await readCredentials()).toBeNull();
+  });
+});

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -67,19 +67,30 @@ export async function ensureCredentialsForStudio(): Promise<void> {
     ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
   } catch (err) {
     // Only swallow transport-level failures so Studio stays usable while
-    // offline. undici's fetch raises `TypeError("fetch failed")` (with
-    // `err.cause` set to the underlying ECONNREFUSED/ETIMEDOUT/etc.) for
-    // every transport-class error.
+    // offline. undici uses `TypeError` for *both* transport failures and
+    // configuration errors, so `instanceof TypeError` alone is too loose:
     //
-    // Everything else must surface so the user sees the real cause instead
-    // of a silently-broken Studio:
+    //   - Transport failure → `TypeError("fetch failed")` with `err.cause`
+    //     set to the underlying ECONNREFUSED/ETIMEDOUT/ENOTFOUND/etc.
+    //     The cloud-api may come back; server-side retry on first
+    //     /api/credentials hit has a chance.
+    //   - Config error (`ARKOR_CLOUD_API_URL=""`, `localhost:3003` without
+    //     scheme, etc.) → `TypeError` with a *different* message ("Invalid
+    //     URL", "URL scheme must be a HTTP(S) scheme", etc.). Every retry
+    //     will hit the same error, so we must surface it at startup.
+    //
+    // Filter on `message === "fetch failed"` because that's the contract
+    // undici exposes for transient transport failures.
+    //
+    // Everything else also surfaces:
     //   - non-2xx responses from cloud-api (`requestAnonymousToken` wraps
-    //     them in a plain `Error` — server-side retry would hit the same
-    //     reject)
+    //     them in a plain `Error` — server-side retry would re-reject)
     //   - schema mismatches (`ZodError` — cloud-api responded with garbage)
     //   - fs failures writing credentials.json (`EACCES`, `EROFS`, … —
     //     server-side retry would fail to persist for the same reason)
-    if (!(err instanceof TypeError)) throw err;
+    if (!(err instanceof TypeError) || err.message !== "fetch failed") {
+      throw err;
+    }
     ui.log.warn(
       `Could not reach ${baseUrl} (${err.message}). Studio will keep running and retry on first /api/credentials hit.`,
     );

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -66,10 +66,22 @@ export async function ensureCredentialsForStudio(): Promise<void> {
     await writeCredentials(creds);
     ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
   } catch (err) {
+    // Only swallow transport-level failures so Studio stays usable while
+    // offline. undici's fetch raises `TypeError("fetch failed")` (with
+    // `err.cause` set to the underlying ECONNREFUSED/ETIMEDOUT/etc.) for
+    // every transport-class error.
+    //
+    // Everything else must surface so the user sees the real cause instead
+    // of a silently-broken Studio:
+    //   - non-2xx responses from cloud-api (`requestAnonymousToken` wraps
+    //     them in a plain `Error` — server-side retry would hit the same
+    //     reject)
+    //   - schema mismatches (`ZodError` — cloud-api responded with garbage)
+    //   - fs failures writing credentials.json (`EACCES`, `EROFS`, … —
+    //     server-side retry would fail to persist for the same reason)
+    if (!(err instanceof TypeError)) throw err;
     ui.log.warn(
-      `Could not acquire an anonymous token from ${baseUrl} (${
-        err instanceof Error ? err.message : String(err)
-      }). Studio will keep running and retry on first /api/credentials hit.`,
+      `Could not reach ${baseUrl} (${err.message}). Studio will keep running and retry on first /api/credentials hit.`,
     );
   }
 }

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -39,10 +39,14 @@ export async function ensureCredentialsForStudio(): Promise<void> {
 
   const baseUrl = defaultArkorCloudApiUrl();
   let cfg: Awaited<ReturnType<typeof fetchCliConfig>> | null = null;
+  let deploymentModeKnown = false;
   try {
     cfg = await fetchCliConfig(baseUrl);
+    deploymentModeKnown = true;
   } catch {
-    cfg = null;
+    // cfg null + deploymentModeKnown=false → we couldn't even determine
+    // whether the deployment requires Auth0. See the catch below for why
+    // that matters for the bootstrap recovery decision.
   }
 
   if (cfg?.auth0Domain && cfg.clientId && cfg.audience) {
@@ -66,29 +70,28 @@ export async function ensureCredentialsForStudio(): Promise<void> {
     await writeCredentials(creds);
     ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
   } catch (err) {
-    // Only swallow transport-level failures so Studio stays usable while
-    // offline. undici uses `TypeError` for *both* transport failures and
-    // configuration errors, so `instanceof TypeError` alone is too loose:
+    // Only swallow transport-level failures, AND only when we positively
+    // confirmed the deployment doesn't require Auth0. Two filters:
     //
-    //   - Transport failure → `TypeError("fetch failed")` with `err.cause`
-    //     set to the underlying ECONNREFUSED/ETIMEDOUT/ENOTFOUND/etc.
-    //     The cloud-api may come back; server-side retry on first
-    //     /api/credentials hit has a chance.
-    //   - Config error (`ARKOR_CLOUD_API_URL=""`, `localhost:3003` without
-    //     scheme, etc.) → `TypeError` with a *different* message ("Invalid
-    //     URL", "URL scheme must be a HTTP(S) scheme", etc.). Every retry
-    //     will hit the same error, so we must surface it at startup.
+    // 1. `TypeError("fetch failed")` is undici's contract for transient
+    //    transport failures (ECONNREFUSED/ETIMEDOUT/ENOTFOUND/etc.) where
+    //    the cloud-api may come back. Other TypeErrors are config errors
+    //    ("Invalid URL", "URL scheme must be a HTTP(S) scheme") that keep
+    //    failing on every retry. Plain Errors (non-2xx responses, ZodError
+    //    on garbage responses) and fs errors (EACCES on credentials.json)
+    //    also keep failing on retry.
     //
-    // Filter on `message === "fetch failed"` because that's the contract
-    // undici exposes for transient transport failures.
-    //
-    // Everything else also surfaces:
-    //   - non-2xx responses from cloud-api (`requestAnonymousToken` wraps
-    //     them in a plain `Error` — server-side retry would re-reject)
-    //   - schema mismatches (`ZodError` — cloud-api responded with garbage)
-    //   - fs failures writing credentials.json (`EACCES`, `EROFS`, … —
-    //     server-side retry would fail to persist for the same reason)
-    if (!(err instanceof TypeError) || err.message !== "fetch failed") {
+    // 2. `deploymentModeKnown` guards against silently starting a broken
+    //    Studio against an Auth0-only deployment. If fetchCliConfig itself
+    //    failed, we don't know whether `/v1/auth/anonymous` is even
+    //    enabled on this cloud-api. Server-side retry on /api/credentials
+    //    would hit the same anon endpoint and get a permanent rejection
+    //    instead of being routed back to the interactive `runLogin`. Fail
+    //    fast so the user sees the real cause and can re-run once
+    //    connectivity is back.
+    const isTransportFailure =
+      err instanceof TypeError && err.message === "fetch failed";
+    if (!isTransportFailure || !deploymentModeKnown) {
       throw err;
     }
     ui.log.warn(

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -23,17 +23,18 @@ export interface DevOptions {
 }
 
 /**
- * Ensure we have credentials on disk before the Studio server starts.
+ * Best-effort credential bootstrap before the Studio server starts.
  *
  *  - If credentials already exist → no-op.
- *  - Otherwise, ask the cloud-api whether Auth0 is configured. When it is,
- *    run the interactive PKCE login. When it isn't, fall back to anonymous.
- *
- * Doing this up-front (rather than deferring to Studio's `/api/credentials`
- * auto-anonymous) means the user gets the real Auth0 flow when available
- * instead of silently being given a throwaway identity.
+ *  - If Auth0 is configured → run the interactive PKCE login (fatal on
+ *    failure: Auth0 mode requires reaching the cloud-api to know which
+ *    tenant to authorize against).
+ *  - Otherwise → try to acquire an anonymous token. On network failure,
+ *    warn and continue: the Studio server is built with `autoAnonymous`
+ *    enabled, so it will retry on the first `/api/credentials` hit. This
+ *    keeps `arkor dev` usable when the cloud-api is momentarily down.
  */
-async function ensureCredentialsForStudio(): Promise<void> {
+export async function ensureCredentialsForStudio(): Promise<void> {
   if (await readCredentials()) return;
 
   const baseUrl = defaultArkorCloudApiUrl();
@@ -53,16 +54,24 @@ async function ensureCredentialsForStudio(): Promise<void> {
   ui.log.info(
     "No credentials on file and Auth0 isn't configured — requesting an anonymous token.",
   );
-  const anon = await requestAnonymousToken(baseUrl, "cli");
-  const creds: AnonymousCredentials = {
-    mode: "anon",
-    token: anon.token,
-    anonymousId: anon.anonymousId,
-    arkorCloudApiUrl: baseUrl,
-    orgSlug: anon.orgSlug,
-  };
-  await writeCredentials(creds);
-  ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
+  try {
+    const anon = await requestAnonymousToken(baseUrl, "cli");
+    const creds: AnonymousCredentials = {
+      mode: "anon",
+      token: anon.token,
+      anonymousId: anon.anonymousId,
+      arkorCloudApiUrl: baseUrl,
+      orgSlug: anon.orgSlug,
+    };
+    await writeCredentials(creds);
+    ui.log.success(`Signed in anonymously (${anon.orgSlug}).`);
+  } catch (err) {
+    ui.log.warn(
+      `Could not acquire an anonymous token from ${baseUrl} (${
+        err instanceof Error ? err.message : String(err)
+      }). Studio will keep running and retry on first /api/credentials hit.`,
+    );
+  }
 }
 
 /**
@@ -124,7 +133,10 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
     );
   }
 
-  const app = buildStudioApp({ autoAnonymous: false, studioToken });
+  // `autoAnonymous: true` (the default) lets the Hono server retry the
+  // anonymous bootstrap on first `/api/credentials` hit if the up-front
+  // attempt above failed (e.g. cloud-api was unreachable at launch).
+  const app = buildStudioApp({ studioToken });
   const url = `http://127.0.0.1:${port}`;
   serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
   process.stdout.write(`Arkor Studio running on ${url}\n`);


### PR DESCRIPTION
## Summary

- `arkor dev` failed to start when the cloud-api was unreachable: `ensureCredentialsForStudio` ran `requestAnonymousToken` after a swallowed `fetchCliConfig` failure, and the unhandled throw bubbled all the way out of `runDev`.
- Wrap the anonymous bootstrap in try/catch and warn instead of throwing. The Studio server is now built without an explicit `autoAnonymous: false` override, so its default `autoAnonymous: true` kicks in and the server retries the bootstrap on the first `/api/credentials` hit once the network is back.
- Auth0-configured deployments still fail fast on `runLogin`: that mode requires reaching the cloud-api to know which tenant to authorize against, so an offline failure there is genuinely terminal.

## Test plan

- [x] `pnpm --filter arkor typecheck`
- [x] `pnpm --filter arkor test` — 51/51 passing on Node 24 (4 new, in `dev.test.ts`)
- [x] New: existing credentials short-circuit without any fetch
- [x] New: successful anonymous bootstrap writes creds
- [x] New: anonymous endpoint network failure (after a successful config fetch) → no throw, no creds written
- [x] New: full cloud-api outage (config fetch also throws) → no throw, no creds written

## Notes

- `ensureCredentialsForStudio` is now `export`-ed for testability. No other callers.
- The error message that used to be thrown is now logged at `warn` level: `Could not acquire an anonymous token from <baseUrl> (<reason>). Studio will keep running and retry on first /api/credentials hit.`