### PR TITLE
Bind `arkor dev` Studio server to localhost instead of 127.0.0.1

### DIFF
--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -163,8 +163,16 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   // anonymous bootstrap on first `/api/credentials` hit if the up-front
   // attempt above failed (e.g. cloud-api was unreachable at launch).
   const app = buildStudioApp({ studioToken });
+  // Bind to 127.0.0.1 (not "localhost") so the listener can't end up on `::1`
+  // only — `@hono/node-server` passes hostname to `net.Server.listen`, which
+  // calls `dns.lookup`. On hosts where `/etc/hosts` orders `::1 localhost`
+  // before `127.0.0.1 localhost`, a "localhost" bind would refuse IPv4
+  // connections, breaking the studio-app Vite proxy (hardcoded to
+  // `http://127.0.0.1:4000`) and any browser that resolves localhost to
+  // IPv4. The host-header guard already accepts both, so the displayed URL
+  // can still be `localhost`.
   const url = `http://localhost:${port}`;
-  serve({ fetch: app.fetch, port, hostname: "localhost" });
+  serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
   process.stdout.write(`Arkor Studio running on ${url}\n`);
   if (!options.noBrowser) {
     try {

--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -155,7 +155,7 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
     ui.log.warn(
       `Could not write ${studioTokenPath()} (${
         err instanceof Error ? err.message : String(err)
-      }). The Studio at http://127.0.0.1:${port} is unaffected, but the Vite SPA dev workflow will see 403s on /api/*.`,
+      }). The Studio at http://localhost:${port} is unaffected, but the Vite SPA dev workflow will see 403s on /api/*.`,
     );
   }
 
@@ -163,8 +163,8 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   // anonymous bootstrap on first `/api/credentials` hit if the up-front
   // attempt above failed (e.g. cloud-api was unreachable at launch).
   const app = buildStudioApp({ studioToken });
-  const url = `http://127.0.0.1:${port}`;
-  serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
+  const url = `http://localhost:${port}`;
+  serve({ fetch: app.fetch, port, hostname: "localhost" });
   process.stdout.write(`Arkor Studio running on ${url}\n`);
   if (!options.noBrowser) {
     try {


### PR DESCRIPTION
## Summary
- Switch the `arkor dev` Studio server's bind hostname and printed URL from `127.0.0.1` to `localhost`, so users see `http://localhost:4000` and the browser opens that URL.
- The host-header guard in `buildStudioApp` already accepts both `127.0.0.1` and `localhost`, so the per-launch CSRF / DNS-rebinding defenses are unchanged.
- Updates the warning message in the `studio-token` persistence fallback to match.

## Test plan
- [ ] `pnpm --filter arkor test` passes (67/67)
- [ ] `arkor dev` prints `Arkor Studio running on http://localhost:4000` and opens that URL
- [ ] `/api/*` requests from the served SPA still succeed (host header `localhost:4000` passes the guard)
- [ ] `/api/*` requests with a non-loopback `Host` header (e.g. `192.168.x.x:4000`) still return 403
