### PR TITLE
## Summary  Phase 4 of the SDK / CLI redesign. Brings the scaffold output and the post-init UX in line with the umbrella manifest + `dev`/`build`/`start` shape that landed in Phases 1–3.

### DIFF
--- a/e2e/cli/src/arkor-init.test.ts
+++ b/e2e/cli/src/arkor-init.test.ts
@@ -43,7 +43,7 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("pnpm install");
-    expect(result.stdout).toContain("pnpm arkor train");
+    expect(result.stdout).toContain("pnpm arkor dev");
   });
 
   it("renders the npm next-steps (npx for run) when --use-npm is set", async () => {
@@ -54,13 +54,13 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("npm install");
-    expect(result.stdout).toContain("npx arkor train");
+    expect(result.stdout).toContain("npx arkor dev");
   });
 
   it.each([
-    { pm: "yarn", trainCmd: "yarn arkor train" },
-    { pm: "bun", trainCmd: "bun arkor train" },
-  ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, trainCmd }) => {
+    { pm: "yarn", devCmd: "yarn arkor dev" },
+    { pm: "bun", devCmd: "bun arkor dev" },
+  ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, devCmd }) => {
     const result = await runCli(
       ARKOR_BIN,
       ["init", "-y", "--skip-install", "--skip-git", `--use-${pm}`],
@@ -68,7 +68,7 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain(`${pm} install`);
-    expect(result.stdout).toContain(trainCmd);
+    expect(result.stdout).toContain(devCmd);
   });
 
   it("creates a real git repo and initial commit when --git is set", async () => {
@@ -115,8 +115,8 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
 
-    const entry = readFileSync(join(cwd, "src/arkor/index.ts"), "utf8");
-    expect(entry).toContain('"chatml-run"');
+    const trainer = readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8");
+    expect(trainer).toContain('"chatml-run"');
 
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),

--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -50,11 +50,16 @@ describe("create-arkor (E2E)", () => {
     ) as { name?: string };
     expect(pkg.name).toBe(basename(targetDir));
 
-    const entry = readFileSync(join(targetDir, "src/arkor/index.ts"), "utf8");
-    expect(entry).toContain("createTrainer");
+    const index = readFileSync(join(targetDir, "src/arkor/index.ts"), "utf8");
+    expect(index).toContain("createArkor");
+    const trainer = readFileSync(
+      join(targetDir, "src/arkor/trainer.ts"),
+      "utf8",
+    );
+    expect(trainer).toContain("createTrainer");
 
-    // No `--use-*` and CI=1 → pm undefined → manual install hint + npx train.
-    expect(result.stdout).toContain("npx arkor train");
+    // No `--use-*` and CI=1 → pm undefined → manual install hint + npx dev.
+    expect(result.stdout).toContain("npx arkor dev");
     expect(result.stdout).toContain(
       "install dependencies (npm i / pnpm install / yarn / bun install)",
     );
@@ -69,7 +74,7 @@ describe("create-arkor (E2E)", () => {
     ]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("pnpm install");
-    expect(result.stdout).toContain("pnpm arkor train");
+    expect(result.stdout).toContain("pnpm arkor dev");
   });
 
   it("renders the npm next-steps (npx for run) when --use-npm is set", async () => {
@@ -82,13 +87,13 @@ describe("create-arkor (E2E)", () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("npm install");
     // npm forces `npx arkor` since `npm arkor` isn't a thing.
-    expect(result.stdout).toContain("npx arkor train");
+    expect(result.stdout).toContain("npx arkor dev");
   });
 
   it.each([
-    { pm: "yarn", trainCmd: "yarn arkor train" },
-    { pm: "bun", trainCmd: "bun arkor train" },
-  ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, trainCmd }) => {
+    { pm: "yarn", devCmd: "yarn arkor dev" },
+    { pm: "bun", devCmd: "bun arkor dev" },
+  ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, devCmd }) => {
     const { result } = await runCreateArkor([
       "-y",
       "--skip-install",
@@ -97,7 +102,7 @@ describe("create-arkor (E2E)", () => {
     ]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain(`${pm} install`);
-    expect(result.stdout).toContain(trainCmd);
+    expect(result.stdout).toContain(devCmd);
   });
 
   it("creates a real git repo and initial commit when --git is set", async () => {
@@ -145,8 +150,11 @@ describe("create-arkor (E2E)", () => {
     ) as { name?: string };
     expect(pkg.name).toBe("no-prompt-app");
 
-    const entry = readFileSync(join(targetDir, "src/arkor/index.ts"), "utf8");
-    expect(entry).toContain('"chatml-run"');
+    const trainer = readFileSync(
+      join(targetDir, "src/arkor/trainer.ts"),
+      "utf8",
+    );
+    expect(trainer).toContain('"chatml-run"');
   });
 
   // Regression for ENG-357 — `--name "Foo Bar"` previously fell through to
@@ -205,8 +213,11 @@ describe("create-arkor (E2E)", () => {
     ) as { name?: string };
     expect(pkg.name).toBe("custom-app");
 
-    const entry = readFileSync(join(targetDir, "src/arkor/index.ts"), "utf8");
-    expect(entry).toContain('"alpaca-run"');
+    const trainer = readFileSync(
+      join(targetDir, "src/arkor/trainer.ts"),
+      "utf8",
+    );
+    expect(trainer).toContain('"alpaca-run"');
   });
 
   it.skipIf(SKIP_INSTALL).each([{ pm: "npm" }, { pm: "pnpm" }])(

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -141,7 +141,7 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   const port = options.port ?? 4000;
   // Per-launch CSRF token: injected into index.html as <meta>, required on
   // every /api/* request. Prevents another tab on the same machine from
-  // hitting `arkor train` (and therefore RCE via dynamic import).
+  // hitting `arkor start` (and therefore RCE via dynamic import).
   const studioToken = randomBytes(32).toString("base64url");
 
   // Persisting the token to disk is *only* needed for the Vite SPA dev

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -139,13 +139,13 @@ export async function runInit(options: InitOptions): Promise<void> {
   // reproducible.
   await maybeGitInit(cwd, options);
 
-  const trainCmd =
-    pm && pm !== "npm" ? `${pm} arkor train` : "npx arkor train";
+  const devCmd =
+    pm && pm !== "npm" ? `${pm} arkor dev` : "npx arkor dev";
   ui.outro(
     installed
-      ? `Next: \`${trainCmd}\``
+      ? `Next: \`${devCmd}\``
       : pm
-        ? `Next: \`${pm} install\`, then \`${trainCmd}\``
-        : `Next: ${MANUAL_INSTALL_HINT}, then \`${trainCmd}\``,
+        ? `Next: \`${pm} install\`, then \`${devCmd}\``
+        : `Next: ${MANUAL_INSTALL_HINT}, then \`${devCmd}\``,
   );
 }

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -204,7 +204,7 @@ describe("Studio server", () => {
 
   // Regression for ENG-404 — `path.resolve` doesn't follow symlinks, so a
   // link inside the project directory pointing outside it would previously
-  // pass the containment check and be handed to `arkor train` (which would
+  // pass the containment check and be handed to `arkor start` (which would
   // then dlopen the link's target).
   it("rejects /api/train when body.file is a symlink to a path outside cwd", async () => {
     await writeCredentials(ANON_CREDS);

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -23,7 +23,9 @@ afterEach(() => {
 describe("scaffold", () => {
   it("writes all starter files in an empty directory", async () => {
     const result = await scaffold({ cwd, name: "my-app", template: "minimal" });
+    // index.ts, trainer.ts, arkor.config.ts, README.md, .gitignore, package.json
     expect(result.files.map((f) => f.action)).toEqual([
+      "created",
       "created",
       "created",
       "created",
@@ -31,33 +33,54 @@ describe("scaffold", () => {
       "created",
     ]);
 
-    const entry = readFileSync(join(cwd, "src/arkor/index.ts"), "utf8");
-    expect(entry).toContain("createTrainer");
-    expect(entry).toContain("unsloth/gemma-4-E4B-it");
+    const index = readFileSync(join(cwd, "src/arkor/index.ts"), "utf8");
+    expect(index).toContain("createArkor");
+    expect(index).toContain('from "./trainer"');
+
+    const trainer = readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8");
+    expect(trainer).toContain("createTrainer");
+    expect(trainer).toContain("unsloth/gemma-4-E4B-it");
+    expect(trainer).toContain('"my-first-run"');
 
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),
     ) as Record<string, unknown>;
     expect(pkg.name).toBe("my-app");
-    expect(pkg.scripts).toMatchObject({ train: "arkor train", dev: "arkor dev" });
+    expect(pkg.scripts).toMatchObject({
+      dev: "arkor dev",
+      build: "arkor build",
+      start: "arkor start",
+    });
+    expect((pkg.scripts as Record<string, string>).train).toBeUndefined();
 
     const gi = readFileSync(join(cwd, ".gitignore"), "utf8");
     expect(gi).toContain(".arkor/");
   });
 
-  it("keeps existing src/arkor/index.ts untouched", async () => {
-    const existing = "// custom\nexport default {};\n";
+  it("keeps existing src/arkor/index.ts and trainer.ts untouched", async () => {
+    const existingIndex = "// custom index\nexport default {};\n";
+    const existingTrainer = "// custom trainer\nexport const trainer = {};\n";
     writeFileSync(join(cwd, "placeholder.txt"), "keep me");
     const { readdirSync, mkdirSync } = await import("node:fs");
     mkdirSync(join(cwd, "src/arkor"), { recursive: true });
-    writeFileSync(join(cwd, "src/arkor/index.ts"), existing);
+    writeFileSync(join(cwd, "src/arkor/index.ts"), existingIndex);
+    writeFileSync(join(cwd, "src/arkor/trainer.ts"), existingTrainer);
 
     const result = await scaffold({ cwd, name: "foo", template: "minimal" });
-    const entryFile = result.files.find(
+    const indexEntry = result.files.find(
       (f) => f.path === "src/arkor/index.ts",
     );
-    expect(entryFile?.action).toBe("kept");
-    expect(readFileSync(join(cwd, "src/arkor/index.ts"), "utf8")).toBe(existing);
+    const trainerEntry = result.files.find(
+      (f) => f.path === "src/arkor/trainer.ts",
+    );
+    expect(indexEntry?.action).toBe("kept");
+    expect(trainerEntry?.action).toBe("kept");
+    expect(readFileSync(join(cwd, "src/arkor/index.ts"), "utf8")).toBe(
+      existingIndex,
+    );
+    expect(readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8")).toBe(
+      existingTrainer,
+    );
     expect(readdirSync(cwd)).toContain("placeholder.txt");
   });
 
@@ -86,9 +109,10 @@ describe("scaffold", () => {
     expect(patched.name).toBe("already");
     expect(patched.dependencies).toEqual({ react: "19.0.0" });
     const scripts = patched.scripts as Record<string, string>;
+    // Existing user-defined `build` survives untouched.
     expect(scripts.build).toBe("tsc");
-    expect(scripts.train).toBe("arkor train");
     expect(scripts.dev).toBe("arkor dev");
+    expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
     expect(devDeps.arkor).toBe("^0.0.1-alpha.0");
 
@@ -108,7 +132,7 @@ describe("scaffold", () => {
     expect(secondEntry?.action).toBe("ok");
   });
 
-  it("renders each template with a distinct entry body", async () => {
+  it("renders each template with a distinct trainer body", async () => {
     const expectations: Record<"minimal" | "alpaca" | "chatml", string> = {
       minimal: `"my-first-run"`,
       alpaca: `"alpaca-run"`,
@@ -117,8 +141,11 @@ describe("scaffold", () => {
     for (const template of ["minimal", "alpaca", "chatml"] as const) {
       const dir = mkdtempSync(join(tmpdir(), `scaffold-${template}-`));
       await scaffold({ cwd: dir, name: template, template });
-      const entry = readFileSync(join(dir, "src/arkor/index.ts"), "utf8");
-      expect(entry).toContain(expectations[template]);
+      const trainer = readFileSync(join(dir, "src/arkor/trainer.ts"), "utf8");
+      expect(trainer).toContain(expectations[template]);
+      // The umbrella manifest is template-independent.
+      const index = readFileSync(join(dir, "src/arkor/index.ts"), "utf8");
+      expect(index).toContain("createArkor({ trainer })");
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import {
   STARTER_CONFIG,
+  STARTER_INDEX,
   STARTER_README,
   TEMPLATES,
   type TemplateId,
@@ -23,11 +24,18 @@ export interface ScaffoldResult {
   cwd: string;
 }
 
-const ENTRY_PATH = "src/arkor/index.ts";
+const INDEX_PATH = "src/arkor/index.ts";
+const TRAINER_PATH = "src/arkor/trainer.ts";
 const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
+
+const SCRIPT_DEFAULTS: Record<string, string> = {
+  dev: "arkor dev",
+  build: "arkor build",
+  start: "arkor start",
+};
 
 async function ensureDirExists(cwd: string): Promise<void> {
   if (!existsSync(cwd)) {
@@ -80,10 +88,7 @@ async function patchPackageJson(
           name,
           private: true,
           type: "module",
-          scripts: {
-            train: "arkor train",
-            dev: "arkor dev",
-          },
+          scripts: { ...SCRIPT_DEFAULTS },
           devDependencies: { arkor: "^0.0.1-alpha.0" },
         },
         null,
@@ -99,15 +104,12 @@ async function patchPackageJson(
   const scripts =
     (current.scripts as Record<string, string> | undefined) ?? {};
   let dirty = false;
-  if (!scripts.train) {
-    scripts.train = "arkor train";
-    current.scripts = scripts;
-    dirty = true;
-  }
-  if (!scripts.dev) {
-    scripts.dev = "arkor dev";
-    current.scripts = scripts;
-    dirty = true;
+  for (const [key, value] of Object.entries(SCRIPT_DEFAULTS)) {
+    if (!scripts[key]) {
+      scripts[key] = value;
+      current.scripts = scripts;
+      dirty = true;
+    }
   }
   const devDeps =
     (current.devDependencies as Record<string, string> | undefined) ?? {};
@@ -130,10 +132,14 @@ export async function scaffold(
 
   const files: ScaffoldResult["files"] = [];
   files.push({
-    path: ENTRY_PATH,
+    path: INDEX_PATH,
+    action: await ensureFile(join(cwd, INDEX_PATH), STARTER_INDEX),
+  });
+  files.push({
+    path: TRAINER_PATH,
     action: await ensureFile(
-      join(cwd, ENTRY_PATH),
-      TEMPLATES[options.template].entry,
+      join(cwd, TRAINER_PATH),
+      TEMPLATES[options.template].trainer,
     ),
   });
   files.push({

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -1,53 +1,54 @@
 /**
  * Starter templates written out by `create-arkor` / `arkor init`.
  * Single source of truth — both consumers bundle this module at build time.
+ *
+ * Layout written to disk:
+ *
+ *   src/arkor/index.ts    ← umbrella manifest (`createArkor({ trainer })`)
+ *   src/arkor/trainer.ts  ← per-template trainer (`createTrainer({...})`)
+ *
+ * `index.ts` is identical across templates — only the trainer body differs.
  */
 export type TemplateId = "minimal" | "alpaca" | "chatml";
 
-export const TEMPLATES: Record<TemplateId, { label: string; hint: string; entry: string }> = {
-  minimal: {
-    label: "Minimal",
-    hint: "bare createTrainer call",
-    entry: `import { createTrainer } from "arkor";
+export interface Template {
+  label: string;
+  hint: string;
+  /** Body of `src/arkor/trainer.ts` for this template. */
+  trainer: string;
+}
 
-export default createTrainer({
+const MINIMAL_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
   name: "my-first-run",
-  config: {
-    model: "unsloth/gemma-4-E4B-it",
-    datasetSource: {
-      type: "huggingface",
-      name: "yahma/alpaca-cleaned",
-      split: "train[:500]",
-    },
-    maxSteps: 50,
-    loraR: 16,
-    loraAlpha: 16,
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: {
+    type: "huggingface",
+    name: "yahma/alpaca-cleaned",
+    split: "train[:500]",
   },
+  maxSteps: 50,
+  lora: { r: 16, alpha: 16 },
   callbacks: {
     onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
   },
 });
-`,
-  },
-  alpaca: {
-    label: "Alpaca",
-    hint: "instruction-tuning + mid-training eval",
-    entry: `import { createTrainer } from "arkor";
+`;
 
-export default createTrainer({
+const ALPACA_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
   name: "alpaca-run",
-  config: {
-    model: "unsloth/gemma-4-E4B-it",
-    datasetSource: {
-      type: "huggingface",
-      name: "yahma/alpaca-cleaned",
-      split: "train[:1000]",
-    },
-    datasetFormat: { type: "alpaca" },
-    maxSteps: 100,
-    loraR: 16,
-    loraAlpha: 16,
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: {
+    type: "huggingface",
+    name: "yahma/alpaca-cleaned",
+    split: "train[:1000]",
   },
+  datasetFormat: { type: "alpaca" },
+  maxSteps: 100,
+  lora: { r: 16, alpha: 16 },
   callbacks: {
     onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
     onCheckpoint: async ({ step, infer }) => {
@@ -59,34 +60,56 @@ export default createTrainer({
     },
   },
 });
-`,
-  },
-  chatml: {
-    label: "ChatML",
-    hint: "multi-turn chat fine-tuning",
-    entry: `import { createTrainer } from "arkor";
+`;
 
-export default createTrainer({
+const CHATML_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
   name: "chatml-run",
-  config: {
-    model: "unsloth/gemma-4-E4B-it",
-    datasetSource: {
-      type: "huggingface",
-      name: "stingning/ultrachat",
-      split: "train[:500]",
-    },
-    datasetFormat: { type: "chatml" },
-    maxSteps: 100,
-    loraR: 16,
-    loraAlpha: 16,
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: {
+    type: "huggingface",
+    name: "stingning/ultrachat",
+    split: "train[:500]",
   },
+  datasetFormat: { type: "chatml" },
+  maxSteps: 100,
+  lora: { r: 16, alpha: 16 },
   callbacks: {
     onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
   },
 });
-`,
+`;
+
+export const TEMPLATES: Record<TemplateId, Template> = {
+  minimal: {
+    label: "Minimal",
+    hint: "bare createTrainer call",
+    trainer: MINIMAL_TRAINER,
+  },
+  alpaca: {
+    label: "Alpaca",
+    hint: "instruction-tuning + mid-training eval",
+    trainer: ALPACA_TRAINER,
+  },
+  chatml: {
+    label: "ChatML",
+    hint: "multi-turn chat fine-tuning",
+    trainer: CHATML_TRAINER,
   },
 };
+
+/**
+ * Body of `src/arkor/index.ts` — identical across templates. The umbrella
+ * factory is what `arkor build` / Studio discovers; per-role primitives
+ * (`trainer`, future `deploy`, `eval`) live in sibling files and get gathered
+ * here.
+ */
+export const STARTER_INDEX = `import { createArkor } from "arkor";
+import { trainer } from "./trainer";
+
+export const arkor = createArkor({ trainer });
+`;
 
 export const STARTER_CONFIG = `// Training defaults. Project routing (orgSlug / projectSlug) is tracked
 // automatically in .arkor/state.json — do not put it here.
@@ -100,16 +123,25 @@ An arkor training project scaffolded by \`create-arkor\`.
 ## Getting started
 
 \`\`\`
-pnpm install        # or npm install / yarn
+pnpm install        # or npm install / yarn / bun
 pnpm arkor login    # optional; anonymous tokens work too
-pnpm arkor train    # runs src/arkor/index.ts on the cloud
-pnpm arkor dev      # opens the local Studio GUI
+pnpm arkor dev      # opens the local Studio GUI (most workflows live here)
+\`\`\`
+
+CLI-only flow (no GUI):
+
+\`\`\`
+pnpm arkor build    # bundles src/arkor/ into .arkor/build/index.mjs
+pnpm arkor start    # runs the build artifact on the cloud
 \`\`\`
 
 ## Files
 
-- \`src/arkor/index.ts\` — your training entry (loaded via Node's
-  \`--experimental-strip-types\`).
+- \`src/arkor/index.ts\` — umbrella manifest (\`createArkor({ trainer })\`).
+  This is what the CLI and Studio discover.
+- \`src/arkor/trainer.ts\` — your trainer (\`createTrainer({...})\`). Add
+  sibling files for future primitives (\`deploy.ts\`, \`eval.ts\`) and
+  register them on the umbrella.
 - \`arkor.config.ts\` — training defaults. Project routing lives in
   \`.arkor/state.json\`, managed by the CLI.
 

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -172,15 +172,15 @@ async function run(options: RunOptions): Promise<void> {
     : pm
       ? `  ${pm} install`
       : `  ${MANUAL_INSTALL_HINT}`;
-  const trainLine =
-    pm && pm !== "npm" ? `  ${pm} arkor train` : `  npx arkor train`;
+  const devLine =
+    pm && pm !== "npm" ? `  ${pm} arkor dev` : `  npx arkor dev`;
 
   clack.outro(
     [
       `Next steps:`,
       `  cd ${options.dir ?? "."}`,
       ...(installLine ? [installLine] : []),
-      trainLine,
+      devLine,
     ].join("\n"),
   );
 }


### PR DESCRIPTION
## Summary

Phase 4 of the SDK / CLI redesign. Brings the scaffold output and the post-init UX in line with the umbrella manifest + `dev`/`build`/`start` shape that landed in Phases 1–3.

- `refactor: scaffold src/arkor/{index,trainer}.ts and recommend arkor dev` — splits per-template content into `src/arkor/trainer.ts` (`createTrainer({...})`, flat shape with `lora: { r, alpha }` and grouped `callbacks`) and a template-independent `src/arkor/index.ts` (`createArkor({ trainer })`). `package.json` scripts seed `dev` / `build` / `start`; existing user scripts stay untouched on patch. Post-init "Next:" outro recommends `arkor dev` instead of the removed `arkor train`. README rewritten around the dev/build/start triad. Unit + e2e assertions follow.
- `chore: drop stale arkor train references from inline comments` — two explanatory comments (CSRF threat model in `dev.ts`, symlink-escape regression in `server.test.ts`) named the spawn target as `arkor train`. The Phase 2 spawn switch made those misleading.

Pre-existing scaffolds aren't migrated automatically — alpha stage, no compat shim. `arkor init` keeps existing files, so re-running it slots `trainer.ts` in alongside the user's old code.

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green (scaffold unit tests assert the new layout + scripts; e2e arkor-init / create-arkor cover all four package managers and the `arkor dev` next-steps strings)
- [ ] Manual smoke: `pnpm create arkor my-app --template alpaca --skip-install --skip-git`, then inspect `src/arkor/index.ts` (umbrella) and `src/arkor/trainer.ts` (alpaca trainer). Verify `pnpm install && pnpm arkor dev` boots Studio with the trainer name visible (Phase 3 manifest UI)

--
## 概要

SDK / CLI 再設計の Phase 4。Phase 1〜3 で導入した umbrella manifest + `dev`/`build`/`start` 形に合わせて、scaffold 出力と init 直後の UX を更新する。

- `refactor: scaffold src/arkor/{index,trainer}.ts and recommend arkor dev` — テンプレート個別の内容を `src/arkor/trainer.ts`（`createTrainer({...})`、フラット形 + `lora: { r, alpha }` + grouped `callbacks`）に切り出し、テンプレート非依存の `src/arkor/index.ts`（`createArkor({ trainer })`）を共通化。`package.json` のスクリプトは `dev` / `build` / `start` を seed（既存ユーザスクリプトは patch 時に温存）。init 後の "Next:" outro は廃止された `arkor train` ではなく `arkor dev` を推奨。README も dev/build/start 三本柱で書き直し。unit / e2e のアサーションも追従。
- `chore: drop stale arkor train references from inline comments` — 2 箇所の説明コメント（`dev.ts` の CSRF 脅威モデル、`server.test.ts` の ENG-404 regression）が spawn 対象を `arkor train` と書き残していた。Phase 2 で spawn 切替済みなので解消。

既存 scaffold は自動マイグレーションしない（alpha 期 / compat shim 無し方針）。`arkor init` は既存ファイルを保持するので、再実行すると古いコードと並んで `trainer.ts` が追加される。

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green（scaffold 単体テストは新レイアウト + スクリプトを検証、e2e arkor-init / create-arkor は 4 種パッケージマネージャと `arkor dev` next-steps 文字列を網羅）
- [ ] 手動 smoke：`pnpm create arkor my-app --template alpaca --skip-install --skip-git` 後、`src/arkor/index.ts`（umbrella）と `src/arkor/trainer.ts`（alpaca trainer）を確認。`pnpm install && pnpm arkor dev` で Studio が起動し、Phase 3 で追加した manifest UI に trainer 名が表示されることを確認