### PR TITLE
feat: integrate arkor versioning into scaffolding and configuration

### DIFF
--- a/packages/arkor/tsdown.config.ts
+++ b/packages/arkor/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: ["src/index.ts", "src/bin.ts"],
@@ -12,5 +13,8 @@ export default defineConfig({
   // isn't on npm.
   deps: {
     alwaysBundle: ["@arkor/cli-internal"],
+  },
+  define: {
+    __ARKOR_VERSION__: JSON.stringify(pkg.version),
   },
 });

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { scaffold, templateChoices } from "./scaffold";
 import {
   detectPackageManager,
@@ -10,6 +11,16 @@ import {
 
 let cwd: string;
 const ORIG_UA = process.env.npm_config_user_agent;
+const TEST_DIR = fileURLToPath(new URL(".", import.meta.url));
+const arkorVersion = (
+  JSON.parse(
+    readFileSync(
+      join(TEST_DIR, "../../arkor/package.json"),
+      "utf8",
+    ),
+  ) as { version: string }
+).version;
+const pinnedArkorVersion = `^${arkorVersion}`;
 
 beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "cli-internal-test-"));
@@ -114,7 +125,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.0");
+    expect(devDeps.arkor).toBe(pinnedArkorVersion);
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -9,6 +9,8 @@ import {
   type TemplateId,
 } from "./templates";
 
+declare const __ARKOR_VERSION__: string | undefined;
+
 export type FileAction = "created" | "kept" | "patched" | "ok";
 
 export interface ScaffoldOptions {
@@ -30,6 +32,10 @@ const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
+const PINNED_ARKOR_VERSION =
+  typeof __ARKOR_VERSION__ === "string"
+    ? `^${__ARKOR_VERSION__}`
+    : "^0.0.1-alpha.0";
 
 const SCRIPT_DEFAULTS: Record<string, string> = {
   dev: "arkor dev",
@@ -89,7 +95,7 @@ async function patchPackageJson(
           private: true,
           type: "module",
           scripts: { ...SCRIPT_DEFAULTS },
-          devDependencies: { arkor: "^0.0.1-alpha.0" },
+          devDependencies: { arkor: PINNED_ARKOR_VERSION },
         },
         null,
         2,
@@ -114,7 +120,7 @@ async function patchPackageJson(
   const devDeps =
     (current.devDependencies as Record<string, string> | undefined) ?? {};
   if (!devDeps.arkor) {
-    devDeps.arkor = "^0.0.1-alpha.0";
+    devDeps.arkor = PINNED_ARKOR_VERSION;
     current.devDependencies = devDeps;
     dirty = true;
   }

--- a/packages/create-arkor/tsdown.config.ts
+++ b/packages/create-arkor/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: ["src/bin.ts"],
@@ -12,5 +13,8 @@ export default defineConfig({
   // isn't on npm.
   deps: {
     alwaysBundle: ["@arkor/cli-internal"],
+  },
+  define: {
+    __ARKOR_VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
- Replaced the hardcoded scaffold version `^0.0.1-alpha.0` with a shared `PINNED_ARKOR_VERSION` constant that uses `__ARKOR_VERSION__` when injected at bundle time, and otherwise falls back to `^0.0.1-alpha.0`.​

- Applied that constant in both package.json write paths:
  1) new package.json creation
  2) existing package.json patching.​

- Added version define injection in `packages/arkor/tsdown.config.ts`:
  `define: { __ARKOR_VERSION__: JSON.stringify(pkg.version) }`.​

- Added the same version define injection in `packages/create-arkor/tsdown.config.ts`.​

- Updated scaffold tests to compute expected pinned version dynamically from `packages/arkor/package.json` instead of using a hardcoded string
