### PR TITLE
fix(cli): derive default project name via path.basename

### DIFF
--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -168,6 +168,26 @@ describe("create-arkor (E2E)", () => {
     expect(pkg.name).toBe("foo-bar");
   });
 
+  // Regression for ENG-359 — `process.cwd()` / `options.dir` ending in `/`
+  // (Docker root, `--dir foo/`, etc.) used to produce an empty defaultName
+  // because `cwd.split(/[/\\]/).pop()` returned "" and `??` only fires on
+  // null/undefined. `path.basename` correctly strips the trailing slash.
+  it("derives defaultName via basename when --dir has a trailing slash", async () => {
+    const targetDir = join(parentDir, "trail");
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["trail/", "-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+    const pkg = JSON.parse(
+      readFileSync(join(targetDir, "package.json"), "utf8"),
+    ) as { name?: string };
+    // Before the fix this would have been "arkor-project" (the sanitise
+    // fallback for empty input).
+    expect(pkg.name).toBe("trail");
+  });
+
   it("honours --name --template alpaca", async () => {
     const { result, targetDir } = await runCreateArkor([
       "-y",

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   gitInitialCommit,
   install,
@@ -90,7 +91,11 @@ async function maybeGitInit(
 
 export async function runInit(options: InitOptions): Promise<void> {
   const cwd = process.cwd();
-  const defaultName = cwd.split(/[/\\]/).pop() ?? "arkor-project";
+  // `path.basename` correctly handles trailing separators and the
+  // filesystem root (`/`, `C:\`), where the previous split-and-pop
+  // returned an empty string and `??` left it through (only null/undefined
+  // trigger the fallback). `basename("/")` returns `""`, hence the `||`.
+  const defaultName = basename(cwd) || "arkor-project";
 
   ui.intro("arkor init");
   const projectName = await promptText({

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import process from "node:process";
 import * as clack from "@clack/prompts";
 import { Command } from "commander";
@@ -99,12 +99,11 @@ async function run(options: RunOptions): Promise<void> {
   clack.intro("create-arkor");
 
   const cwd = options.dir ? resolve(options.dir) : process.cwd();
-  const defaultName = sanitise(
-    options.name ??
-      (options.dir
-        ? options.dir.split(/[/\\]/).pop()!
-        : process.cwd().split(/[/\\]/).pop()!),
-  );
+  // `path.basename` of the resolved cwd handles trailing separators and
+  // filesystem roots correctly. `sanitise("")` falls back to
+  // `"arkor-project"`, so the empty-basename case at root collapses to
+  // the same default the prompt would otherwise offer.
+  const defaultName = sanitise(options.name ?? basename(cwd));
 
   // Always sanitise — `defaultName` is already sanitised, but `options.name`
   // straight from `--name` is not, and falls through to package.json as-is


### PR DESCRIPTION
## Summary

- `cwd.split(/[/\\]/).pop()` returned `""` when cwd ended in a separator (filesystem root `/`, Docker root, or `--dir foo/` with a trailing slash). `??` only fires on null/undefined, so the empty value slipped through into the prompt's `initialValue` — and on `--yes` paths, straight into `package.json`'s `name` field.
- Replace the split-and-pop with `path.basename` in both `init.ts` and `create-arkor/bin.ts`. `basename` strips trailing separators correctly. The empty-result-at-root case falls through to `|| "arkor-project"` in `init.ts` and to `sanitise`'s built-in empty fallback in `create-arkor` — the same default the prompt would have offered anyway.

## Test plan

- [x] `pnpm --filter arkor --filter create-arkor --filter @arkor/e2e-cli typecheck`
- [x] `pnpm --filter arkor test` — 54/54 passing on Node 24
- [x] `SKIP_E2E_INSTALL=1 pnpm --filter @arkor/e2e-cli test` — 21/21 passing (4 install-gated cases skipped, unchanged)
- [x] New E2E regression: `create-arkor trail/ -y --skip-install --skip-git` writes `package.json` with `"name": "trail"` (was `"arkor-project"` before the fix).

## Notes

- `arkor init`'s buggy code path triggers only when `process.cwd()` returns a separator-terminated path — i.e. when run from filesystem root. We can't reproduce that from a spawn-based E2E without writing into `/`, so the regression test lives on the `create-arkor` side where `--dir` accepts user input directly. The fix in both files is identical (`basename` over the same source), so coverage of one validates the other.