### PR TITLE
fix(sdk): exponential backoff + jitter + max-attempts on trainer SSE reconnect

### DIFF
--- a/packages/arkor/src/core/trainer.test.ts
+++ b/packages/arkor/src/core/trainer.test.ts
@@ -410,7 +410,8 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
     const trainer = createTrainer(
       {
         name: "run",
-        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
       },
       {
         baseUrl: "http://mock",
@@ -465,7 +466,8 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
     const trainer = createTrainer(
       {
         name: "run",
-        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
       },
       {
         baseUrl: "http://mock",
@@ -489,6 +491,53 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
   // *after* the exponential is clamped to `maxReconnectDelayMs`, so a
   // saturated `exp` could still wait up to 1.25 × the documented cap
   // when `Math.random()` lands near 1.
+  // Codex review on PR #13 (round 3) flagged that a 200-OK stream that
+  // EOFs without emitting any frame would loop forever at the base delay
+  // — `maxReconnectAttempts` was bypassed because clean closes never
+  // touched the failure counter. Misconfigured proxies / load-balancers
+  // that accept the connection and immediately drop it would hang
+  // `wait()` indefinitely.
+  it("counts clean closes with no frames toward maxReconnectAttempts", async () => {
+    await writeState(
+      { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
+      cwd,
+    );
+    // 200 OK with empty body each time (proxy accepts then EOFs). With
+    // max=2, three empty streams should exhaust the budget.
+    const { fetch: fetcher, streamCalls } = streamFetcher([
+      { kind: "stream", chunks: [] },
+      { kind: "stream", chunks: [] },
+      { kind: "stream", chunks: [] },
+    ]);
+
+    const trainer = createTrainer(
+      {
+        name: "run",
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
+      },
+      {
+        baseUrl: "http://mock",
+        credentials: creds,
+        cwd,
+        reconnectDelayMs: 1,
+        maxReconnectDelayMs: 5,
+        maxReconnectAttempts: 2,
+      },
+    );
+
+    const error = await withMockedFetch(fetcher, async () =>
+      trainer.wait().catch((e: unknown) => e),
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/failed 3 consecutive times/);
+    expect((error as Error).cause).toBeInstanceOf(Error);
+    expect(((error as Error).cause as Error).message).toMatch(
+      /closed without emitting any frame/,
+    );
+    expect(streamCalls()).toBe(3);
+  });
+
   it("clamps the jittered delay at maxReconnectDelayMs", async () => {
     await writeState(
       { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
@@ -515,10 +564,8 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
       const trainer = createTrainer(
         {
           name: "run",
-          config: {
-            model: "m",
-            datasetSource: { type: "huggingface", name: "x" },
-          },
+          model: "m",
+          dataset: { type: "huggingface", name: "x" },
         },
         {
           baseUrl: "http://mock",
@@ -575,10 +622,8 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
       const trainer = createTrainer(
         {
           name: "run",
-          config: {
-            model: "m",
-            datasetSource: { type: "huggingface", name: "x" },
-          },
+          model: "m",
+          dataset: { type: "huggingface", name: "x" },
         },
         {
           baseUrl: "http://mock",

--- a/packages/arkor/src/core/trainer.test.ts
+++ b/packages/arkor/src/core/trainer.test.ts
@@ -485,6 +485,68 @@ describe("createTrainer (reconnect backoff + max attempts)", () => {
     expect(streamCalls()).toBe(5);
   });
 
+  // Codex review on PR #13 (round 2) flagged that jitter is applied
+  // *after* the exponential is clamped to `maxReconnectDelayMs`, so a
+  // saturated `exp` could still wait up to 1.25 × the documented cap
+  // when `Math.random()` lands near 1.
+  it("clamps the jittered delay at maxReconnectDelayMs", async () => {
+    await writeState(
+      { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
+      cwd,
+    );
+    // Math.random = 0.9 → jitter component = exp * (0.9 * 0.5 - 0.25) =
+    // exp * 0.20. Without the outer clamp, exp + jitter = 1.20 × cap.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.9);
+    const delays: number[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((fn, ms) => {
+        delays.push(ms ?? 0);
+        return realSetTimeout(fn as () => void, 0);
+      });
+
+    try {
+      const { fetch: fetcher } = streamFetcher([
+        { kind: "throw", error: new TypeError("fetch failed") },
+        { kind: "throw", error: new TypeError("fetch failed") },
+      ]);
+
+      const trainer = createTrainer(
+        {
+          name: "run",
+          config: {
+            model: "m",
+            datasetSource: { type: "huggingface", name: "x" },
+          },
+        },
+        {
+          baseUrl: "http://mock",
+          credentials: creds,
+          cwd,
+          // base = cap means `exp` saturates the cap on the very first
+          // attempt, so the jitter would push above without the clamp.
+          reconnectDelayMs: 100,
+          maxReconnectDelayMs: 100,
+          maxReconnectAttempts: 1,
+        },
+      );
+
+      await withMockedFetch(fetcher, async () => {
+        await expect(trainer.wait()).rejects.toThrow();
+      });
+
+      // Single backoff between the first failure and the second attempt
+      // (the second hits maxReconnectAttempts and throws without delay).
+      // Was 120 ms before the fix; must not exceed 100.
+      expect(delays).toHaveLength(1);
+      expect(delays[0]).toBeLessThanOrEqual(100);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      randomSpy.mockRestore();
+    }
+  });
+
   it("emits backoff delays that grow exponentially (no jitter, ×2 each attempt)", async () => {
     await writeState(
       { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },

--- a/packages/arkor/src/core/trainer.test.ts
+++ b/packages/arkor/src/core/trainer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -324,5 +324,220 @@ describe("createTrainer (SSE event stream)", () => {
       globalThis.fetch = originalFetch;
     }
     expect(inferResponseText).toBe("hello from checkpoint 5");
+  });
+});
+
+// Regression for ENG-406 — the previous reconnect loop had no upper bound
+// and no jitter, so a permanently-down cloud-api would keep retrying every
+// `reconnectDelayMs` forever (and on recovery several SDK clients would
+// reconnect at exactly the same instant).
+describe("createTrainer (reconnect backoff + max attempts)", () => {
+  const minimalJobRow = {
+    id: "j1",
+    orgId: "o1",
+    projectId: "p1",
+    name: "run",
+    status: "queued",
+    config: {
+      model: "m",
+      datasetSource: { type: "huggingface", name: "x" },
+    },
+    createdAt: "2026-01-01T00:00:00Z",
+    startedAt: null,
+    completedAt: null,
+  };
+
+  function streamFetcher(
+    handlers: Array<
+      | { kind: "throw"; error: Error }
+      | { kind: "stream"; chunks: string[] }
+    >,
+  ): { fetch: typeof fetch; streamCalls: () => number } {
+    let streamCalls = 0;
+    const impl: typeof fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.includes("/v1/jobs?")) {
+        return new Response(JSON.stringify({ job: minimalJobRow }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.includes("/v1/jobs/j1/events/stream")) {
+        const handler = handlers[streamCalls++];
+        if (!handler) {
+          throw new Error(`unexpected stream open #${streamCalls}`);
+        }
+        if (handler.kind === "throw") throw handler.error;
+        return new Response(sseStream(handler.chunks), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+    return { fetch: impl, streamCalls: () => streamCalls };
+  }
+
+  async function withMockedFetch<T>(
+    impl: typeof fetch,
+    body: () => Promise<T>,
+  ): Promise<T> {
+    const original = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      return await body();
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+
+  it("rejects after maxReconnectAttempts of consecutive open failures", async () => {
+    await writeState(
+      { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
+      cwd,
+    );
+    // max=2 → 1 initial + 2 retries before giving up on the 3rd attempt.
+    const { fetch: fetcher, streamCalls } = streamFetcher([
+      { kind: "throw", error: new TypeError("fetch failed") },
+      { kind: "throw", error: new TypeError("fetch failed") },
+      { kind: "throw", error: new TypeError("fetch failed") },
+    ]);
+
+    const trainer = createTrainer(
+      {
+        name: "run",
+        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+      },
+      {
+        baseUrl: "http://mock",
+        credentials: creds,
+        cwd,
+        reconnectDelayMs: 1,
+        maxReconnectDelayMs: 5,
+        maxReconnectAttempts: 2,
+      },
+    );
+
+    const error = await withMockedFetch(fetcher, async () =>
+      trainer.wait().catch((e: unknown) => e),
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(
+      /failed 3 consecutive times/,
+    );
+    expect((error as Error).cause).toBeInstanceOf(TypeError);
+    expect(streamCalls()).toBe(3);
+  });
+
+  it("resets the failure counter after the stream yields any frame", async () => {
+    await writeState(
+      { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
+      cwd,
+    );
+    // Without the reset, max=2 would trip after [throw, success, throw, throw]
+    // (4 opens). With the reset, the success in slot 2 wipes the previous
+    // failure, so we get [throw, success, throw, throw, throw] = 5 opens
+    // before the 3rd consecutive failure exceeds the limit.
+    const { fetch: fetcher, streamCalls } = streamFetcher([
+      { kind: "throw", error: new TypeError("fetch failed") },
+      {
+        kind: "stream",
+        chunks: [
+          `id: 1\nevent: training.log\ndata: ${JSON.stringify({
+            type: "training.log",
+            jobId: "j1",
+            timestamp: "2026-01-01T00:00:01Z",
+            step: 1,
+            loss: 1,
+          })}\n\n`,
+          // No terminal event — stream closes cleanly, outer loop reconnects.
+        ],
+      },
+      { kind: "throw", error: new TypeError("fetch failed") },
+      { kind: "throw", error: new TypeError("fetch failed") },
+      { kind: "throw", error: new TypeError("fetch failed") },
+    ]);
+
+    const trainer = createTrainer(
+      {
+        name: "run",
+        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+      },
+      {
+        baseUrl: "http://mock",
+        credentials: creds,
+        cwd,
+        reconnectDelayMs: 1,
+        maxReconnectDelayMs: 5,
+        maxReconnectAttempts: 2,
+      },
+    );
+
+    await withMockedFetch(fetcher, async () => {
+      await expect(trainer.wait()).rejects.toThrow(
+        /failed 3 consecutive times/,
+      );
+    });
+    expect(streamCalls()).toBe(5);
+  });
+
+  it("emits backoff delays that grow exponentially (no jitter, ×2 each attempt)", async () => {
+    await writeState(
+      { orgSlug: "anon-org", projectSlug: "proj", projectId: "p1" },
+      cwd,
+    );
+    // Math.random = 0.5 → jitter component is exactly zero, so the delay
+    // schedule is base * 2^attempt clamped to maxReconnectDelayMs.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const delays: number[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((fn, ms) => {
+        delays.push(ms ?? 0);
+        return realSetTimeout(fn as () => void, 0);
+      });
+
+    try {
+      const { fetch: fetcher } = streamFetcher([
+        { kind: "throw", error: new TypeError("fetch failed") },
+        { kind: "throw", error: new TypeError("fetch failed") },
+        { kind: "throw", error: new TypeError("fetch failed") },
+      ]);
+
+      const trainer = createTrainer(
+        {
+          name: "run",
+          config: {
+            model: "m",
+            datasetSource: { type: "huggingface", name: "x" },
+          },
+        },
+        {
+          baseUrl: "http://mock",
+          credentials: creds,
+          cwd,
+          reconnectDelayMs: 10,
+          maxReconnectDelayMs: 1_000_000,
+          maxReconnectAttempts: 2,
+        },
+      );
+
+      await withMockedFetch(fetcher, async () => {
+        await expect(trainer.wait()).rejects.toThrow();
+      });
+
+      // Two backoff delays before the third attempt errors out (the third
+      // open hits maxReconnectAttempts and throws without delaying).
+      expect(delays).toEqual([10, 20]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      randomSpy.mockRestore();
+    }
   });
 });

--- a/packages/arkor/src/core/trainer.ts
+++ b/packages/arkor/src/core/trainer.ts
@@ -375,11 +375,13 @@ export function createTrainer(
           continue;
         }
 
+        let receivedAny = false;
         try {
           for await (const sse of iterateEvents(response)) {
             // Any frame from the server (including pings) means we're
             // connected and making progress — reset the failure counter
             // so subsequent transient blips get the full retry budget.
+            receivedAny = true;
             attempt = 0;
             if (sse.id) lastEventId = sse.id;
             if (sse.event === "ping") continue;
@@ -405,11 +407,22 @@ export function createTrainer(
           continue;
         }
 
-        if (!terminal) {
-          // Stream closed cleanly but we haven't seen a terminal event yet.
-          // Not a failure — reconnect with Last-Event-ID at the base delay
-          // (no exponential backoff, no counter increment).
+        if (terminal) break;
+
+        if (receivedAny) {
+          // Stream had real activity then closed cleanly. Not a failure —
+          // reconnect with Last-Event-ID at the base delay (no exponential
+          // backoff, no counter increment).
           await delay(initialReconnectDelayMs, abortSignal);
+        } else {
+          // 200 OK but the stream EOF'd without yielding any frame. This
+          // is the signature of a misconfigured proxy / LB that accepts
+          // the connection and immediately drops it. Count it toward
+          // `maxReconnectAttempts` so we don't loop forever at the base
+          // delay against the same broken intermediary.
+          await handleFailure(
+            new Error("SSE stream closed without emitting any frame"),
+          );
         }
       }
 

--- a/packages/arkor/src/core/trainer.ts
+++ b/packages/arkor/src/core/trainer.ts
@@ -202,6 +202,11 @@ export function createTrainer(
    * Exponential backoff with ±25% jitter, capped at `maxReconnectDelayMs`.
    * The jitter spreads reconnect storms when a cloud-api recovers and
    * many SDK clients retry at once.
+   *
+   * The final value is clamped at `maxReconnectDelayMs` because jitter
+   * sits *outside* the exponential clamp — without the outer clamp, a
+   * long outage where `exp` already hit the cap could wait up to 1.25 ×
+   * the documented cap when `Math.random()` lands near 1.
    */
   function nextReconnectDelay(attempt: number): number {
     const exp = Math.min(
@@ -209,7 +214,7 @@ export function createTrainer(
       maxReconnectDelayMs,
     );
     const jitter = exp * (Math.random() * 0.5 - 0.25);
-    return Math.max(0, exp + jitter);
+    return Math.max(0, Math.min(maxReconnectDelayMs, exp + jitter));
   }
 
   async function delay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/arkor/src/core/trainer.ts
+++ b/packages/arkor/src/core/trainer.ts
@@ -31,7 +31,25 @@ export interface TrainerInternalContext {
   baseUrl?: string;
   credentials?: Credentials;
   cwd?: string;
+  /**
+   * Initial reconnect back-off in milliseconds. Subsequent failures use
+   * exponential backoff (×2 each time) capped at `maxReconnectDelayMs`.
+   * Defaults to 1000.
+   */
   reconnectDelayMs?: number;
+  /**
+   * Cap for the exponential backoff delay in milliseconds. Defaults to
+   * 60_000 (60 s) so a multi-hour outage doesn't escalate beyond the
+   * recovery window the cloud-api is optimised for.
+   */
+  maxReconnectDelayMs?: number;
+  /**
+   * Maximum number of consecutive failed reconnect attempts before
+   * `wait()` rejects with the last error. Counter resets every time the
+   * stream yields at least one event (so a single mid-stream blip doesn't
+   * count against a long-running job). Undefined means unlimited.
+   */
+  maxReconnectAttempts?: number;
 }
 
 interface StreamEventBase {
@@ -111,7 +129,9 @@ export function createTrainer(
   context: TrainerInternalContext = {},
 ): Trainer {
   const baseUrl = context.baseUrl ?? defaultArkorCloudApiUrl();
-  const reconnectDelayMs = context.reconnectDelayMs ?? 1000;
+  const initialReconnectDelayMs = context.reconnectDelayMs ?? 1000;
+  const maxReconnectDelayMs = context.maxReconnectDelayMs ?? 60_000;
+  const maxReconnectAttempts = context.maxReconnectAttempts;
   const cwd = context.cwd ?? process.cwd();
   const config = buildJobConfig(input);
 
@@ -176,6 +196,20 @@ export function createTrainer(
     };
     await writeState(state, cwd);
     return state;
+  }
+
+  /**
+   * Exponential backoff with ±25% jitter, capped at `maxReconnectDelayMs`.
+   * The jitter spreads reconnect storms when a cloud-api recovers and
+   * many SDK clients retry at once.
+   */
+  function nextReconnectDelay(attempt: number): number {
+    const exp = Math.min(
+      initialReconnectDelayMs * 2 ** attempt,
+      maxReconnectDelayMs,
+    );
+    const jitter = exp * (Math.random() * 0.5 - 0.25);
+    return Math.max(0, exp + jitter);
   }
 
   async function delay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -304,6 +338,25 @@ export function createTrainer(
       let lastEventId: string | undefined;
       let artifacts: unknown[] = [];
       let terminal = false;
+      // Consecutive failed reconnects. Reset every time the stream yields
+      // at least one event so a long-running job that briefly drops
+      // doesn't burn through `maxReconnectAttempts` over its lifetime.
+      let attempt = 0;
+
+      const handleFailure = async (err: unknown): Promise<void> => {
+        if (abortSignal?.aborted) throw err;
+        if (
+          maxReconnectAttempts !== undefined &&
+          attempt >= maxReconnectAttempts
+        ) {
+          throw new Error(
+            `Trainer SSE stream failed ${attempt + 1} consecutive times; giving up.`,
+            { cause: err },
+          );
+        }
+        await delay(nextReconnectDelay(attempt), abortSignal);
+        attempt++;
+      };
 
       while (!terminal) {
         let response: Response;
@@ -313,14 +366,16 @@ export function createTrainer(
             signal: abortSignal,
           });
         } catch (err) {
-          if (abortSignal?.aborted) throw err;
-          // Transient network error — back off and retry.
-          await delay(reconnectDelayMs, abortSignal);
+          await handleFailure(err);
           continue;
         }
 
         try {
           for await (const sse of iterateEvents(response)) {
+            // Any frame from the server (including pings) means we're
+            // connected and making progress — reset the failure counter
+            // so subsequent transient blips get the full retry budget.
+            attempt = 0;
             if (sse.id) lastEventId = sse.id;
             if (sse.event === "ping") continue;
             if (sse.event === "end") {
@@ -341,16 +396,15 @@ export function createTrainer(
             }
           }
         } catch (err) {
-          if (abortSignal?.aborted) throw err;
-          // Stream closed unexpectedly — back off and resume with Last-Event-ID.
-          await delay(reconnectDelayMs, abortSignal);
+          await handleFailure(err);
           continue;
         }
 
         if (!terminal) {
           // Stream closed cleanly but we haven't seen a terminal event yet.
-          // Reconnect with Last-Event-ID to drain the queue.
-          await delay(reconnectDelayMs, abortSignal);
+          // Not a failure — reconnect with Last-Event-ID at the base delay
+          // (no exponential backoff, no counter increment).
+          await delay(initialReconnectDelayMs, abortSignal);
         }
       }
 


### PR DESCRIPTION
## Summary

- The trainer's SSE reconnect loop used a fixed 1 s delay with no upper bound and no jitter. A multi-hour cloud-api outage during a long-running training job left the SDK retrying every second forever (CPU/network burn), and a synchronized recovery would have multiple SDK clients hit the same endpoint at the same instant.
- Replace the fixed delay with **exponential backoff** (`×2` each attempt) capped at `maxReconnectDelayMs` (default `60_000`) and **±25 % jitter** to spread reconnect storms.
- Add a **`maxReconnectAttempts`** budget (default `undefined` = unlimited) that resets every time the stream yields any frame, so a single mid-stream blip during a day-long job doesn't accumulate towards the limit.
- Failure paths now wrap the underlying error as `cause` and throw `"Trainer SSE stream failed N consecutive times; giving up."` so callers can distinguish "we tried hard" from a single network blip.

## API surface

`CreateTrainerContext` gains two optional fields (additive, no breaking change):

```ts
maxReconnectDelayMs?: number; // default 60_000
maxReconnectAttempts?: number; // default undefined (unlimited)
```

`reconnectDelayMs` is repurposed as the **initial** delay for the backoff schedule; existing callers passing small values (e.g. tests using `5`) still get fast retries because subsequent delays just compound from there.

## Test plan

- [x] `pnpm --filter arkor typecheck`
- [x] `pnpm --filter arkor test` — 57/57 passing on Node 24 (3 new in `trainer.test.ts`)
- [x] New: `maxReconnectAttempts: 2` triggers `wait()` rejection after 3 stream-open calls (1 initial + 2 retries) with `error.cause instanceof TypeError`.
- [x] New: counter reset — `[throw, success+frame, throw, throw, throw]` results in 5 opens before the limit (vs 4 without the reset).
- [x] New: backoff schedule with `Math.random` spied to `0.5` (zero jitter) emits delays `[10, 20]` for two consecutive failures with `reconnectDelayMs: 10`.
