### PR TITLE
feat(studio): make Studio aware of the user's createArkor manifest (Phase 3)

### DIFF
--- a/packages/arkor/src/studio/manifest.ts
+++ b/packages/arkor/src/studio/manifest.ts
@@ -1,0 +1,36 @@
+import { pathToFileURL } from "node:url";
+import { runBuild } from "../cli/commands/build";
+import { isArkor } from "../core/arkor";
+
+/**
+ * Wire-friendly snapshot of the user's `createArkor({...})` manifest. Mirrors
+ * the runtime `Arkor` shape but keeps only fields the Studio UI can render
+ * without re-importing the artifact.
+ */
+export interface ManifestSummary {
+  trainer: { name: string } | null;
+  // future: deploy: { name: string } | null;
+  // future: eval:   { name: string } | null;
+}
+
+const EMPTY: ManifestSummary = { trainer: null };
+
+/**
+ * Build the user's `src/arkor/index.ts` and import the artifact to extract a
+ * serialisable summary of its manifest. The Studio UI hits this on home-page
+ * load to show *what* the project contains (just the trainer name today;
+ * deploy / eval slots when those primitives land).
+ *
+ * Each call rebuilds and re-imports so edits to the user's source surface
+ * without restarting Studio. The import URL carries a cache-bust query so
+ * Node's ESM cache doesn't return a stale module.
+ */
+export async function readManifestSummary(cwd: string): Promise<ManifestSummary> {
+  const { outFile } = await runBuild({ cwd, quiet: true });
+  const url = `${pathToFileURL(outFile).href}?t=${Date.now()}`;
+  const mod = (await import(url)) as Record<string, unknown>;
+  const candidate = mod.arkor ?? mod.default;
+  if (!isArkor(candidate)) return EMPTY;
+  const trainer = candidate.trainer ? { name: candidate.trainer.name } : null;
+  return { trainer };
+}

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -329,4 +329,71 @@ process.exit(0);
       expect(text).not.toContain("exit=0");
     });
   });
+
+  describe("/api/manifest", () => {
+    const FAKE_MANIFEST_SOURCE = `export const arkor = Object.freeze({
+      _kind: "arkor",
+      trainer: {
+        name: "qa-bot",
+        start: async () => ({ jobId: "j1" }),
+        wait: async () => ({ job: {}, artifacts: [] }),
+        cancel: async () => {},
+      },
+    });
+    `;
+
+    it("returns the trainer name when src/arkor/index.ts exports a manifest", async () => {
+      await writeCredentials(ANON_CREDS);
+      mkdirSync(join(trainCwd, "src/arkor"), { recursive: true });
+      writeFileSync(
+        join(trainCwd, "src/arkor/index.ts"),
+        FAKE_MANIFEST_SOURCE,
+      );
+      const app = build();
+      const res = await app.request("/api/manifest", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        trainer: { name: string } | null;
+      };
+      expect(body.trainer).toEqual({ name: "qa-bot" });
+    });
+
+    it("returns 400 when src/arkor/index.ts is missing", async () => {
+      await writeCredentials(ANON_CREDS);
+      const app = build();
+      const res = await app.request("/api/manifest", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toMatch(/Build entry not found/);
+    });
+
+    it("returns trainer:null when the manifest has no trainer slot", async () => {
+      await writeCredentials(ANON_CREDS);
+      mkdirSync(join(trainCwd, "src/arkor"), { recursive: true });
+      writeFileSync(
+        join(trainCwd, "src/arkor/index.ts"),
+        `export const arkor = Object.freeze({ _kind: "arkor" });\n`,
+      );
+      const app = build();
+      const res = await app.request("/api/manifest", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { trainer: unknown };
+      expect(body.trainer).toBeNull();
+    });
+  });
 });

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -11,6 +11,7 @@ import {
   type Credentials,
 } from "../core/credentials";
 import { readState } from "../core/state";
+import { readManifestSummary } from "./manifest";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve, sep } from "node:path";
 
@@ -165,6 +166,22 @@ export function buildStudioApp(options: StudioServerOptions) {
       status: res.status,
       headers: { "content-type": "application/json" },
     });
