### PR TITLE
create-arkor: scaffold into a fresh subdirectory by default

### DIFF
--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { CREATE_ARKOR_BIN } from "./bins";
 import { cleanup, makeTempDir, runCli, runGit } from "./spawn-cli";
@@ -275,6 +275,82 @@ describe("create-arkor (E2E)", () => {
     ) as { name?: string };
     expect(pkg.name).toBe("named-app");
     expect(readdirSync(parentDir).sort()).toEqual(["named-app"]);
+  });
+
+  // Collision guards for the auto-derived `./<name>/` path. When the user
+  // didn't pass `[dir]` we refuse to merge into a non-empty existing
+  // directory — easy to hit by accident (typo, forgotten earlier scaffold)
+  // and the silent merge would surprise users.
+  it("refuses to scaffold when ./arkor-project/ already exists and is non-empty", async () => {
+    const collidingDir = join(parentDir, "arkor-project");
+    mkdirSync(collidingDir);
+    writeFileSync(join(collidingDir, "sentinel.txt"), "do not touch\n");
+
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain(
+      'Directory "arkor-project/" already exists and is not empty.',
+    );
+    // Sentinel survives — we bailed before touching anything.
+    expect(readFileSync(join(collidingDir, "sentinel.txt"), "utf8")).toBe(
+      "do not touch\n",
+    );
+    expect(existsSync(join(collidingDir, "package.json"))).toBe(false);
+  });
+
+  it("refuses to scaffold when --name target dir exists and is non-empty", async () => {
+    const collidingDir = join(parentDir, "taken");
+    mkdirSync(collidingDir);
+    writeFileSync(join(collidingDir, "sentinel.txt"), "x\n");
+
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["-y", "--skip-install", "--skip-git", "--name", "taken"],
+      parentDir,
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain(
+      'Directory "taken/" already exists and is not empty.',
+    );
+    expect(existsSync(join(collidingDir, "package.json"))).toBe(false);
+  });
+
+  // Back-compat: explicit `[dir]` keeps the "scaffold into an existing
+  // project" semantics (patches package.json / .gitignore in place,
+  // preserves existing files).
+  it("still merges into an explicitly-given [dir] that exists", async () => {
+    const targetDir = join(parentDir, "existing");
+    mkdirSync(targetDir);
+    writeFileSync(join(targetDir, "sentinel.txt"), "kept\n");
+
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["existing", "-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+    expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+    expect(readFileSync(join(targetDir, "sentinel.txt"), "utf8")).toBe("kept\n");
+  });
+
+  // Collision check should NOT fire when the would-be target is empty —
+  // makes sure the guard discriminates between empty placeholders (e.g. a
+  // pre-created mount point) and real existing projects.
+  it("scaffolds into an empty pre-existing ./<name>/ without complaining", async () => {
+    const target = join(parentDir, "arkor-project");
+    mkdirSync(target);
+
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+    expect(existsSync(join(target, "package.json"))).toBe(true);
   });
 
   it.skipIf(SKIP_INSTALL).each([{ pm: "npm" }, { pm: "pnpm" }])(

--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { CREATE_ARKOR_BIN } from "./bins";
 import { cleanup, makeTempDir, runCli, runGit } from "./spawn-cli";
@@ -218,6 +218,63 @@ describe("create-arkor (E2E)", () => {
       "utf8",
     );
     expect(trainer).toContain('"alpaca-run"');
+  });
+
+  // Regression for ENG-426 — without an explicit `[dir]` the CLI used to
+  // scaffold straight into `process.cwd()`, littering whatever directory the
+  // user happened to be in. The new behaviour mirrors `create-vite`: derive
+  // the project name (prompted in interactive mode, `arkor-project` under
+  // `-y`) and create a fresh subdirectory named after it.
+  it("scaffolds into ./arkor-project/ when no [dir] is passed", async () => {
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+
+    const targetDir = join(parentDir, "arkor-project");
+    expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+    expect(existsSync(join(targetDir, "src/arkor/index.ts"))).toBe(true);
+
+    // Nothing should land directly in parentDir except the new subdir.
+    expect(readdirSync(parentDir).sort()).toEqual(["arkor-project"]);
+
+    // Outro should tell the user to `cd arkor-project`.
+    expect(result.stdout).toContain("cd arkor-project");
+  });
+
+  // Companion to the regression above: the explicit "scaffold here" opt-in.
+  it("scaffolds into the current directory when `.` is passed", async () => {
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      [".", "-y", "--skip-install", "--skip-git"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+    expect(existsSync(join(parentDir, "package.json"))).toBe(true);
+    expect(existsSync(join(parentDir, "src/arkor/index.ts"))).toBe(true);
+
+    // No `cd` line in the outro when scaffolding in place.
+    expect(result.stdout).not.toMatch(/\bcd \./);
+  });
+
+  // `--name foo` without [dir] should also create `./foo/`, not pollute cwd.
+  it("scaffolds into ./<name>/ when --name is passed without [dir]", async () => {
+    const result = await runCli(
+      CREATE_ARKOR_BIN,
+      ["-y", "--skip-install", "--skip-git", "--name", "named-app"],
+      parentDir,
+    );
+    expect(result.code).toBe(0);
+
+    const targetDir = join(parentDir, "named-app");
+    expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+    const pkg = JSON.parse(
+      readFileSync(join(targetDir, "package.json"), "utf8"),
+    ) as { name?: string };
+    expect(pkg.name).toBe("named-app");
+    expect(readdirSync(parentDir).sort()).toEqual(["named-app"]);
   });
 
   it.skipIf(SKIP_INSTALL).each([{ pm: "npm" }, { pm: "pnpm" }])(

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -15,6 +15,16 @@ yarn create arkor my-app
 bun create arkor my-app
 ```
 
+With no positional, you'll be prompted for a project name and a fresh
+subdirectory of that name will be created in the current directory. Pass `.`
+to scaffold into the current directory instead:
+
+```bash
+npm create arkor@latest          # → ./<prompted-name>/
+npm create arkor@latest my-app   # → ./my-app/
+npm create arkor@latest .        # → scaffold here
+```
+
 Interactive by default. Pass flags to skip prompts:
 
 ```bash
@@ -29,8 +39,8 @@ pnpm create arkor my-app \
 
 | Flag | Effect |
 |---|---|
-| `[dir]` (positional) | Target directory; defaults to the current one |
-| `--name <name>` | Project name (sanitised for `package.json`) |
+| `[dir]` (positional) | Target directory. If omitted, a new subdirectory named after the project is created. Pass `.` to scaffold into the current directory |
+| `--name <name>` | Project name (sanitised for `package.json`). When `[dir]` is omitted, also used as the new subdirectory name |
 | `--template <id>` | `minimal` / `alpaca` / `chatml` |
 | `-y`, `--yes` | Accept defaults instead of prompting |
 | `--skip-install` | Don't run `<pm> install` after scaffolding |

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -60,8 +60,12 @@ my-app/
 └── package.json        # scripts: dev / build / start
 ```
 
-Existing files are kept (never overwritten). `package.json` is patched in
-place — only missing keys are added, so a hand-edited `build: "tsc"` survives.
+When `[dir]` is given explicitly, existing files are kept (never overwritten)
+and `package.json` is patched in place — only missing keys are added, so a
+hand-edited `build: "tsc"` survives. When the target directory is auto-derived
+(no `[dir]` passed), an existing non-empty `./<project-name>/` is treated as a
+collision: interactive runs re-prompt for a different name, and `-y` /
+non-interactive runs exit with an error.
 
 ## Templates
 

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { basename, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import process from "node:process";
 import * as clack from "@clack/prompts";
 import { Command } from "commander";
@@ -98,12 +98,14 @@ async function maybeGitInit(
 async function run(options: RunOptions): Promise<void> {
   clack.intro("create-arkor");
 
-  const cwd = options.dir ? resolve(options.dir) : process.cwd();
-  // `path.basename` of the resolved cwd handles trailing separators and
-  // filesystem roots correctly. `sanitise("")` falls back to
-  // `"arkor-project"`, so the empty-basename case at root collapses to
-  // the same default the prompt would otherwise offer.
-  const defaultName = sanitise(options.name ?? basename(cwd));
+  // When `dir` is explicit, derive the project name from its basename so
+  // `npm create arkor my-app` still produces `pkg.name = "my-app"`. Otherwise
+  // we'd lose the historical UX. `sanitise("")` falls back to "arkor-project"
+  // for the root-dir / empty-basename case.
+  const defaultName = sanitise(
+    options.name ??
+      (options.dir !== undefined ? basename(resolve(options.dir)) : "arkor-project"),
+  );
 
   // Always sanitise — `defaultName` is already sanitised, but `options.name`
   // straight from `--name` is not, and falls through to package.json as-is
@@ -135,6 +137,16 @@ async function run(options: RunOptions): Promise<void> {
     template = chosenTemplate;
   }
 
+  // When no `dir` was passed, scaffold into a fresh subdirectory named after
+  // the project — matching `create-vite` / `create-next-app`. Pass `.` (or
+  // any path that resolves to `process.cwd()`) to opt into "scaffold here".
+  const cwd =
+    options.dir !== undefined
+      ? resolve(options.dir)
+      : join(process.cwd(), name);
+  const cdTarget = options.dir ?? name;
+  const inPlace = resolve(cwd) === resolve(process.cwd());
+
   const spin = clack.spinner();
   spin.start(`Scaffolding in ${cwd}`);
   const { files } = await scaffold({ cwd, name, template });
@@ -156,7 +168,9 @@ async function run(options: RunOptions): Promise<void> {
     } catch (err) {
       clack.log.warn(err instanceof Error ? err.message : String(err));
       clack.log.info(
-        `Retry manually: cd ${options.dir ?? "."} && ${pm} install`,
+        inPlace
+          ? `Retry manually: ${pm} install`
+          : `Retry manually: cd ${cdTarget} && ${pm} install`,
       );
     }
   }
@@ -178,7 +192,7 @@ async function run(options: RunOptions): Promise<void> {
   clack.outro(
     [
       `Next steps:`,
-      `  cd ${options.dir ?? "."}`,
+      ...(inPlace ? [] : [`  cd ${cdTarget}`]),
       ...(installLine ? [installLine] : []),
       devLine,
     ].join("\n"),
@@ -190,8 +204,14 @@ const program = new Command();
 program
   .name("create-arkor")
   .description("Scaffold a TypeScript arkor training project.")
-  .argument("[dir]", "target directory (default: current directory)")
-  .option("--name <name>", "project name (default: directory name)")
+  .argument(
+    "[dir]",
+    "target directory (default: a new subdirectory named after the project; pass `.` to scaffold into the current directory)",
+  )
+  .option(
+    "--name <name>",
+    "project name (default: [dir] basename, else the prompted name, else 'arkor-project')",
+  )
   .option(
     "--template <template>",
     "starter template: minimal | alpaca | chatml",

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -140,12 +140,24 @@ async function run(options: RunOptions): Promise<void> {
     // directory (likely a typo or a forgotten earlier scaffold). Explicit
     // `dir` keeps the historical "scaffold into an existing project"
     // semantics, so we only validate when `options.dir` is undefined.
-    let promptInitial = defaultName;
+    //
+    // First attempt: empty input field showing `defaultName` as a placeholder;
+    // pressing Enter on empty input falls back to `defaultName` via clack's
+    // `defaultValue`. After a collision, pre-fill the rejected name as
+    // `initialValue` so the user can edit (e.g. add a suffix) instead of
+    // retyping, and require non-empty input — otherwise the user could loop
+    // forever by pressing Enter on the same colliding default.
+    let retryInitial: string | null = null;
     while (true) {
       const chosenName = await clack.text({
         message: "Project name?",
-        initialValue: promptInitial,
-        validate: (v) => (v.trim() ? undefined : "Project name cannot be empty"),
+        ...(retryInitial === null
+          ? { placeholder: defaultName, defaultValue: defaultName }
+          : { initialValue: retryInitial }),
+        validate: (v) =>
+          retryInitial !== null && !v.trim()
+            ? "Project name cannot be empty"
+            : undefined,
       });
       if (clack.isCancel(chosenName)) {
         clack.cancel("Cancelled.");
@@ -157,7 +169,7 @@ async function run(options: RunOptions): Promise<void> {
         (await isOccupied(join(process.cwd(), sanitised)))
       ) {
         clack.log.warn(`${collisionMessage(sanitised)} Pick another name.`);
-        promptInitial = sanitised;
+        retryInitial = sanitised;
         continue;
       }
       name = sanitised;

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import process from "node:process";
 import * as clack from "@clack/prompts";
@@ -34,6 +36,25 @@ const MANUAL_INSTALL_HINT =
 
 function isInteractive(): boolean {
   return Boolean(process.stdout.isTTY) && !process.env.CI;
+}
+
+/**
+ * Truthy when `path` is a non-empty directory — or when it exists but isn't a
+ * readable directory at all (file, broken symlink, etc.). Both cases should
+ * block scaffolding into an auto-derived `./<name>/` so we don't silently
+ * merge into someone else's work.
+ */
+async function isOccupied(path: string): Promise<boolean> {
+  if (!existsSync(path)) return false;
+  try {
+    return (await readdir(path)).length > 0;
+  } catch {
+    return true;
+  }
+}
+
+function collisionMessage(name: string): string {
+  return `Directory "${name}/" already exists and is not empty.`;
 }
 
 /**
@@ -114,16 +135,34 @@ async function run(options: RunOptions): Promise<void> {
   let template: TemplateId = options.template ?? "minimal";
 
   if (!options.yes && isInteractive()) {
-    const chosenName = await clack.text({
-      message: "Project name?",
-      initialValue: defaultName,
-      validate: (v) => (v.trim() ? undefined : "Project name cannot be empty"),
-    });
-    if (clack.isCancel(chosenName)) {
-      clack.cancel("Cancelled.");
-      process.exit(1);
+    // Re-prompt loop: when the project name is auto-derived into a fresh
+    // `./<name>/` subdirectory, refuse to merge into an existing non-empty
+    // directory (likely a typo or a forgotten earlier scaffold). Explicit
+    // `dir` keeps the historical "scaffold into an existing project"
+    // semantics, so we only validate when `options.dir` is undefined.
+    let promptInitial = defaultName;
+    while (true) {
+      const chosenName = await clack.text({
+        message: "Project name?",
+        initialValue: promptInitial,
+        validate: (v) => (v.trim() ? undefined : "Project name cannot be empty"),
+      });
+      if (clack.isCancel(chosenName)) {
+        clack.cancel("Cancelled.");
+        process.exit(1);
+      }
+      const sanitised = sanitise(chosenName);
+      if (
+        options.dir === undefined &&
+        (await isOccupied(join(process.cwd(), sanitised)))
+      ) {
+        clack.log.warn(`${collisionMessage(sanitised)} Pick another name.`);
+        promptInitial = sanitised;
+        continue;
+      }
+      name = sanitised;
+      break;
     }
-    name = sanitise(chosenName);
 
     const chosenTemplate = await clack.select<TemplateId>({
       message: "Starter template?",
@@ -146,6 +185,16 @@ async function run(options: RunOptions): Promise<void> {
       : join(process.cwd(), name);
   const cdTarget = options.dir ?? name;
   const inPlace = resolve(cwd) === resolve(process.cwd());
+
+  // Guard for the non-interactive / `--yes` paths where we couldn't re-prompt
+  // (the interactive loop above already prevents this branch from firing in
+  // TTY mode). Explicit `dir` is exempt — same rationale as the loop.
+  if (options.dir === undefined && (await isOccupied(cwd))) {
+    clack.cancel(
+      `${collisionMessage(name)} Pass an explicit [dir] or remove the existing directory first.`,
+    );
+    process.exit(1);
+  }
 
   const spin = clack.spinner();
   spin.start(`Scaffolding in ${cwd}`);


### PR DESCRIPTION
## Summary

- Running `npm create arkor` (or `pnpm create arkor`, etc.) with no positional argument used to write `package.json`, `src/arkor/`, `arkor.config.ts`, and friends straight into the user's current working directory, scattering scaffold files wherever they happened to be. This now matches the conventional `create-*` UX (vite, next-app): when no `[dir]` is given, prompt for the project name and create a fresh `./<name>/` subdirectory.
- Added an explicit `.` opt-in (`npm create arkor .`) for the rare case where the user really does want to scaffold into the current directory — preserving the old `mkdir foo && cd foo && npm create arkor` workflow.
- The "Next steps" outro and the install-retry hint now reflect the real target path: the `cd <name>` line is emitted for the auto-derived case and suppressed entirely when scaffolding in place.
- README and `--help` strings updated to document the new behavior.

## Test plan

- [x] `pnpm --filter create-arkor build` + `typecheck`
- [x] `SKIP_E2E_INSTALL=1 pnpm --filter @arkor/e2e-cli test` (28 passed / 4 skipped on Node 24)
- [x] New e2e regressions added:
  - no positional → `./arkor-project/` is created and nothing else lands in cwd
  - `.` → scaffolds in place, no `cd` line in the outro
  - `--name foo` without `[dir]` → `./foo/` is created with `pkg.name = "foo"`
- [ ] Manual smoke: `mkdir scratch && cd scratch && node packages/create-arkor/dist/bin.mjs` → confirm prompted name produces `./<name>/` rather than littering `scratch/`
- [ ] Manual smoke: `node packages/create-arkor/dist/bin.mjs my-app -y --skip-install --skip-git` → existing `./my-app/` flow still works (back-compat)
