### PR TITLE
test(e2e) + docs: cover `arkor build` end-to-end and add READMEs (Phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# arkor
+# Arkor
+
+> Fine-tune and deploy open-weight models with TypeScript.
+
+Arkor is a TypeScript framework for improving and shipping custom open-weight
+models. The audience is product engineers who already build with TypeScript /
+Next.js and want custom model behaviour without standing up an ML
+infrastructure team. Arkor handles GPUs, fine-tuning, and serving underneath
+so the user's job stays "write some TypeScript".
+
+> Status: alpha (`0.0.1-alpha.0`). Public APIs may change without notice.
+
+## Quickstart
+
+```bash
+npm create arkor@latest my-app
+cd my-app
+npm install
+npx arkor login        # Auth0 PKCE flow; --anonymous also works
+npx arkor dev          # opens the local Studio GUI on http://127.0.0.1:4000
+```
+
+`arkor dev` is the primary surface — it starts a local Studio with hot
+reload over your TypeScript and a GUI for running training, inspecting jobs,
+and trying out checkpoints in a Playground.
+
+CLI-only flow (no GUI):
+
+```bash
+npx arkor build        # bundles src/arkor/ into .arkor/build/index.mjs
+npx arkor start        # runs the build artifact on the cloud
+```
+
+## What's in a project
+
+```
+my-app/
+├── src/arkor/
+│   ├── index.ts        # umbrella — `createArkor({ trainer })`
+│   └── trainer.ts      # `createTrainer({ name, model, dataset, ... })`
+├── arkor.config.ts     # training defaults
+├── .arkor/             # state + build artifact (gitignored)
+└── package.json
+```
+
+The umbrella is what the CLI and Studio discover. Per-role primitives —
+`trainer` today, `deploy` and `eval` later — live in sibling files and get
+gathered on `createArkor`. Adding a new primitive is "drop a file, register
+it on the umbrella": no scaffold change required.
+
+## CLI
+
+| Command | Purpose |
+|---|---|
+| `arkor init` | Scaffold a new project in the current directory |
+| `arkor login` / `logout` / `whoami` | Auth0 PKCE / anonymous tokens |
+| `arkor dev` | Launch the local Studio (hot reload + GUI) |
+| `arkor build` | Bundle `src/arkor/index.ts` to `.arkor/build/index.mjs` |
+| `arkor start` | Run the build artifact (auto-builds when missing) |
+
+`pnpm dev` resolves to `arkor dev` in scaffolded projects, so most workflows
+live behind that one command.
+
+## Packages
+
+| Package | What it is |
+|---|---|
+| [`arkor`](packages/arkor) | The SDK + CLI + bundled local Studio |
+| [`create-arkor`](packages/create-arkor) | `npm create arkor` scaffolder |
+
+## Requirements
+
+- Node.js 22.6+ (the SDK relies on stable APIs from that line)
+- pnpm / npm / yarn / bun all work for installs
+
+## License
+
+UNLICENSED — see individual package metadata.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ so the user's job stays "write some TypeScript".
 ## Quickstart
 
 ```bash
-npm create arkor@latest my-app
+pnpm create arkor my-app
 cd my-app
-npm install
-npx arkor login        # Auth0 PKCE flow; --anonymous also works
-npx arkor dev          # opens the local Studio GUI on http://127.0.0.1:4000
+pnpm install
+pnpm arkor login       # Auth0 PKCE flow; --anonymous also works
+pnpm arkor dev         # opens the local Studio GUI on http://127.0.0.1:4000
 ```
 
 `arkor dev` is the primary surface — it starts a local Studio with hot
@@ -27,8 +27,8 @@ and trying out checkpoints in a Playground.
 CLI-only flow (no GUI):
 
 ```bash
-npx arkor build        # bundles src/arkor/ into .arkor/build/index.mjs
-npx arkor start        # runs the build artifact on the cloud
+pnpm arkor build       # bundles src/arkor/ into .arkor/build/index.mjs
+pnpm arkor start       # runs the build artifact on the cloud
 ```
 
 ## What's in a project
@@ -66,7 +66,7 @@ live behind that one command.
 | Package | What it is |
 |---|---|
 | [`arkor`](packages/arkor) | The SDK + CLI + bundled local Studio |
-| [`create-arkor`](packages/create-arkor) | `npm create arkor` scaffolder |
+| [`create-arkor`](packages/create-arkor) | `pnpm create arkor` scaffolder |
 
 ## Requirements
 

--- a/e2e/cli/src/arkor-build.test.ts
+++ b/e2e/cli/src/arkor-build.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { ARKOR_BIN } from "./bins";
+import { cleanup, makeTempDir, runCli } from "./spawn-cli";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = makeTempDir("arkor-build-e2e-");
+});
+
+afterEach(() => {
+  cleanup(cwd);
+});
+
+// Self-contained manifest source so the bundle has no `import` statements
+// to resolve at runtime — keeps the e2e test independent of whether `arkor`
+// is installed in the temp project.
+const FAKE_MANIFEST = `export const arkor = Object.freeze({
+  _kind: "arkor",
+  trainer: {
+    name: "smoke",
+    start: async () => ({ jobId: "j" }),
+    wait: async () => ({ job: {}, artifacts: [] }),
+    cancel: async () => {},
+  },
+});
+`;
+
+describe("arkor build (E2E)", () => {
+  it("bundles src/arkor/index.ts to .arkor/build/index.mjs", async () => {
+    mkdirSync(join(cwd, "src/arkor"), { recursive: true });
+    writeFileSync(join(cwd, "src/arkor/index.ts"), FAKE_MANIFEST);
+
+    const result = await runCli(ARKOR_BIN, ["build"], cwd);
+    expect(result.code).toBe(0);
+
+    const outFile = join(cwd, ".arkor/build/index.mjs");
+    expect(existsSync(outFile)).toBe(true);
+    const content = readFileSync(outFile, "utf8");
+    // Manifest brand and trainer name survive bundling.
+    expect(content).toContain("_kind");
+    expect(content).toContain('"arkor"');
+    expect(content).toContain('"smoke"');
+  });
+
+  it("bundles a custom entry when one is passed positionally", async () => {
+    writeFileSync(join(cwd, "custom.ts"), FAKE_MANIFEST);
+
+    const result = await runCli(ARKOR_BIN, ["build", "custom.ts"], cwd);
+    expect(result.code).toBe(0);
+    expect(existsSync(join(cwd, ".arkor/build/index.mjs"))).toBe(true);
+  });
+
+  it("fails with a clear error when no entry exists", async () => {
+    const result = await runCli(ARKOR_BIN, ["build"], cwd);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/Build entry not found/);
+  });
+
+  // Regression for the redesign: a freshly init'd project must build out of
+  // the box. Catches drift between the scaffold output and what `arkor build`
+  // expects on disk (e.g. if templates ever stop exporting `arkor`).
+  it("builds a freshly init'd project end-to-end", async () => {
+    const initResult = await runCli(
+      ARKOR_BIN,
+      ["init", "-y", "--skip-install", "--skip-git"],
+      cwd,
+    );
+    expect(initResult.code).toBe(0);
+
+    const buildResult = await runCli(ARKOR_BIN, ["build"], cwd);
+    expect(buildResult.code).toBe(0);
+    expect(existsSync(join(cwd, ".arkor/build/index.mjs"))).toBe(true);
+  });
+});

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -11,13 +11,13 @@ The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 Most users get this package via the scaffolder:
 
 ```bash
-npm create arkor@latest my-app
+pnpm create arkor my-app
 ```
 
 Direct install is fine too:
 
 ```bash
-npm install arkor
+pnpm add arkor
 ```
 
 Requires Node.js 22.6+.

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -1,0 +1,149 @@
+# arkor
+
+The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
+
+> Status: alpha (`0.0.1-alpha.0`). APIs may change without notice. No compat
+> shims are offered between alpha versions — pin and re-read the changelog
+> before bumping.
+
+## Install
+
+Most users get this package via the scaffolder:
+
+```bash
+npm create arkor@latest my-app
+```
+
+Direct install is fine too:
+
+```bash
+npm install arkor
+```
+
+Requires Node.js 22.6+.
+
+## SDK
+
+Two factories. One umbrella, one per role.
+
+```ts
+// src/arkor/trainer.ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "my-first-run",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: {
+    type: "huggingface",
+    name: "yahma/alpaca-cleaned",
+    split: "train[:500]",
+  },
+  lora: { r: 16, alpha: 16 },
+  maxSteps: 50,
+  callbacks: {
+    onLog: ({ step, loss }) => console.log(`step=${step} loss=${loss}`),
+    onCheckpoint: async ({ step, infer }) => {
+      const res = await infer({
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      });
+      console.log(`ckpt @ ${step}:`, await res.text());
+    },
+  },
+});
+```
+
+```ts
+// src/arkor/index.ts  ← discovered by the CLI / Studio
+import { createArkor } from "arkor";
+import { trainer } from "./trainer";
+
+export const arkor = createArkor({ trainer });
+```
+
+The umbrella is intentionally opaque — `createArkor` returns a frozen
+manifest today, with room to grow operation methods later without breaking
+callers. Keys are role-fixed (`trainer`, future `deploy` / `eval`) so the
+CLI and Studio can predict what's there.
+
+### Trainer lifecycle
+
+`createTrainer` returns a `Trainer` with:
+
+- `start()` — submits the job to the cloud; resolves with `{ jobId }`
+- `wait()` — opens an SSE stream and dispatches `callbacks.*` until the
+  run reaches a terminal status; resolves with `{ job, artifacts }`
+- `cancel()` — best-effort cancellation
+
+Inside `onCheckpoint` you also get a bound `infer({ messages, stream? })`
+helper that points at the checkpoint adapter for mid-training evaluation.
+
+### Runtime context
+
+`baseUrl`, `credentials`, and `cwd` come from the environment + `.arkor/`
+state — never from user code. Set `ARKOR_CLOUD_API_URL` to point at a
+non-default cloud-api deployment; everything else is managed by `arkor
+login` / `arkor logout`.
+
+## CLI
+
+| Command | Purpose |
+|---|---|
+| `arkor init` | Scaffold a project in the current directory |
+| `arkor login` / `logout` / `whoami` | Auth0 PKCE / anonymous tokens |
+| `arkor dev` | Launch the local Studio (hot reload + GUI) |
+| `arkor build [entry]` | Bundle `src/arkor/index.ts` (or `entry`) to `.arkor/build/index.mjs` |
+| `arkor start [entry]` | Run the build artifact; rebuilds when an entry is supplied |
+
+`arkor build` uses esbuild with `packages: "external"`, so bare specifiers
+(`arkor`, anything from `node_modules`) resolve at runtime against the
+project's installed copy. Relative imports get inlined.
+
+## Studio
+
+`arkor dev` boots a Hono server on `127.0.0.1:4000` and serves a Vite +
+React SPA from the same origin. Two roles:
+
+- **Hot reload** for the user's TypeScript so the UI reflects current
+  source without restarts.
+- **GUI operations** — running training, inspecting jobs, mid-training
+  inference in a Playground.
+
+Studio is loopback-only and per-launch CSRF-token-gated:
+
+- `/api/*` requires the `X-Arkor-Studio-Token` header (or
+  `?studioToken=` query for `EventSource`). The token is generated on
+  every `arkor dev` launch and injected into the served `index.html` as
+  a `<meta>` tag the same-origin SPA reads at startup.
+- The middleware also rejects requests whose `Host` isn't `127.0.0.1` or
+  `localhost` — defense against DNS rebinding.
+
+## Public exports
+
+```ts
+import {
+  // factories
+  createArkor,
+  createTrainer,
+  isArkor,
+  // types
+  type Arkor,
+  type ArkorInput,
+  type DatasetSource,
+  type LoraConfig,
+  type Trainer,
+  type TrainerCallbacks,
+  type TrainerInput,
+  type TrainingJob,
+  type TrainingResult,
+  // identity / state helpers
+  ensureCredentials,
+  readCredentials,
+  writeCredentials,
+  readState,
+  writeState,
+} from "arkor";
+```
+
+`runTrainer(file?)` is exported for power-user embedding (e.g. running
+training from a custom Node script). `arkor start` uses it under the hood.

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -122,17 +122,31 @@ An arkor training project scaffolded by \`create-arkor\`.
 
 ## Getting started
 
+The \`dev\` / \`build\` / \`start\` package scripts forward to the matching
+\`arkor\` subcommands, so the script form works across every package
+manager (\`npm\` does not run package binaries via \`npm <bin>\` — use
+\`npm run <script>\` or \`npx arkor <subcommand>\`).
+
 \`\`\`
-pnpm install        # or npm install / yarn / bun
-pnpm arkor login    # optional; anonymous tokens work too
-pnpm arkor dev      # opens the local Studio GUI (most workflows live here)
+npm install && npm run dev
+# or: pnpm install && pnpm dev
+# or: yarn && yarn dev
+# or: bun install && bun dev
+\`\`\`
+
+\`arkor dev\` opens the local Studio GUI (most workflows live there).
+
+Optional — log in to your own org instead of using anonymous tokens:
+
+\`\`\`
+npx arkor login
 \`\`\`
 
 CLI-only flow (no GUI):
 
 \`\`\`
-pnpm arkor build    # bundles src/arkor/ into .arkor/build/index.mjs
-pnpm arkor start    # runs the build artifact on the cloud
+npm run build    # bundles src/arkor/ into .arkor/build/index.mjs
+npm run start    # runs the build artifact on the cloud
 \`\`\`
 
 ## Files

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -70,8 +70,14 @@ After scaffolding:
 ```bash
 cd my-app
 <pm> install
