### PR TITLE
refactor(sdk): redesign createTrainer + introduce createArkor umbrella (Phase 1)

### DIFF
--- a/packages/arkor/src/core/arkor.test.ts
+++ b/packages/arkor/src/core/arkor.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { createArkor, isArkor } from "./arkor";
+import type { Trainer } from "./types";
+
+function fakeTrainer(name = "run"): Trainer {
+  return {
+    name,
+    async start() {
+      return { jobId: "j" };
+    },
+    async wait() {
+      return {
+        job: {
+          id: "j",
+          orgId: "o",
+          projectId: "p",
+          name,
+          status: "completed",
+          config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+          createdAt: "2026-01-01",
+        },
+        artifacts: [],
+      };
+    },
+    async cancel() {},
+  };
+}
+
+describe("createArkor", () => {
+  it("returns a frozen manifest with the brand and the trainer", () => {
+    const trainer = fakeTrainer();
+    const arkor = createArkor({ trainer });
+
+    expect(arkor._kind).toBe("arkor");
+    expect(arkor.trainer).toBe(trainer);
+    expect(Object.isFrozen(arkor)).toBe(true);
+  });
+
+  it("accepts an empty input (no trainer yet)", () => {
+    const arkor = createArkor({});
+    expect(arkor._kind).toBe("arkor");
+    expect(arkor.trainer).toBeUndefined();
+  });
+});
+
+describe("isArkor", () => {
+  it("recognises a manifest produced by createArkor", () => {
+    expect(isArkor(createArkor({ trainer: fakeTrainer() }))).toBe(true);
+  });
+
+  it("rejects plain objects, trainers, and non-objects", () => {
+    expect(isArkor(null)).toBe(false);
+    expect(isArkor(undefined)).toBe(false);
+    expect(isArkor({})).toBe(false);
+    expect(isArkor(fakeTrainer())).toBe(false);
+    expect(isArkor({ trainer: fakeTrainer() })).toBe(false);
+    expect(isArkor("arkor")).toBe(false);
+  });
+});

--- a/packages/arkor/src/core/arkor.ts
+++ b/packages/arkor/src/core/arkor.ts
@@ -1,0 +1,30 @@
+import type { Arkor, ArkorInput } from "./types";
+
+/**
+ * Build the project's umbrella manifest.
+ *
+ * `createArkor` is the umbrella factory — it gathers per-role primitives
+ * (`trainer`, future: `deploy`, `eval`) under a single value that the CLI
+ * (`arkor build` / `arkor start`) and Studio discover from
+ * `src/arkor/index.ts`.
+ *
+ * The returned object is intentionally a frozen, opaque manifest. Operation
+ * methods may be added to this shape in the future without breaking the
+ * user-facing API; callers should treat the result as a value to hand back to
+ * Arkor's tooling, not a programmable client.
+ */
+export function createArkor(input: ArkorInput): Arkor {
+  return Object.freeze({
+    _kind: "arkor" as const,
+    trainer: input.trainer,
+  });
+}
+
+/** Type guard used by the CLI runner to discover an Arkor manifest. */
+export function isArkor(value: unknown): value is Arkor {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { _kind?: unknown })._kind === "arkor"
+  );
+}

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -89,11 +89,26 @@ describe("runTrainer — entry extraction", () => {
     await expect(runTrainer(entry)).resolves.toBeUndefined();
   });
 