+  });
+
+  app.get("/api/manifest", async (c) => {
+    try {
+      const manifest = await readManifestSummary(trainCwd);
+      return c.json(manifest);
+    } catch (err) {
+      // The user's `src/arkor/index.ts` may not exist yet (fresh scaffold) or
+      // the bundle may throw at import time. Surface the error as 400 so the
+      // SPA can render a hint instead of treating it as an infrastructure
+      // failure.
+      return c.json(
+        { error: err instanceof Error ? err.message : String(err) },
+        400,
+      );
+    }
   });
 
   app.get("/api/jobs", async (c) => {

--- a/packages/studio-app/src/components/RunTraining.tsx
+++ b/packages/studio-app/src/components/RunTraining.tsx
@@ -1,10 +1,33 @@
-import { useRef, useState } from "react";
-import { streamTraining } from "../lib/api";
+import { useEffect, useRef, useState } from "react";
+import {
+  fetchManifest,
+  streamTraining,
+  type ManifestResult,
+} from "../lib/api";
 
 export function RunTraining() {
   const [running, setRunning] = useState(false);
   const [log, setLog] = useState("");
+  const [manifest, setManifest] = useState<ManifestResult | null>(null);
   const boxRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchManifest()
+      .then((m) => {
+        if (!cancelled) setManifest(m);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setManifest({
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function run() {
     setRunning(true);
@@ -26,10 +49,34 @@ export function RunTraining() {
     }
   }
 
+  const trainer =
+    manifest && "trainer" in manifest ? manifest.trainer : null;
+  const manifestError =
+    manifest && "error" in manifest ? manifest.error : null;
+  const hasTrainer = Boolean(trainer);
+
+  const buttonLabel = running
+    ? "Running…"
+    : trainer
+      ? `Run training: ${trainer.name}`
+      : "Run training";
+
   return (
     <div className="run-training">
-      <button onClick={run} disabled={running}>
-        {running ? "Running…" : "Run training (src/arkor/index.ts)"}
+      {manifestError && (
+        <p className="manifest-hint">
+          Couldn't read manifest: {manifestError}
+        </p>
+      )}
+      {manifest && !manifestError && !hasTrainer && (
+        <p className="manifest-hint">
+          No trainer in src/arkor/index.ts yet. Add{" "}
+          <code>createTrainer(...)</code> and pass it to{" "}
+          <code>createArkor</code>.
+        </p>
+      )}
+      <button onClick={run} disabled={running || !hasTrainer}>
+        {buttonLabel}
       </button>
       <pre ref={boxRef} className="log">
         {log || "Output will appear here."}

--- a/packages/studio-app/src/lib/api.ts
+++ b/packages/studio-app/src/lib/api.ts
@@ -24,6 +24,22 @@ export interface Job {
   config?: Record<string, unknown>;
 }
 
+/**
+ * Wire-friendly snapshot of the user's `createArkor({...})` manifest. The
+ * Studio backend builds `src/arkor/index.ts` and pulls these fields out so
+ * the SPA can show what the project contains without re-importing the
+ * artifact itself.
+ */
+export interface ManifestSummary {
+  trainer: { name: string } | null;
+}
+
+export interface ManifestError {
+  error: string;
+}
+
+export type ManifestResult = ManifestSummary | ManifestError;
+
 function readStudioToken(): string {
   if (typeof document === "undefined") return "";
   const meta = document.querySelector('meta[name="arkor-studio-token"]');
@@ -68,6 +84,18 @@ export async function fetchMe(): Promise<Me> {
 
 export async function fetchJobs(): Promise<{ jobs: Job[] }> {
   return json(await apiFetch("/api/jobs"));
+}
+
+/**
+ * Fetch a serialisable summary of the user's `createArkor({...})` manifest.
+ * Returns `{ error }` (not a thrown exception) on 4xx so the SPA can render a
+ * targeted hint — typically "no src/arkor/index.ts yet" right after scaffold.
+ */
+export async function fetchManifest(): Promise<ManifestResult> {
+  const res = await apiFetch("/api/manifest");
+  if (res.ok) return (await res.json()) as ManifestSummary;
+  if (res.status === 400) return (await res.json()) as ManifestError;
+  throw new Error(`${res.status} ${res.statusText}`);
 }
 
 export function openJobEvents(jobId: string): EventSource {


### PR DESCRIPTION
## Summary

Phase 3 of the SDK / CLI redesign. Studio stops being a thin spawn-and-stream proxy and starts knowing what the user's project actually contains.

- `feat(studio): expose /api/manifest from the build artifact` — new `readManifestSummary(cwd)` calls `runBuild` (the same esbuild path `arkor build` uses), imports the artifact with a `?t=Date.now()` cache-bust so edits surface without restarting Studio, and returns a wire-friendly summary (`{ trainer: { name } | null }`). Wired up at `GET /api/manifest`. 4xx errors carry a plain message so the SPA can render targeted hints (e.g. "no `src/arkor/index.ts` yet" right after scaffold) instead of treating them as infrastructure failures.
- `feat(studio-app): show trainer name from /api/manifest in Run Training` — the Run-training panel now labels its button `Run training: <trainer.name>`, disables it when the manifest has no trainer slot (with a short `createTrainer → createArkor` hint), and surfaces manifest errors inline. `fetchManifest` returns `ManifestSummary | ManifestError` so the component branches on data shape rather than try/catch.

Each commit individually leaves the tree green.

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green (3 new backend tests covering happy path, missing entry, manifest with no trainer; 67 SDK tests total)
- [ ] Manual smoke: `arkor dev` against a project with `createArkor({ trainer })` shows the trainer name on the home screen; against a fresh scaffold shows the missing-entry hint (deferred — Phase 4 will refresh templates so the smoke is end-to-end clean)

--
## 概要

SDK / CLI 再設計の Phase 3。Studio が単なる spawn-and-stream プロキシから、**ユーザのプロジェクトに何があるかを把握する** GUI へ進化する。

- `feat(studio): expose /api/manifest from the build artifact` — 新規 `readManifestSummary(cwd)` は `runBuild`（`arkor build` と同じ esbuild 経路）を呼び、`?t=Date.now()` のキャッシュバスト付きで成果物を import し、wire-friendly な summary（`{ trainer: { name } | null }`）を返す。`GET /api/manifest` に接続。4xx は plain message を返すので、SPA は scaffold 直後の「`src/arkor/index.ts` がまだ無い」状態を hint として表示できる（infra エラーとして扱わない）。
- `feat(studio-app): show trainer name from /api/manifest in Run Training` — Run-training パネルのボタンが `Run training: <trainer.name>` に変わり、manifest に trainer slot が無い時は disable + `createTrainer → createArkor` のヒント表示、manifest 読み取りエラーもインラインで表示。`fetchManifest` は `ManifestSummary | ManifestError` を返すので、想定内の「未生成」ケースを try/catch なしでデータ形状で分岐できる。

各コミット時点で tree green。

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green（バックエンド 3 テスト追加：happy path / entry 不在 / trainer slot 無し manifest。SDK は計 67 テスト）
- [ ] 手動 smoke：`createArkor({ trainer })` を持つプロジェクトで `arkor dev` し、home 画面に trainer 名が表示されることを確認。fresh scaffold では missing-entry ヒントが出ることを確認（Phase 4 でテンプレート更新後にクリーンに動かすため保留）