-<pm> arkor dev
+<pm> run dev          # npm run dev / pnpm dev / yarn dev / bun dev
 ```
+
+The `dev` / `build` / `start` package scripts forward to the corresponding
+`arkor` subcommands, so the script form works the same across npm, pnpm,
+yarn, and bun. (npm in particular does *not* run package binaries via
+`npm <bin>` — use `npm run <script>`, or `npx arkor <subcommand>` for
+one-off invocations.)
 
 `arkor dev` opens the local Studio. See the
 [`arkor` package README](../arkor/README.md) for the full SDK + CLI

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -18,7 +18,7 @@ bun create arkor my-app
 Interactive by default. Pass flags to skip prompts:
 
 ```bash
-npm create arkor@latest my-app -- \
+pnpm create arkor my-app \
   --template alpaca \
   --use-pnpm \
   --skip-install \

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -1,0 +1,78 @@
+# create-arkor
+
+Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
+`npm create` / `pnpm create` / `yarn create` / `bun create`.
+
+> Status: alpha (`0.0.1-alpha.0`).
+
+## Usage
+
+```bash
+npm create arkor@latest my-app
+# or:
+pnpm create arkor my-app
+yarn create arkor my-app
+bun create arkor my-app
+```
+
+Interactive by default. Pass flags to skip prompts:
+
+```bash
+npm create arkor@latest my-app -- \
+  --template alpaca \
+  --use-pnpm \
+  --skip-install \
+  --skip-git
+```
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `[dir]` (positional) | Target directory; defaults to the current one |
+| `--name <name>` | Project name (sanitised for `package.json`) |
+| `--template <id>` | `minimal` / `alpaca` / `chatml` |
+| `-y`, `--yes` | Accept defaults instead of prompting |
+| `--skip-install` | Don't run `<pm> install` after scaffolding |
+| `--use-npm` / `--use-pnpm` / `--use-yarn` / `--use-bun` | Force a package manager (otherwise auto-detected from `npm_config_user_agent`) |
+| `--git` / `--skip-git` | Initialise a git repo with an initial commit, or skip the prompt |
+
+## What it writes
+
+```
+my-app/
+├── src/arkor/
+│   ├── index.ts        # createArkor({ trainer }) umbrella
+│   └── trainer.ts      # template-specific createTrainer({...})
+├── arkor.config.ts
+├── README.md
+├── .gitignore          # node_modules/, dist/, .arkor/
+└── package.json        # scripts: dev / build / start
+```
+
+Existing files are kept (never overwritten). `package.json` is patched in
+place — only missing keys are added, so a hand-edited `build: "tsc"` survives.
+
+## Templates
+
+- **minimal** — bare `createTrainer` call, the smallest working example.
+- **alpaca** — instruction-tuning with a mid-training `onCheckpoint` that
+  fires an `infer({...})` against the in-progress adapter.
+- **chatml** — multi-turn chat fine-tuning on `stingning/ultrachat`.
+
+The umbrella `src/arkor/index.ts` is identical across templates; only
+`src/arkor/trainer.ts` differs.
+
+## Next step
+
+After scaffolding:
+
+```bash
+cd my-app
+<pm> install
+<pm> arkor dev
+```
+
+`arkor dev` opens the local Studio. See the
+[`arkor` package README](../arkor/README.md) for the full SDK + CLI
+reference.