+  it("runs when the entry named-exports an `arkor` manifest", async () => {
+    const entry = join(cwd, "arkor-entry.mjs");
+    writeFileSync(
+      entry,
+      `const trainer = {
+        name: "n",
+        start: async () => ({ jobId: "j1" }),
+        wait: async () => ({ job: { id: "j1", orgId: "o", projectId: "p", name: "n", status: "completed", config: { model: "m", datasetSource: { type: "huggingface", name: "x" } }, createdAt: "2026-01-01", startedAt: null, completedAt: null }, artifacts: [] }),
+        cancel: async () => {},
+      };
+      export const arkor = Object.freeze({ _kind: "arkor", trainer });`,
+    );
+    await expect(runTrainer(entry)).resolves.toBeUndefined();
+  });
+
   it("throws when neither default nor named export is a Trainer", async () => {
     const entry = join(cwd, "bad-entry.mjs");
     writeFileSync(entry, `export default { notATrainer: true };`);
     await expect(runTrainer(entry)).rejects.toThrow(
-      /must default-export \(or export `trainer`\)/,
+      /must export `arkor`/,
     );
   });
 

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -7,6 +7,7 @@ import type { Trainer } from "./types";
 
 function fakeTrainer(onStart?: () => void, onWait?: () => void): Trainer {
   return {
+    name: "n",
     async start() {
       onStart?.();
       return { jobId: "j1" };
@@ -63,6 +64,7 @@ describe("runTrainer — entry extraction", () => {
     writeFileSync(
       entry,
       `export default {
+        name: "n",
         start: async () => ({ jobId: "j1" }),
         wait: async () => ({ job: { id: "j1", orgId: "o", projectId: "p", name: "n", status: "completed", config: { model: "m", datasetSource: { type: "huggingface", name: "x" } }, createdAt: "2026-01-01", startedAt: null, completedAt: null }, artifacts: [] }),
         cancel: async () => {},
@@ -78,6 +80,7 @@ describe("runTrainer — entry extraction", () => {
     writeFileSync(
       entry,
       `export const trainer = {
+        name: "n",
         start: async () => ({ jobId: "j1" }),
         wait: async () => ({ job: { id: "j1", orgId: "o", projectId: "p", name: "n", status: "completed", config: { model: "m", datasetSource: { type: "huggingface", name: "x" } }, createdAt: "2026-01-01", startedAt: null, completedAt: null }, artifacts: [] }),
         cancel: async () => {},

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { resolve, isAbsolute } from "node:path";
 import { pathToFileURL } from "node:url";
+import { isArkor } from "./arkor";
 import type { Trainer } from "./types";
 
 const DEFAULT_ENTRY = "src/arkor/index.ts";
@@ -15,17 +16,29 @@ function isTrainer(value: unknown): value is Trainer {
   );
 }
 
+function trainerFromValue(value: unknown): Trainer | null {
+  if (isArkor(value) && value.trainer && isTrainer(value.trainer)) {
+    return value.trainer;
+  }
+  if (isTrainer(value)) return value;
+  return null;
+}
+
 function extractTrainer(mod: Record<string, unknown>): Trainer {
-  // Preferred: named export `trainer`. Fallback: `default` export.
+  // Preferred (new): `arkor` named export from createArkor({...}).
+  const fromArkor = trainerFromValue(mod.arkor);
+  if (fromArkor) return fromArkor;
+  // Power-user shortcut: a bare `trainer` export.
   if (isTrainer(mod.trainer)) return mod.trainer;
-  const def = mod.default as unknown;
-  if (isTrainer(def)) return def;
-  if (def && typeof def === "object") {
-    const t = (def as Record<string, unknown>).trainer;
-    if (isTrainer(t)) return t;
+  // Fallback: default export holding either an Arkor manifest or a Trainer.
+  const fromDefault = trainerFromValue(mod.default);
+  if (fromDefault) return fromDefault;
+  if (mod.default && typeof mod.default === "object") {
+    const nested = (mod.default as Record<string, unknown>).trainer;
+    if (isTrainer(nested)) return nested;
   }
   throw new Error(
-    "Training entry must default-export (or export `trainer`) the result of createTrainer(...).",
+    "Training entry must export `arkor` (from createArkor({...})) or `trainer` (from createTrainer({...})), or default-export one of them.",
   );
 }
 

--- a/packages/arkor/src/core/trainer.test.ts
+++ b/packages/arkor/src/core/trainer.test.ts
@@ -136,10 +136,8 @@ describe("createTrainer (SSE event stream)", () => {
     const trainer = createTrainer(
       {
         name: "run",
-        config: {
-          model: "m",
-          datasetSource: { type: "huggingface", name: "x" },
-        },
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
         callbacks: {
           onStarted: ({ job }) => void calls.push(`onStarted(${job.status})`),
           onLog: ({ step, loss }) => void calls.push(`onLog(${step},${loss})`),
@@ -221,7 +219,8 @@ describe("createTrainer (SSE event stream)", () => {
     const trainer = createTrainer(
       {
         name: "run",
-        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
         callbacks: {
           onFailed: ({ error }) => {
             captured = error;
@@ -302,7 +301,8 @@ describe("createTrainer (SSE event stream)", () => {
     const trainer = createTrainer(
       {
         name: "run",
-        config: { model: "m", datasetSource: { type: "huggingface", name: "x" } },
+        model: "m",
+        dataset: { type: "huggingface", name: "x" },
         callbacks: {
           onCheckpoint: async ({ infer }) => {
             const res = await infer({

--- a/packages/arkor/src/core/trainer.ts
+++ b/packages/arkor/src/core/trainer.ts
@@ -10,8 +10,9 @@ import type {
   ArkorProjectState,
   CheckpointContext,
   InferArgs,
+  JobConfig,
   Trainer,
-  TrainerOptions,
+  TrainerInput,
   TrainingJob,
   TrainingLogContext,
   TrainingResult,
@@ -19,14 +20,17 @@ import type {
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
-export interface CreateTrainerContext {
-  /** Override the resolved cloud-api base URL (defaults to env / localhost:3003). */
+/**
+ * Internal runtime context. Not part of the public API surface — exposed only
+ * for tests and advanced power-user scenarios that need to inject a mock
+ * `fetch` or override the working directory.
+ *
+ * @internal
+ */
+export interface TrainerInternalContext {
   baseUrl?: string;
-  /** Override credentials (primarily for tests). */
   credentials?: Credentials;
-  /** Override the project working directory (defaults to `process.cwd()`). */
   cwd?: string;
-  /** Reconnect back-off on stream drops (ms). Defaults to 1000. */
   reconnectDelayMs?: number;
 }
 
@@ -59,21 +63,57 @@ type StreamEvent =
     })
   | (StreamEventBase & { type: "training.failed"; error: string; step?: number });
 
+function buildJobConfig(input: TrainerInput): JobConfig {
+  const config: JobConfig = {
+    model: input.model,
+    datasetSource: input.dataset,
+  };
+  if (input.lora) {
+    config.loraR = input.lora.r;
+    config.loraAlpha = input.lora.alpha;
+    if (input.lora.maxLength !== undefined) config.maxLength = input.lora.maxLength;
+    if (input.lora.loadIn4bit !== undefined) config.loadIn4bit = input.lora.loadIn4bit;
+  }
+  if (input.maxSteps !== undefined) config.maxSteps = input.maxSteps;
+  if (input.numTrainEpochs !== undefined) config.numTrainEpochs = input.numTrainEpochs;
+  if (input.learningRate !== undefined) config.learningRate = input.learningRate;
+  if (input.batchSize !== undefined) config.batchSize = input.batchSize;
+  if (input.optim !== undefined) config.optim = input.optim;
+  if (input.lrSchedulerType !== undefined) config.lrSchedulerType = input.lrSchedulerType;
+  if (input.weightDecay !== undefined) config.weightDecay = input.weightDecay;
+  if (input.warmupSteps !== undefined) config.warmupSteps = input.warmupSteps;
+  if (input.loggingSteps !== undefined) config.loggingSteps = input.loggingSteps;
+  if (input.saveSteps !== undefined) config.saveSteps = input.saveSteps;
+  if (input.evalSteps !== undefined) config.evalSteps = input.evalSteps;
+  if (input.trainOnResponsesOnly !== undefined)
+    config.trainOnResponsesOnly = input.trainOnResponsesOnly;
+  if (input.datasetFormat !== undefined) config.datasetFormat = input.datasetFormat;
+  if (input.datasetSplit !== undefined) config.datasetSplit = input.datasetSplit;
+  return config;
+}
+
 /**
  * Build a `Trainer` bound to the user's configuration.
  *
+ * Public signature: `createTrainer(input)` — runtime options like
+ * `baseUrl` / `credentials` / `cwd` come from the environment and `.arkor/`
+ * state, never from user code. The optional second argument is reserved for
+ * tests and advanced overrides.
+ *
  * `.start()` submits the job and `.wait()` opens an SSE stream
- * (`GET /v1/jobs/:id/events/stream`), dispatching callbacks as events
- * arrive. `onCheckpoint` receives an `infer` helper bound to the
- * checkpoint's adapter for mid-training evaluation.
+ * (`GET /v1/jobs/:id/events/stream`), dispatching callbacks as events arrive.
+ * `onCheckpoint` receives an `infer` helper bound to the checkpoint's adapter
+ * for mid-training evaluation.
  */
 export function createTrainer(
-  options: TrainerOptions,
-  context: CreateTrainerContext = {},
+  input: TrainerInput,
+  /** @internal */
+  context: TrainerInternalContext = {},
 ): Trainer {
   const baseUrl = context.baseUrl ?? defaultArkorCloudApiUrl();
   const reconnectDelayMs = context.reconnectDelayMs ?? 1000;
   const cwd = context.cwd ?? process.cwd();
+  const config = buildJobConfig(input);
 
   let startedJob: TrainingJob | null = null;
   let scope: { orgSlug: string; projectSlug: string } | null = null;
@@ -161,7 +201,7 @@ export function createTrainer(
       throw new Error("Trainer is in an inconsistent state");
     }
     const client = await getClient();
-    const callbacks = options.callbacks ?? {};
+    const callbacks = input.callbacks ?? {};
 
     switch (event.type) {
       case "training.started": {
@@ -235,6 +275,8 @@ export function createTrainer(
   }
 
   const trainer: Trainer = {
+    name: input.name,
+
     async start() {
       if (startedJob) return { jobId: startedJob.id };
       const client = await getClient();
@@ -244,8 +286,8 @@ export function createTrainer(
       const { job } = await client.createJob({
         orgSlug: state.orgSlug,
         projectSlug: state.projectSlug,
-        name: options.name,
-        config: options.config,
+        name: input.name,
+        config,
       });
       startedJob = job;
       return { jobId: job.id };
@@ -257,7 +299,7 @@ export function createTrainer(
         throw new Error("Trainer is in an inconsistent state after start()");
       }
       const client = await getClient();
-      const { abortSignal } = options;
+      const { abortSignal } = input;
 
       let lastEventId: string | undefined;
       let artifacts: unknown[] = [];

--- a/packages/arkor/src/core/types.ts
+++ b/packages/arkor/src/core/types.ts
@@ -26,6 +26,10 @@ export interface BlobDatasetSource {
 
 export type DatasetSource = HuggingfaceDatasetSource | BlobDatasetSource;
 
+/**
+ * Wire shape sent to the cloud API's job-create endpoint. Internal — users
+ * compose a `TrainerInput` and the SDK translates to this.
+ */
 export interface JobConfig {
   model: string;
   datasetSource: DatasetSource;
@@ -118,22 +122,63 @@ export interface TrainerCallbacks {
   }) => unknown | Promise<unknown>;
 }
 
-export interface TrainerOptions {
-  /** Human-readable run name, shown in Studio + Web UI. */
+/**
+ * LoRA / quantisation knobs. Grouped here because they cluster naturally as a
+ * single concept ("how is the adapter trained?").
+ */
+export interface LoraConfig {
+  /** LoRA rank (often 8 / 16 / 32). */
+  r: number;
+  /** LoRA alpha (often 2× r). */
+  alpha: number;
+  /** Maximum sequence length (truncates samples beyond this). */
+  maxLength?: number;
+  /** Load the base model in 4-bit quantisation (QLoRA). */
+  loadIn4bit?: boolean;
+}
+
+/**
+ * User-facing input to `createTrainer`. Flat by design so the common shape
+ * reads like a config object; lifecycle handlers are grouped under
+ * `callbacks` for legibility.
+ */
+export interface TrainerInput {
+  /** Human-readable run name; shown in Studio + Web UI. */
   name: string;
-  /** Training configuration; matches the cloud API's jobConfigSchema. */
-  config: JobConfig;
+  /** Base model identifier (HuggingFace path, etc.). */
+  model: string;
+  /** Dataset source (HuggingFace name or blob URL). */
+  dataset: DatasetSource;
+  /** LoRA / quantisation knobs. */
+  lora?: LoraConfig;
+  /** Cap training at this many gradient steps. */
+  maxSteps?: number;
+  numTrainEpochs?: number;
+  learningRate?: number;
+  batchSize?: number;
+  optim?: string;
+  lrSchedulerType?: string;
+  weightDecay?: number;
   /**
-   * Optional lifecycle callbacks. `onLog` / `onCheckpoint` land in a later phase
-   * (they need an SSE event stream on the server side) and are accepted here but
-   * not yet invoked.
+   * Forwarded to the cloud API as-is. Reserved for fields that aren't yet
+   * first-classed in this SDK. Prefer the dedicated fields above when present.
    */
+  warmupSteps?: unknown;
+  loggingSteps?: unknown;
+  saveSteps?: unknown;
+  evalSteps?: unknown;
+  trainOnResponsesOnly?: unknown;
+  datasetFormat?: unknown;
+  datasetSplit?: unknown;
+  /** Optional lifecycle callbacks. */
   callbacks?: Partial<TrainerCallbacks>;
   /** Abort signal to stop polling and cancel the in-flight job. */
   abortSignal?: AbortSignal;
 }
 
 export interface Trainer {
+  /** The run name supplied by the user, copied here for discovery. */
+  readonly name: string;
   /** Submit the job. Returns the created job id. */
   start(): Promise<{ jobId: string }>;
   /** Resolve when the job reaches a terminal status. */

--- a/packages/arkor/src/core/types.ts
+++ b/packages/arkor/src/core/types.ts
@@ -187,6 +187,26 @@ export interface Trainer {
   cancel(): Promise<void>;
 }
 
+/**
+ * Umbrella manifest produced by `createArkor`. Currently a frozen descriptor
+ * of the project's primitives. The shape is intentionally opaque — operation
+ * methods may be added later without breaking the user-facing API.
+ */
+export interface Arkor {
+  /** Runtime discriminator used by `isArkor` and `arkor build` discovery. */
+  readonly _kind: "arkor";
+  readonly trainer?: Trainer;
+  // future: readonly deploy?: Deploy;
+  // future: readonly eval?: Eval;
+}
+
+/** User-facing input to `createArkor`. Role-fixed keys. */
+export interface ArkorInput {
+  trainer?: Trainer;
+  // future: deploy?: Deploy;
+  // future: eval?: Eval;
+}
+
 export interface ArkorProjectState {
   orgSlug: string;
   projectSlug: string;

--- a/packages/arkor/src/index.ts
+++ b/packages/arkor/src/index.ts
@@ -1,6 +1,9 @@
 export { createTrainer } from "./core/trainer";
+export { createArkor, isArkor } from "./core/arkor";
 export { runTrainer } from "./core/runner";
 export type {
+  Arkor,
+  ArkorInput,
   ArkorProjectState,
   BlobDatasetSource,
   DatasetSource,

--- a/packages/arkor/src/index.ts
+++ b/packages/arkor/src/index.ts
@@ -1,16 +1,15 @@
 export { createTrainer } from "./core/trainer";
-export type { CreateTrainerContext } from "./core/trainer";
 export { runTrainer } from "./core/runner";
 export type {
   ArkorProjectState,
   BlobDatasetSource,
   DatasetSource,
   HuggingfaceDatasetSource,
-  JobConfig,
   JobStatus,
+  LoraConfig,
   Trainer,
   TrainerCallbacks,
-  TrainerOptions,
+  TrainerInput,
   TrainingJob,
   TrainingResult,
 } from "./core/types";


### PR DESCRIPTION
## Summary

Phase 1 of the SDK / CLI redesign discussed in `arkor-sdk-cli-studio-sdk-sequential-conway` plan. Aligns the SDK shape with TypeScript / Next.js conventions for the framework's actual audience (product engineers without ML teams).

- **`refactor(sdk): flatten createTrainer to a 1-argument input`** — collapses the old 2-arg `createTrainer({ name, config: {...}, callbacks: {...} }, { baseUrl, credentials, cwd, ... })` into `createTrainer(input)` with `name`/`model`/`dataset`/training hyperparams at the top level and lifecycle handlers grouped under `callbacks: { ... }`. Runtime context (`baseUrl`/`credentials`/`cwd`/`reconnectDelayMs`) is resolved from env + `.arkor/` only and lives behind an `@internal` `TrainerInternalContext` retained for tests. New `LoraConfig` groups `loraR`/`loraAlpha`/`maxLength`/`loadIn4bit`. `JobConfig`, `TrainerOptions`, and `CreateTrainerContext` drop out of the public surface; `JobConfig` survives as the internal cloud-API wire shape and is built from `TrainerInput` via `buildJobConfig`.

- **`feat(sdk): add createArkor umbrella + manifest-aware runner discovery`** — introduces the umbrella factory (`export const arkor = createArkor({ trainer })`) that gathers per-role primitives under a single value the CLI / Studio can discover from `src/arkor/index.ts`. Mastra-style umbrella thinking but function-form (no `new`) with role-fixed keys (`trainer`, future: `deploy`, `eval`). `createArkor` returns a frozen, opaque manifest stamped with `_kind: "arkor"`; `isArkor` reads the brand for runner discovery. `runTrainer` extends entry-point detection: `mod.arkor` → `mod.trainer` → `mod.default` → `mod.default.trainer`.

Out of scope (later phases): CLI command reshape (`arkor dev/build/start`, removing `train`/`jobs`/`logs`), Studio `/api/train` integration, scaffold templates, docs.

## Test plan

- [x] `pnpm -w typecheck` — green across all 5 packages
- [x] `pnpm -w test` — green (49 SDK tests including the new `arkor.test.ts` and the runner test that loads a frozen `{ _kind: "arkor", trainer }` manifest, plus 24 e2e CLI tests unaffected)
- [x] Each commit individually green (commit 1: 44 tests; commit 2: 49 tests)
- [ ] Manual smoke: scaffold a project, write a `createTrainer({...})` against the new flat shape, confirm IDE completions match the documented surface (deferred to Phase 4 when templates are updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)