### PR TITLE
Default arkor SDK to `https://api.arkor.ai`

### DIFF
--- a/packages/arkor/src/core/credentials.test.ts
+++ b/packages/arkor/src/core/credentials.test.ts
@@ -92,8 +92,8 @@ describe("defaultArkorCloudApiUrl", () => {
     process.env.ARKOR_CLOUD_API_URL = "https://api.example.com/";
     expect(defaultArkorCloudApiUrl()).toBe("https://api.example.com");
   });
-  it("falls back to localhost:3003", () => {
+  it("falls back to https://api.arkor.ai", () => {
     delete process.env.ARKOR_CLOUD_API_URL;
-    expect(defaultArkorCloudApiUrl()).toBe("http://localhost:3003");
+    expect(defaultArkorCloudApiUrl()).toBe("https://api.arkor.ai");
   });
 });

--- a/packages/arkor/src/core/credentials.ts
+++ b/packages/arkor/src/core/credentials.ts
@@ -69,7 +69,7 @@ export async function getToken(credentials: Credentials): Promise<string> {
 export function defaultArkorCloudApiUrl(): string {
   return (
     process.env.ARKOR_CLOUD_API_URL?.replace(/\/$/, "") ??
-    "http://localhost:3003"
+    "https://api.arkor.ai"
   );
 }
 


### PR DESCRIPTION
## Summary

- Switch the `defaultArkorCloudApiUrl()` fallback in the `arkor` SDK/CLI from `http://localhost:3003` to the production endpoint `https://api.arkor.ai`, so a freshly-installed `arkor` binary talks to the managed cloud out of the box without extra configuration.
- Override behavior is preserved: setting `ARKOR_CLOUD_API_URL` (with or without a trailing slash) still wins, which keeps `arkor dev` / `arkor login` etc. usable against a local `dev:arkor-cloud-api` on `:3003` or any other deployment.
- Updated the corresponding unit test to assert the new default.

## Test plan

- [x] `pnpm --filter arkor test` (12 files, 81 tests passing)
- [ ] Manual smoke: with `ARKOR_CLOUD_API_URL` unset, `arkor whoami` / `arkor login` should hit `https://api.arkor.ai`
- [ ] Manual smoke: with `ARKOR_CLOUD_API_URL=http://localhost:3003`, the same commands should hit the local dev server
