### PR TITLE
feat: add redaction / translate / triage demo templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import { createTrainer } from "arkor";
 export const trainer = createTrainer({
   name: "support-bot-v1",
   model: "unsloth/gemma-4-E4B-it",
-  dataset: { type: "huggingface", name: "yahma/alpaca-cleaned", split: "train[:1000]" },
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
   lora: { r: 16, alpha: 16 },
   maxSteps: 100,
   callbacks: {

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ Run `arkor login` later if you want to claim your work under an account.
 
 ### Pick a template
 
-The scaffolder asks which template you want. 
-All three start from the same small open-weight base (`unsloth/gemma-4-E4B-it`) so the first run finishes quickly.
+The scaffolder asks which template you want.
+All three pair the same small open-weight base (`unsloth/gemma-4-E4B-it`) with a curated public dataset on HuggingFace, so the first run finishes in minutes.
 
-| Template  | What it shows                                                       | Dataset                            |
-| --------- | ------------------------------------------------------------------- | ---------------------------------- |
-| `minimal` | The smallest working `createTrainer({ ... })` call.                 | `yahma/alpaca-cleaned` (500 rows)  |
-| `alpaca`  | Instruction-tuning with mid-training `infer()` on every checkpoint. | `yahma/alpaca-cleaned` (1000 rows) |
-| `chatml`  | Multi-turn chat fine-tuning over a real chat dataset.               | `stingning/ultrachat` (500 rows)   |
+| Template    | Task                                                            | Dataset                     | Est. training |
+| ----------- | --------------------------------------------------------------- | --------------------------- | ------------- |
+| `triage`    | Support ticket → `{category, urgency, summary, nextAction}` JSON | `arkorlab/triage-demo`      | ~7 min        |
+| `translate` | Multilingual support intake translation across 9 languages       | `arkorlab/translate-demo`   | ~7 min        |
+| `redaction` | PII redaction → tagged `[REDACTED]` spans + categories           | `arkorlab/redaction-demo`   | ~12 min       |
 
-Skip the prompt with `pnpm create arkor my-arkor-app --template alpaca`.
+Skip the prompt with `pnpm create arkor my-arkor-app --template triage`.
 
 ## Why Arkor
 

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -24,7 +24,7 @@ Requires Node.js 22.6+.
 
 ## SDK
 
-Two factories. One umbrella, one per role.
+Two factories. One for the project entry point, one per role.
 
 ```ts
 // src/arkor/trainer.ts
@@ -61,10 +61,10 @@ import { trainer } from "./trainer";
 export const arkor = createArkor({ trainer });
 ```
 
-The umbrella is intentionally opaque — `createArkor` returns a frozen
-manifest today, with room to grow operation methods later without breaking
-callers. Keys are role-fixed (`trainer`, future `deploy` / `eval`) so the
-CLI and Studio can predict what's there.
+`createArkor` returns an intentionally opaque, frozen manifest — room to
+grow operation methods later without breaking callers. Keys are role-fixed
+(`trainer`, future `deploy` / `eval`) so the CLI and Studio can predict
+what's there.
 
 ### Trainer lifecycle
 

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -33,11 +33,7 @@ import { createTrainer } from "arkor";
 export const trainer = createTrainer({
   name: "my-first-run",
   model: "unsloth/gemma-4-E4B-it",
-  dataset: {
-    type: "huggingface",
-    name: "yahma/alpaca-cleaned",
-    split: "train[:500]",
-  },
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
   lora: { r: 16, alpha: 16 },
   maxSteps: 50,
   callbacks: {

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -105,9 +105,9 @@ export async function runInit(options: InitOptions): Promise<void> {
   });
   const template = await promptSelect<TemplateId>({
     message: "Starter template?",
-    initialValue: options.template ?? "minimal",
+    initialValue: options.template ?? "triage",
     options: templateChoices(),
-    skipWith: options.yes ? options.template ?? "minimal" : undefined,
+    skipWith: options.yes ? options.template ?? "triage" : undefined,
   });
 
   // Sanitise here so `--name "Foo Bar"` (which bypasses prompts under

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -5,6 +5,7 @@ import {
   isInGitRepo,
   sanitise,
   scaffold,
+  TEMPLATES,
   templateChoices,
   type PackageManager,
   type TemplateId,
@@ -97,17 +98,32 @@ export async function runInit(options: InitOptions): Promise<void> {
   // trigger the fallback). `basename("/")` returns `""`, hence the `||`.
   const defaultName = basename(cwd) || "arkor-project";
 
+  // Reject typos / unknown template ids before any prompt or filesystem work.
+  // `Object.hasOwn` (not `in`) so prototype keys like `toString` / `__proto__`
+  // can't pass validation and crash later inside scaffold().
+  if (
+    options.template !== undefined &&
+    !Object.hasOwn(TEMPLATES, options.template)
+  ) {
+    throw new Error(
+      `Unknown template "${options.template}". Available: ${Object.keys(TEMPLATES).join(", ")}`,
+    );
+  }
+
   ui.intro("arkor init");
   const projectName = await promptText({
     message: "Project name?",
     initialValue: options.name ?? defaultName,
     skipWith: options.yes ? options.name ?? defaultName : undefined,
   });
+  // An explicit `--template <id>` is treated as authoritative — skip the
+  // prompt entirely so a hidden-but-valid template (e.g. `minimal`) can't be
+  // overwritten by the visible-only options list.
   const template = await promptSelect<TemplateId>({
     message: "Starter template?",
     initialValue: options.template ?? "triage",
     options: templateChoices(),
-    skipWith: options.yes ? options.template ?? "triage" : undefined,
+    skipWith: options.template ?? (options.yes ? "triage" : undefined),
   });
 
   // Sanitise here so `--name "Foo Bar"` (which bypasses prompts under

--- a/packages/arkor/src/cli/main.ts
+++ b/packages/arkor/src/cli/main.ts
@@ -6,7 +6,7 @@ import { runInit } from "./commands/init";
 import { runDev } from "./commands/dev";
 import { runBuild } from "./commands/build";
 import { runStart } from "./commands/start";
-import { resolvePackageManager } from "@arkor/cli-internal";
+import { resolvePackageManager, type TemplateId } from "@arkor/cli-internal";
 
 export async function main(argv: string[]): Promise<void> {
   const program = new Command();
@@ -17,7 +17,7 @@ export async function main(argv: string[]): Promise<void> {
     .description("Scaffold src/arkor/index.ts + arkor.config.ts in the current directory")
     .option("-y, --yes", "Accept defaults instead of prompting")
     .option("--name <name>", "Project name (default: directory name)")
-    .option("--template <template>", "Starter template: minimal | alpaca | chatml")
+    .option("--template <template>", "Starter template: triage | translate | redaction")
     .option("--skip-install", "Skip installing dependencies after scaffolding")
     .option("--use-npm", "Force npm as the package manager")
     .option("--use-pnpm", "Force pnpm as the package manager")
@@ -53,7 +53,7 @@ export async function main(argv: string[]): Promise<void> {
         await runInit({
           yes: opts.yes,
           name: opts.name,
-          template: opts.template as "minimal" | "alpaca" | "chatml" | undefined,
+          template: opts.template as TemplateId | undefined,
           skipInstall: opts.skipInstall,
           packageManager,
           git: opts.git,

--- a/packages/arkor/src/core/arkor.ts
+++ b/packages/arkor/src/core/arkor.ts
@@ -1,9 +1,9 @@
 import type { Arkor, ArkorInput } from "./types";
 
 /**
- * Build the project's umbrella manifest.
+ * Build the project's entry-point manifest.
  *
- * `createArkor` is the umbrella factory — it gathers per-role primitives
+ * `createArkor` is the entry-point factory — it gathers per-role primitives
  * (`trainer`, future: `deploy`, `eval`) under a single value that the CLI
  * (`arkor build` / `arkor start`) and Studio discover from
  * `src/arkor/index.ts`.

--- a/packages/arkor/src/core/types.ts
+++ b/packages/arkor/src/core/types.ts
@@ -203,7 +203,7 @@ export interface Trainer {
 }
 
 /**
- * Umbrella manifest produced by `createArkor`. Currently a frozen descriptor
+ * Project entry-point manifest produced by `createArkor`. Currently a frozen descriptor
  * of the project's primitives. The shape is intentionally opaque — operation
  * methods may be added later without breaking the user-facing API.
  */

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -197,12 +197,9 @@ describe("resolvePackageManager", () => {
 });
 
 describe("templateChoices", () => {
-  it("exposes every template with a hint", () => {
+  it("exposes only the non-hidden templates with a hint", () => {
     const list = templateChoices();
     expect(list.map((t) => t.value).sort()).toEqual([
-      "alpaca",
-      "chatml",
-      "minimal",
       "redaction",
       "translate",
       "triage",
@@ -211,5 +208,14 @@ describe("templateChoices", () => {
       expect(t.label).toBeTruthy();
       expect(t.hint).toBeTruthy();
     }
+  });
+
+  it("preserves the TEMPLATES insertion order (triage first, fastest)", () => {
+    const list = templateChoices();
+    expect(list.map((t) => t.value)).toEqual([
+      "triage",
+      "translate",
+      "redaction",
+    ]);
   });
 });

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -143,7 +143,7 @@ describe("scaffold", () => {
       await scaffold({ cwd: dir, name: template, template });
       const trainer = readFileSync(join(dir, "src/arkor/trainer.ts"), "utf8");
       expect(trainer).toContain(expectations[template]);
-      // The umbrella manifest is template-independent.
+      // The src/arkor/index.ts entry-point manifest is template-independent.
       const index = readFileSync(join(dir, "src/arkor/index.ts"), "utf8");
       expect(index).toContain("createArkor({ trainer })");
       rmSync(dir, { recursive: true, force: true });

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -203,6 +203,9 @@ describe("templateChoices", () => {
       "alpaca",
       "chatml",
       "minimal",
+      "redaction",
+      "translate",
+      "triage",
     ]);
     for (const t of list) {
       expect(t.label).toBeTruthy();

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -169,9 +169,11 @@ export function templateChoices(): Array<{
   label: string;
   hint: string;
 }> {
-  return (Object.keys(TEMPLATES) as TemplateId[]).map((key) => ({
-    value: key,
-    label: TEMPLATES[key].label,
-    hint: TEMPLATES[key].hint,
-  }));
+  return (Object.keys(TEMPLATES) as TemplateId[])
+    .filter((key) => !TEMPLATES[key].hidden)
+    .map((key) => ({
+      value: key,
+      label: TEMPLATES[key].label,
+      hint: TEMPLATES[key].hint,
+    }));
 }

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -9,7 +9,13 @@
  *
  * `index.ts` is identical across templates — only the trainer body differs.
  */
-export type TemplateId = "minimal" | "alpaca" | "chatml";
+export type TemplateId =
+  | "minimal"
+  | "alpaca"
+  | "chatml"
+  | "redaction"
+  | "translate"
+  | "triage";
 
 export interface Template {
   label: string;
@@ -81,6 +87,64 @@ export const trainer = createTrainer({
 });
 `;
 
+// The three demo templates below pair `unsloth/gemma-4-E4B-it` with curated
+// HuggingFace datasets published under the `arkorlab` org. Each dataset is in
+// OpenAI messages format (chatml), one sample per JSONL line, with the system
+// prompt baked into the conversation — so `datasetFormat: { type: "chatml" }`
+// hands the right shape to the trainer's apply_chat_template step.
+//
+// Use `dryRun: true` for a 2–3 minute smoke test (50 rows, max_steps=10) before
+// committing to a full run.
+
+const REDACTION_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "redaction-run",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/redaction-demo" },
+  datasetFormat: { type: "chatml" },
+  maxSteps: 100,
+  lora: { r: 16, alpha: 16 },
+  // Set dryRun: true for a fast end-to-end smoke test before a full run.
+  // dryRun: true,
+  callbacks: {
+    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
+  },
+});
+`;
+
+const TRANSLATE_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "translate-run",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/translate-demo" },
+  datasetFormat: { type: "chatml" },
+  maxSteps: 100,
+  lora: { r: 16, alpha: 16 },
+  // dryRun: true,
+  callbacks: {
+    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
+  },
+});
+`;
+
+const TRIAGE_TRAINER = `import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "triage-run",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  datasetFormat: { type: "chatml" },
+  maxSteps: 100,
+  lora: { r: 16, alpha: 16 },
+  // dryRun: true,
+  callbacks: {
+    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
+  },
+});
+`;
+
 export const TEMPLATES: Record<TemplateId, Template> = {
   minimal: {
     label: "Minimal",
@@ -96,6 +160,21 @@ export const TEMPLATES: Record<TemplateId, Template> = {
     label: "ChatML",
     hint: "multi-turn chat fine-tuning",
     trainer: CHATML_TRAINER,
+  },
+  redaction: {
+    label: "Redaction",
+    hint: "PII redaction → structured JSON (name/email/phone/address/id/other)",
+    trainer: REDACTION_TRAINER,
+  },
+  translate: {
+    label: "Translate",
+    hint: "Multilingual intake translation across 9 languages",
+    trainer: TRANSLATE_TRAINER,
+  },
+  triage: {
+    label: "Triage",
+    hint: "Support ticket classification (category, urgency, summary, nextAction)",
+    trainer: TRIAGE_TRAINER,
   },
 };
 

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -4,7 +4,7 @@
  *
  * Layout written to disk:
  *
- *   src/arkor/index.ts    ← umbrella manifest (`createArkor({ trainer })`)
+ *   src/arkor/index.ts    ← entry-point manifest (`createArkor({ trainer })`)
  *   src/arkor/trainer.ts  ← per-template trainer (`createTrainer({...})`)
  *
  * `index.ts` is identical across templates — only the trainer body differs.
@@ -197,7 +197,7 @@ export const TEMPLATES: Record<TemplateId, Template> = {
 };
 
 /**
- * Body of `src/arkor/index.ts` — identical across templates. The umbrella
+ * Body of `src/arkor/index.ts` — identical across templates. The `createArkor`
  * factory is what `arkor build` / Studio discovers; per-role primitives
  * (`trainer`, future `deploy`, `eval`) live in sibling files and get gathered
  * here.
@@ -248,11 +248,11 @@ npm run start    # runs the build artifact on the cloud
 
 ## Files
 
-- \`src/arkor/index.ts\` — umbrella manifest (\`createArkor({ trainer })\`).
+- \`src/arkor/index.ts\` — entry-point manifest (\`createArkor({ trainer })\`).
   This is what the CLI and Studio discover.
 - \`src/arkor/trainer.ts\` — your trainer (\`createTrainer({...})\`). Add
   sibling files for future primitives (\`deploy.ts\`, \`eval.ts\`) and
-  register them on the umbrella.
+  register them in the \`createArkor\` call.
 - \`arkor.config.ts\` — training defaults. Project routing lives in
   \`.arkor/state.json\`, managed by the CLI.
 

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -22,6 +22,13 @@ export interface Template {
   hint: string;
   /** Body of `src/arkor/trainer.ts` for this template. */
   trainer: string;
+  /**
+   * When true, the template is excluded from the CLI's interactive prompt and
+   * `templateChoices()` listing. The entry stays in `TEMPLATES` so direct
+   * `scaffold({ template })` calls (e.g. tests) still work, and re-enabling
+   * is a one-line change.
+   */
+  hidden?: boolean;
 }
 
 const MINIMAL_TRAINER = `import { createTrainer } from "arkor";
@@ -145,36 +152,47 @@ export const trainer = createTrainer({
 });
 `;
 
+// Order is significant — `templateChoices()` preserves insertion order so the
+// CLI prompt lists demos first (sorted by estimated training time).
+//
+// Estimated training times assume A100 80GB on Runpod Serverless with the
+// template defaults (maxSteps: 100, batchSize: 4, LoRA r=16, 4-bit). Real
+// numbers depend on GPU availability + cold-start; treat them as ballparks.
 export const TEMPLATES: Record<TemplateId, Template> = {
+  triage: {
+    label: "Triage",
+    hint: "Support ticket triage (estimated training: ~10 min)",
+    trainer: TRIAGE_TRAINER,
+  },
+  translate: {
+    label: "Translate",
+    hint: "Multilingual intake translation across 9 languages (estimated training: ~10 min)",
+    trainer: TRANSLATE_TRAINER,
+  },
+  redaction: {
+    label: "Redaction",
+    hint: "PII redaction → structured JSON (estimated training: ~15 min)",
+    trainer: REDACTION_TRAINER,
+  },
+  // The starter templates below are kept in source for reference but excluded
+  // from the CLI prompt for now. To re-enable, drop the `hidden: true` flag.
   minimal: {
     label: "Minimal",
     hint: "bare createTrainer call",
     trainer: MINIMAL_TRAINER,
+    hidden: true,
   },
   alpaca: {
     label: "Alpaca",
     hint: "instruction-tuning + mid-training eval",
     trainer: ALPACA_TRAINER,
+    hidden: true,
   },
   chatml: {
     label: "ChatML",
     hint: "multi-turn chat fine-tuning",
     trainer: CHATML_TRAINER,
-  },
-  redaction: {
-    label: "Redaction",
-    hint: "PII redaction → structured JSON (name/email/phone/address/id/other)",
-    trainer: REDACTION_TRAINER,
-  },
-  translate: {
-    label: "Translate",
-    hint: "Multilingual intake translation across 9 languages",
-    trainer: TRANSLATE_TRAINER,
-  },
-  triage: {
-    label: "Triage",
-    hint: "Support ticket classification (category, urgency, summary, nextAction)",
-    trainer: TRIAGE_TRAINER,
+    hidden: true,
   },
 };
 

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -161,17 +161,17 @@ export const trainer = createTrainer({
 export const TEMPLATES: Record<TemplateId, Template> = {
   triage: {
     label: "Triage",
-    hint: "Support ticket triage (estimated training: ~10 min)",
+    hint: "Support ticket triage (estimated training: ~7 min)",
     trainer: TRIAGE_TRAINER,
   },
   translate: {
     label: "Translate",
-    hint: "Multilingual intake translation across 9 languages (estimated training: ~10 min)",
+    hint: "Multilingual intake translation across 9 languages (estimated training: ~7 min)",
     trainer: TRANSLATE_TRAINER,
   },
   redaction: {
     label: "Redaction",
-    hint: "PII redaction → structured JSON (estimated training: ~15 min)",
+    hint: "PII redaction → structured JSON (estimated training: ~12 min)",
     trainer: REDACTION_TRAINER,
   },
   // The starter templates below are kept in source for reference but excluded

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -52,7 +52,7 @@ pnpm create arkor my-app \
 ```
 my-app/
 ├── src/arkor/
-│   ├── index.ts        # createArkor({ trainer }) umbrella
+│   ├── index.ts        # createArkor({ trainer }) entry point
 │   └── trainer.ts      # template-specific createTrainer({...})
 ├── arkor.config.ts
 ├── README.md
@@ -73,7 +73,7 @@ non-interactive runs exit with an error.
 - **translate** — multilingual support-intake translation across 9 languages. → `{translation, detectedLanguage}` JSON. Dataset: `arkorlab/translate-demo`. ~7 min training.
 - **redaction** — PII redaction. Free-text in → `{redactedText, redactedCount, tags}` JSON with `[REDACTED]` substitutions. Dataset: `arkorlab/redaction-demo`. ~12 min training.
 
-All three pair `unsloth/gemma-4-E4B-it` with a public dataset hosted under [`arkorlab` on HuggingFace](https://huggingface.co/arkorlab). The umbrella `src/arkor/index.ts` is identical across templates; only `src/arkor/trainer.ts` differs.
+All three pair `unsloth/gemma-4-E4B-it` with a public dataset hosted under [`arkorlab` on HuggingFace](https://huggingface.co/arkorlab). The `src/arkor/index.ts` entry point is identical across templates; only `src/arkor/trainer.ts` differs.
 
 ## Next step
 

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -29,7 +29,7 @@ Interactive by default. Pass flags to skip prompts:
 
 ```bash
 pnpm create arkor my-app \
-  --template alpaca \
+  --template triage \
   --use-pnpm \
   --skip-install \
   --skip-git
@@ -41,7 +41,7 @@ pnpm create arkor my-app \
 |---|---|
 | `[dir]` (positional) | Target directory. If omitted, a new subdirectory named after the project is created. Pass `.` to scaffold into the current directory |
 | `--name <name>` | Project name (sanitised for `package.json`). When `[dir]` is omitted, also used as the new subdirectory name |
-| `--template <id>` | `minimal` / `alpaca` / `chatml` |
+| `--template <id>` | `triage` / `translate` / `redaction` |
 | `-y`, `--yes` | Accept defaults instead of prompting |
 | `--skip-install` | Don't run `<pm> install` after scaffolding |
 | `--use-npm` / `--use-pnpm` / `--use-yarn` / `--use-bun` | Force a package manager (otherwise auto-detected from `npm_config_user_agent`) |
@@ -69,13 +69,11 @@ non-interactive runs exit with an error.
 
 ## Templates
 
-- **minimal** — bare `createTrainer` call, the smallest working example.
-- **alpaca** — instruction-tuning with a mid-training `onCheckpoint` that
-  fires an `infer({...})` against the in-progress adapter.
-- **chatml** — multi-turn chat fine-tuning on `stingning/ultrachat`.
+- **triage** — support ticket triage. Free-text in → `{category, urgency, summary, nextAction}` JSON. Dataset: `arkorlab/triage-demo`. ~7 min training.
+- **translate** — multilingual support-intake translation across 9 languages. → `{translation, detectedLanguage}` JSON. Dataset: `arkorlab/translate-demo`. ~7 min training.
+- **redaction** — PII redaction. Free-text in → `{redactedText, redactedCount, tags}` JSON with `[REDACTED]` substitutions. Dataset: `arkorlab/redaction-demo`. ~12 min training.
 
-The umbrella `src/arkor/index.ts` is identical across templates; only
-`src/arkor/trainer.ts` differs.
+All three pair `unsloth/gemma-4-E4B-it` with a public dataset hosted under [`arkorlab` on HuggingFace](https://huggingface.co/arkorlab). The umbrella `src/arkor/index.ts` is identical across templates; only `src/arkor/trainer.ts` differs.
 
 ## Next step
 

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -281,7 +281,7 @@ program
   )
   .option(
     "--template <template>",
-    "starter template: minimal | alpaca | chatml",
+    "starter template: triage | translate | redaction",
   )
   .option("-y, --yes", "skip interactive prompts and accept the defaults")
   .option("--skip-install", "skip installing dependencies after scaffolding")

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -132,7 +132,7 @@ async function run(options: RunOptions): Promise<void> {
   // straight from `--name` is not, and falls through to package.json as-is
   // when `--yes` skips the interactive prompt.
   let name = sanitise(options.name ?? defaultName);
-  let template: TemplateId = options.template ?? "minimal";
+  let template: TemplateId = options.template ?? "triage";
 
   if (!options.yes && isInteractive()) {
     // Re-prompt loop: when the project name is auto-derived into a fresh
@@ -308,9 +308,9 @@ program
         throw new Error("Pick one of --git / --skip-git, not both.");
       }
       const template =
-        opts.template === "minimal" ||
-        opts.template === "alpaca" ||
-        opts.template === "chatml"
+        opts.template === "triage" ||
+        opts.template === "translate" ||
+        opts.template === "redaction"
           ? opts.template
           : undefined;
       const packageManager = resolvePackageManager({

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -12,6 +12,7 @@ import {
   resolvePackageManager,
   sanitise,
   scaffold,
+  TEMPLATES,
   templateChoices,
   type PackageManager,
   type TemplateId,
@@ -307,12 +308,19 @@ program
       if (opts.git && opts.skipGit) {
         throw new Error("Pick one of --git / --skip-git, not both.");
       }
-      const template =
-        opts.template === "triage" ||
-        opts.template === "translate" ||
-        opts.template === "redaction"
-          ? opts.template
-          : undefined;
+      // Accept any TEMPLATES key — including hidden ones — so passing
+      // `--template minimal` still scaffolds correctly (per the Template.hidden
+      // JSDoc). Reject typos / removed names with an explicit error rather than
+      // silently coercing them to the default.
+      let template: TemplateId | undefined;
+      if (opts.template !== undefined) {
+        if (!(opts.template in TEMPLATES)) {
+          throw new Error(
+            `Unknown template "${opts.template}". Available: ${Object.keys(TEMPLATES).join(", ")}`,
+          );
+        }
+        template = opts.template as TemplateId;
+      }
       const packageManager = resolvePackageManager({
         useNpm: opts.useNpm,
         usePnpm: opts.usePnpm,

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -177,16 +177,21 @@ async function run(options: RunOptions): Promise<void> {
       break;
     }
 
-    const chosenTemplate = await clack.select<TemplateId>({
-      message: "Starter template?",
-      initialValue: template,
-      options: templateChoices(),
-    });
-    if (clack.isCancel(chosenTemplate)) {
-      clack.cancel("Cancelled.");
-      process.exit(1);
+    // An explicit `--template <id>` is treated as authoritative — skip the
+    // prompt so a hidden-but-valid template (e.g. `minimal`) can't be
+    // overwritten by the visible-only options list.
+    if (options.template === undefined) {
+      const chosenTemplate = await clack.select<TemplateId>({
+        message: "Starter template?",
+        initialValue: template,
+        options: templateChoices(),
+      });
+      if (clack.isCancel(chosenTemplate)) {
+        clack.cancel("Cancelled.");
+        process.exit(1);
+      }
+      template = chosenTemplate;
     }
-    template = chosenTemplate;
   }
 
   // When no `dir` was passed, scaffold into a fresh subdirectory named after
@@ -310,11 +315,13 @@ program
       }
       // Accept any TEMPLATES key — including hidden ones — so passing
       // `--template minimal` still scaffolds correctly (per the Template.hidden
-      // JSDoc). Reject typos / removed names with an explicit error rather than
-      // silently coercing them to the default.
+      // JSDoc). Use `Object.hasOwn` (not `in`) so prototype keys like
+      // `toString` / `__proto__` can't pass validation and crash later inside
+      // scaffold(). Reject typos / removed names with an explicit error rather
+      // than silently coercing them to the default.
       let template: TemplateId | undefined;
       if (opts.template !== undefined) {
-        if (!(opts.template in TEMPLATES)) {
+        if (!Object.hasOwn(TEMPLATES, opts.template)) {
           throw new Error(
             `Unknown template "${opts.template}". Available: ${Object.keys(TEMPLATES).join(", ")}`,
           );


### PR DESCRIPTION
## Summary

Adds three new starter templates to `npm create arkor` and `arkor init`:

| Template | Dataset | Task |
|---|---|---|
| `redaction` | `arkorlab/redaction-demo` | PII redaction → JSON `{redactedText, redactedCount, tags}` |
| `translate` | `arkorlab/translate-demo` | 9-language intake translation → JSON `{translation, detectedLanguage}` |
| `triage` | `arkorlab/triage-demo` | Support ticket → JSON `{category, urgency, summary, nextAction}` |

Each pairs `unsloth/gemma-4-E4B-it` with `datasetFormat: { type: "chatml" }` so the trainer's `apply_chat_template` renders the OpenAI-messages-format JSONL the curated HuggingFace datasets ship in. Comments suggest `dryRun: true` for a 2–3 minute smoke test before a full run.

## Files changed

- `packages/cli-internal/src/templates.ts` — extend `TemplateId`, add 3 trainer constants + `TEMPLATES` entries
- `packages/cli-internal/src/scaffold.test.ts` — update the template-list snapshot

Templates auto-flow through `scaffold.ts`'s `templateChoices()` iteration so both `arkor init` and `npm create arkor` surface the new options without further wiring.

## Test plan

- [x] `pnpm --filter @arkor/cli-internal typecheck` passes
- [x] `pnpm --filter arkor typecheck` and `pnpm --filter create-arkor typecheck` pass
- [x] `pnpm build` passes (cli-internal → arkor → create-arkor)
- [x] `pnpm test` passes (36 tests across 6 packages)
- [ ] After merge + alpha publish: `npm create arkor@alpha` lists the 3 new templates and scaffolds a working project