### PR DESCRIPTION
## Summary

Phase 5 — the closing phase of the SDK / CLI redesign. Locks in the new surface with end-to-end coverage and documents it for users landing on the repo or on npm.

- `test(e2e): cover arkor build end-to-end` — adds `e2e/cli/src/arkor-build.test.ts` driving the bundled `dist/bin.mjs` through four scenarios: happy path (manifest brand + trainer name survive the bundle), custom positional entry, missing entry surfaces the "Build entry not found" error on non-zero exit, and the **init → build** chain (regression guard against scaffold/build drift). Sources use a self-contained manifest literal so the test stays hermetic without an installed `arkor` in the temp project.
- `docs: README.md at root and per-package` — replaces the one-line root placeholder with three audience-scoped READMEs: root (what Arkor is, `npm create arkor` quickstart, CLI table), `packages/arkor` (SDK + CLI + Studio reference), `packages/create-arkor` (scaffolder flag reference + templates). Each leads with the "alpha; APIs may change; no compat shims" disclaimer so pinning expectations are explicit.

E2E count: 25 → 29 tests across 3 files.

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green (29 e2e tests including the four new build scenarios)
- [x] `arkor init` → `arkor build` chain confirmed in the new e2e regression test
- [ ] Manual smoke: render the published READMEs on GitHub / a dry-run npm tarball to verify markdown layout (deferred to release prep)

