### PR TITLE
Hide cloud-api URL from Studio identity header on production

### DIFF
--- a/packages/studio-app/src/App.tsx
+++ b/packages/studio-app/src/App.tsx
@@ -25,6 +25,15 @@ function formatIdentityBaseUrl(baseUrl: string): string | null {
   }
 }
 
+function formatIdentity(creds: Credentials): string {
+  const mode = creds.mode === "anon" ? "anonymous" : "auth0";
+  const org = creds.orgSlug ?? "no org";
+  const project = creds.projectSlug ? ` / ${creds.projectSlug}` : "";
+  const baseUrlLabel = formatIdentityBaseUrl(creds.baseUrl);
+  const baseUrlSuffix = baseUrlLabel ? ` · ${baseUrlLabel}` : "";
+  return `${mode} · ${org}${project}${baseUrlSuffix}`;
+}
+
 type Route =
   | { kind: "home" }
   | { kind: "job"; id: string }
@@ -75,10 +84,7 @@ export function App() {
           {error
             ? `error: ${error}`
             : creds
-              ? (() => {
-                  const baseUrlLabel = formatIdentityBaseUrl(creds.baseUrl);
-                  return `${creds.mode === "anon" ? "anonymous" : "auth0"} · ${creds.orgSlug ?? "no org"}${creds.projectSlug ? ` / ${creds.projectSlug}` : ""}${baseUrlLabel ? ` · ${baseUrlLabel}` : ""}`;
-                })()
+              ? formatIdentity(creds)
               : "connecting…"}
         </div>
       </header>

--- a/packages/studio-app/src/App.tsx
+++ b/packages/studio-app/src/App.tsx
@@ -5,6 +5,22 @@ import { Playground } from "./pages/Playground";
 import { RunTraining } from "./components/RunTraining";
 import { fetchCredentials, type Credentials } from "./lib/api";
 
+const PRODUCTION_CLOUD_API_URL = "https://api.arkor.ai";
+
+// Hide the cloud-api URL from the identity header when pointing at the
+// production endpoint — regular users don't need it. For Arkor contributors
+// running against a local cloud-api (`ARKOR_CLOUD_API_URL=...`), surface just
+// the host:port so it's clear which backend the Studio is talking to without
+// the protocol noise.
+function formatIdentityBaseUrl(baseUrl: string): string | null {
+  if (baseUrl === PRODUCTION_CLOUD_API_URL) return null;
+  try {
+    return new URL(baseUrl).host;
+  } catch {
+    return baseUrl;
+  }
+}
+
 type Route =
   | { kind: "home" }
   | { kind: "job"; id: string }
@@ -55,7 +71,10 @@ export function App() {
           {error
             ? `error: ${error}`
             : creds
-              ? `${creds.mode === "anon" ? "anonymous" : "auth0"} · ${creds.orgSlug ?? "no org"}${creds.projectSlug ? ` / ${creds.projectSlug}` : ""} · ${creds.baseUrl}`
+              ? (() => {
+                  const baseUrlLabel = formatIdentityBaseUrl(creds.baseUrl);
+                  return `${creds.mode === "anon" ? "anonymous" : "auth0"} · ${creds.orgSlug ?? "no org"}${creds.projectSlug ? ` / ${creds.projectSlug}` : ""}${baseUrlLabel ? ` · ${baseUrlLabel}` : ""}`;
+                })()
               : "connecting…"}
         </div>
       </header>

--- a/packages/studio-app/src/App.tsx
+++ b/packages/studio-app/src/App.tsx
@@ -13,7 +13,11 @@ const PRODUCTION_CLOUD_API_URL = "https://api.arkor.ai";
 // the host:port so it's clear which backend the Studio is talking to without
 // the protocol noise.
 function formatIdentityBaseUrl(baseUrl: string): string | null {
-  if (baseUrl === PRODUCTION_CLOUD_API_URL) return null;
+  // Strip trailing slash before comparing — the server normalises env-var
+  // overrides via `defaultArkorCloudApiUrl()` today, but a future change that
+  // forwards the raw value would otherwise let `https://api.arkor.ai/` slip
+  // past the production check and surface in the header.
+  if (baseUrl.replace(/\/$/, "") === PRODUCTION_CLOUD_API_URL) return null;
   try {
     return new URL(baseUrl).host;
   } catch {


### PR DESCRIPTION
## Summary
- The Studio identity header used to always render the full `arkorCloudApiUrl` (e.g. `https://api.arkor.ai`, or `http://localhost:3003` when an Arkor contributor runs against a local cloud-api). The protocol-prefixed URL is noise for regular users and reads like a raw IP:port for anyone unfamiliar with it.
- Hide the baseUrl segment entirely when it matches the production endpoint (`https://api.arkor.ai`) so non-contributor users just see `anonymous · org / project`.
- For non-production endpoints (typically contributors with `ARKOR_CLOUD_API_URL` set), surface only the `host:port` (e.g. `localhost:3003`) so it stays clear which backend the Studio is talking to without the protocol prefix.

## Test plan
- [ ] `pnpm --filter @arkor/studio-app typecheck` passes
- [ ] `arkor dev` against the default cloud-api → identity header shows `anonymous · <org> / <project>` (no URL segment)
- [ ] `ARKOR_CLOUD_API_URL=http://localhost:3003 arkor dev` → identity header shows `anonymous · <org> / <project> · localhost:3003`
- [ ] Malformed `ARKOR_CLOUD_API_URL` → header falls back to the raw string instead of crashing
