### PR TITLE
docs: align README license sections with the MIT switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ live behind that one command.
 
 ## License
 
-UNLICENSED — see individual package metadata.
+MIT — see [LICENSE.md](LICENSE.md).

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -147,3 +147,7 @@ import {
 
 `runTrainer(file?)` is exported for power-user embedding (e.g. running
 training from a custom Node script). `arkor start` uses it under the hood.
+
+## License
+
+MIT — see [LICENSE.md](./LICENSE.md).

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -82,3 +82,7 @@ one-off invocations.)
 `arkor dev` opens the local Studio. See the
 [`arkor` package README](../arkor/README.md) for the full SDK + CLI
 reference.
+
+## License
+
+MIT — see [LICENSE.md](./LICENSE.md).


### PR DESCRIPTION
The root README still claimed `UNLICENSED — see individual package metadata` from the days when both package.json files agreed with that line. After the previous two commits flipped both to MIT and shipped LICENSE.md inside each package, that sentence was the last place still telling the old story.

Bring all three READMEs into the same shape:

- root README: `MIT — see [LICENSE.md](LICENSE.md).`
- packages/arkor/README.md: same line, relative to the package
- packages/create-arkor/README.md: same line, relative to the package

The package READMEs hadn't carried a License section at all — add one so visitors landing on the npm package page see the license without having to dig into package.json.