--
## 概要

SDK / CLI 再設計の最終 Phase 5。新しい surface を E2E でロックし、リポジトリ / npm 上に着地するユーザ向けにドキュメントを揃える。

- `test(e2e): cover arkor build end-to-end` — `e2e/cli/src/arkor-build.test.ts` を新設し、bundle 済み `dist/bin.mjs` を 4 シナリオで実行：happy path（manifest brand + trainer 名がバンドル後も残る）、custom positional entry、entry 不在時に "Build entry not found" を非ゼロ exit で surface、**init → build** チェーン（scaffold / build 乖離の regression guard）。ソースは self-contained な manifest リテラルなので、テンプ project に `arkor` をインストールせず hermetic に動く。
- `docs: README.md at root and per-package` — ルートの 1 行 placeholder を、読者層別に分けた 3 つの README に置換：root（Arkor とは / `npm create arkor` quickstart / CLI 一覧）、`packages/arkor`（SDK + CLI + Studio リファレンス）、`packages/create-arkor`（scaffolder フラグ + テンプレート）。先頭に "alpha; APIs may change; no compat shims" ディスクレーマーを置き、pin の前提を明示。

E2E テスト数：25 → 29（3 ファイル）。

## Test plan

- [x] `pnpm -w typecheck` — green
- [x] `pnpm -w test` — green（追加した build 4 シナリオを含む 29 e2e テスト）
- [x] `arkor init` → `arkor build` チェーンを新規 e2e regression テストで確認
- [ ] 手動 smoke：GitHub / dry-run npm tarball で published README のレンダリングを確認（リリース準備に保留）

