### PR TITLE
feat(studio): let Playground try base models without an adapter

### DIFF
--- a/packages/arkor/src/core/projectState.ts
+++ b/packages/arkor/src/core/projectState.ts
@@ -1,0 +1,71 @@
+import { CloudApiClient, CloudApiError } from "./client";
+import type { Credentials } from "./credentials";
+import { readState, writeState } from "./state";
+import type { ArkorProjectState } from "./types";
+
+export interface EnsureProjectStateOptions {
+  cwd: string;
+  client: CloudApiClient;
+  credentials: Credentials;
+}
+
+/**
+ * Resolve the project scope (`orgSlug` / `projectSlug`) used to address
+ * cloud-api endpoints. Returns existing `.arkor/state.json` if present;
+ * otherwise — for anonymous credentials only — derives a slug from the cwd
+ * basename, creates (or reuses on 409) the project, persists state, and
+ * returns it. Auth0 callers without state must run `arkor init` first.
+ *
+ * Shared by the trainer (`createTrainer().start()`) and Studio's
+ * `/api/inference/chat` so a fresh launch can hit base-model inference
+ * without a prior `arkor init`.
+ */
+export async function ensureProjectState(
+  options: EnsureProjectStateOptions,
+): Promise<ArkorProjectState> {
+  const { cwd, client, credentials } = options;
+  const existing = await readState(cwd);
+  if (existing) return existing;
+
+  if (credentials.mode !== "anon") {
+    throw new Error(
+      "No .arkor/state.json found. Run `arkor init` to scaffold the project, or create .arkor/state.json manually with { orgSlug, projectSlug, projectId }.",
+    );
+  }
+  const orgSlug = credentials.orgSlug;
+
+  const baseName = cwd.split(/[/\\]/).filter(Boolean).pop() ?? "project";
+  const projectSlug =
+    baseName
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || "project";
+
+  let project: { id: string; slug: string };
+  try {
+    const res = await client.createProject({
+      orgSlug,
+      name: baseName,
+      slug: projectSlug,
+    });
+    project = res.project;
+  } catch (err) {
+    if (err instanceof CloudApiError && err.status === 409) {
+      const { projects } = await client.listProjects(orgSlug);
+      const found = projects.find((p) => p.slug === projectSlug);
+      if (!found) throw err;
+      project = found;
+    } else {
+      throw err;
+    }
+  }
+
+  const state: ArkorProjectState = {
+    orgSlug,
+    projectSlug: project.slug,
+    projectId: project.id,
+  };
+  await writeState(state, cwd);
+  return state;
+}

--- a/packages/arkor/src/core/trainer.ts
+++ b/packages/arkor/src/core/trainer.ts
@@ -1,13 +1,12 @@
 import { iterateEvents } from "@arkor/cloud-api-client";
-import { CloudApiClient, CloudApiError } from "./client";
+import { CloudApiClient } from "./client";
 import {
   defaultArkorCloudApiUrl,
   ensureCredentials,
   type Credentials,
 } from "./credentials";
-import { readState, writeState } from "./state";
+import { ensureProjectState } from "./projectState";
 import type {
-  ArkorProjectState,
   CheckpointContext,
   InferArgs,
   JobConfig,
@@ -150,53 +149,9 @@ export function createTrainer(
     return clientPromise;
   }
 
-  async function ensureProjectState(
-    client: CloudApiClient,
-  ): Promise<ArkorProjectState> {
-    const existing = await readState(cwd);
-    if (existing) return existing;
-
+  async function resolveProjectState(client: CloudApiClient) {
     const credentials = context.credentials ?? (await ensureCredentials());
-    if (credentials.mode !== "anon") {
-      throw new Error(
-        "No .arkor/state.json found. Run `arkor init` to scaffold the project, or create .arkor/state.json manually with { orgSlug, projectSlug, projectId }.",
-      );
-    }
-    const orgSlug = credentials.orgSlug;
-
-    const baseName = cwd.split(/[/\\]/).filter(Boolean).pop() ?? "project";
-    const projectSlug = baseName
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 40) || "project";
-
-    let project: { id: string; slug: string };
-    try {
-      const res = await client.createProject({
-        orgSlug,
-        name: baseName,
-        slug: projectSlug,
-      });
-      project = res.project;
-    } catch (err) {
-      if (err instanceof CloudApiError && err.status === 409) {
-        const { projects } = await client.listProjects(orgSlug);
-        const found = projects.find((p) => p.slug === projectSlug);
-        if (!found) throw err;
-        project = found;
-      } else {
-        throw err;
-      }
-    }
-
-    const state: ArkorProjectState = {
-      orgSlug,
-      projectSlug: project.slug,
-      projectId: project.id,
-    };
-    await writeState(state, cwd);
-    return state;
+    return ensureProjectState({ cwd, client, credentials });
   }
 
   /**
@@ -320,7 +275,7 @@ export function createTrainer(
     async start() {
       if (startedJob) return { jobId: startedJob.id };
       const client = await getClient();
-      const state = await ensureProjectState(client);
+      const state = await resolveProjectState(client);
       scope = { orgSlug: state.orgSlug, projectSlug: state.projectSlug };
 
       const { job } = await client.createJob({

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
+  existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
   mkdirSync,
@@ -10,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
+import { writeState } from "../core/state";
 
 const ANON_CREDS = {
   mode: "anon" as const,
@@ -394,6 +397,138 @@ process.exit(0);
       expect(res.status).toBe(200);
       const body = (await res.json()) as { trainer: unknown };
       expect(body.trainer).toBeNull();
+    });
+  });
+
+  describe("/api/inference/chat", () => {
+    const ORIG_FETCH = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = ORIG_FETCH;
+    });
+
+    it("auto-bootstraps project state and proxies base-model inference", async () => {
+      await writeCredentials(ANON_CREDS);
+      // No state.json — server should derive a slug from cwd, create the
+      // project on cloud-api, persist state, and forward the inference call.
+
+      const calls: Array<{ url: string; method: string; body?: string }> = [];
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        const body = typeof init?.body === "string" ? init.body : undefined;
+        calls.push({ url, method, body });
+        if (url.includes("/v1/projects") && method === "POST") {
+          return new Response(
+            JSON.stringify({
+              project: {
+                id: "p-bootstrap",
+                slug: "auto-slug",
+                name: "auto",
+                orgId: "anon-org-id",
+              },
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/v1/inference/chat")) {
+          return new Response("data: {\"content\":\"hi\"}\n\n", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${method} ${url}`);
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/inference/chat", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          baseModel: "unsloth/gemma-4-e4b-it",
+          messages: [{ role: "user", content: "hello" }],
+          stream: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+      const text = await res.text();
+      expect(text).toContain('"content":"hi"');
+
+      // State was persisted using the bootstrapped project's slug.
+      const statePath = join(trainCwd, ".arkor", "state.json");
+      expect(existsSync(statePath)).toBe(true);
+      const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+        orgSlug: string;
+        projectSlug: string;
+        projectId: string;
+      };
+      expect(state).toEqual({
+        orgSlug: "anon-org",
+        projectSlug: "auto-slug",
+        projectId: "p-bootstrap",
+      });
+
+      // Inference request carried the bootstrapped scope and the body verbatim.
+      const chat = calls.find((c) => c.url.includes("/v1/inference/chat"));
+      expect(chat).toBeDefined();
+      expect(chat!.url).toContain("orgSlug=anon-org");
+      expect(chat!.url).toContain("projectSlug=auto-slug");
+      expect(chat!.body).toContain("unsloth/gemma-4-e4b-it");
+    });
+
+    it("proxies inference using existing state without re-creating a project", async () => {
+      await writeCredentials(ANON_CREDS);
+      await writeState(
+        { orgSlug: "anon-org", projectSlug: "existing", projectId: "p-existing" },
+        trainCwd,
+      );
+
+      const calls: Array<{ url: string; method: string }> = [];
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        calls.push({ url, method });
+        if (url.includes("/v1/inference/chat")) {
+          return new Response("data: {\"content\":\"ok\"}\n\n", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${method} ${url}`);
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/inference/chat", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          baseModel: "unsloth/gemma-4-e4b-it",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      // Only the inference call should have hit the network — no project
+      // create/list when state is already present.
+      expect(calls.filter((c) => c.url.includes("/v1/projects"))).toHaveLength(0);
+      const chat = calls.find((c) => c.url.includes("/v1/inference/chat"));
+      expect(chat!.url).toContain("projectSlug=existing");
     });
   });
 });

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -530,5 +530,67 @@ process.exit(0);
       const chat = calls.find((c) => c.url.includes("/v1/inference/chat"));
       expect(chat!.url).toContain("projectSlug=existing");
     });
+
+    it("propagates the cloud-api status when project bootstrap fails", async () => {
+      await writeCredentials(ANON_CREDS);
+      // No state.json — bootstrap will hit cloud-api, which returns 503.
+      // We expect that 503 to be passed through, not collapsed to 400.
+
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("/v1/projects") && method === "POST") {
+          return new Response(JSON.stringify({ error: "upstream is down" }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${method} ${url}`);
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/inference/chat", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          baseModel: "unsloth/gemma-4-e4b-it",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toMatch(/upstream is down/);
+    });
+
+    it("returns 500 with a controlled body when getCredentials throws", async () => {
+      // autoAnonymous: false + no credentials → getCredentials() throws inside
+      // the handler. Previously this surfaced as an unhandled 500 from Hono's
+      // default error path; now it's caught and returned as a structured
+      // response so clients can render the error.
+      const app = build(); // build() uses autoAnonymous: false
+      const res = await app.request("/api/inference/chat", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          baseModel: "unsloth/gemma-4-e4b-it",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toMatch(/credentials|login/i);
+    });
   });
 });

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -3,6 +3,7 @@ import { readFile, realpath } from "node:fs/promises";
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { createClient } from "@arkor/cloud-api-client";
+import { CloudApiClient } from "../core/client";
 import {
   defaultArkorCloudApiUrl,
   readCredentials,
@@ -10,6 +11,7 @@ import {
   requestAnonymousToken,
   type Credentials,
 } from "../core/credentials";
+import { ensureProjectState } from "../core/projectState";
 import { readState } from "../core/state";
 import { readManifestSummary } from "./manifest";
 import { fileURLToPath } from "node:url";
@@ -276,10 +278,21 @@ export function buildStudioApp(options: StudioServerOptions) {
   });
 
   // Playground hits this so mid-training inference from Studio has the same
-  // auth path as the rest of /api/*.
+  // auth path as the rest of /api/*. State is auto-bootstrapped (anon only)
+  // so the Playground's base-model mode works on a fresh launch with no
+  // prior `arkor init`.
   app.post("/api/inference/chat", async (c) => {
-    const state = await readState();
-    if (!state) return c.json({ error: "No project state" }, 400);
+    const credentials = await getCredentials();
+    let state;
+    try {
+      const client = new CloudApiClient({ baseUrl, credentials });
+      state = await ensureProjectState({ cwd: trainCwd, client, credentials });
+    } catch (err) {
+      return c.json(
+        { error: err instanceof Error ? err.message : String(err) },
+        400,
+      );
+    }
     const token = await getToken();
     const body = await c.req.text();
     const url = `${baseUrl}/v1/inference/chat?orgSlug=${encodeURIComponent(state.orgSlug)}&projectSlug=${encodeURIComponent(state.projectSlug)}`;

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -3,7 +3,7 @@ import { readFile, realpath } from "node:fs/promises";
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { createClient } from "@arkor/cloud-api-client";
-import { CloudApiClient } from "../core/client";
+import { CloudApiClient, CloudApiError } from "../core/client";
 import {
   defaultArkorCloudApiUrl,
   readCredentials,
@@ -282,18 +282,31 @@ export function buildStudioApp(options: StudioServerOptions) {
   // so the Playground's base-model mode works on a fresh launch with no
   // prior `arkor init`.
   app.post("/api/inference/chat", async (c) => {
-    const credentials = await getCredentials();
-    let state;
+    let credentials: Credentials;
+    let state: { orgSlug: string; projectSlug: string };
     try {
+      credentials = await getCredentials();
       const client = new CloudApiClient({ baseUrl, credentials });
       state = await ensureProjectState({ cwd: trainCwd, client, credentials });
     } catch (err) {
+      // Propagate cloud-api's status verbatim (e.g. 401 / 403 / 5xx) so the
+      // SPA / clients can react appropriately — collapsing everything to 400
+      // would mis-report upstream outages and auth failures. Anything else
+      // (local writeState failures, missing-credentials guard) is treated as
+      // a server-side error.
+      if (err instanceof CloudApiError) {
+        return new Response(JSON.stringify({ error: err.message }), {
+          status: err.status,
+          headers: { "content-type": "application/json" },
+        });
+      }
       return c.json(
         { error: err instanceof Error ? err.message : String(err) },
-        400,
+        500,
       );
     }
-    const token = await getToken();
+    const token =
+      credentials.mode === "anon" ? credentials.token : credentials.accessToken;
     const body = await c.req.text();
     const url = `${baseUrl}/v1/inference/chat?orgSlug=${encodeURIComponent(state.orgSlug)}&projectSlug=${encodeURIComponent(state.projectSlug)}`;
     const upstream = await fetch(url, {

--- a/packages/studio-app/src/lib/baseModels.ts
+++ b/packages/studio-app/src/lib/baseModels.ts
@@ -1,0 +1,10 @@
+/**
+ * Base models the Studio Playground can target without an adapter. This list
+ * must mirror what cloud-api accepts on `/v1/inference/chat` for `baseModel`;
+ * sending an unsupported value produces a 4xx from upstream.
+ */
+export const SUPPORTED_BASE_MODELS = ["unsloth/gemma-4-e4b-it"] as const;
+
+export type SupportedBaseModel = (typeof SUPPORTED_BASE_MODELS)[number];
+
+export const DEFAULT_BASE_MODEL: SupportedBaseModel = SUPPORTED_BASE_MODELS[0];

--- a/packages/studio-app/src/pages/Playground.tsx
+++ b/packages/studio-app/src/pages/Playground.tsx
@@ -1,14 +1,24 @@
 import { useEffect, useRef, useState } from "react";
 import { fetchJobs, streamInferenceContent, type Job } from "../lib/api";
+import {
+  DEFAULT_BASE_MODEL,
+  SUPPORTED_BASE_MODELS,
+  type SupportedBaseModel,
+} from "../lib/baseModels";
 
 interface Message {
   role: "system" | "user" | "assistant";
   content: string;
 }
 
+type Mode = "base" | "adapter";
+
 export function Playground() {
   const [jobs, setJobs] = useState<Job[]>([]);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("base");
+  const [baseModel, setBaseModel] =
+    useState<SupportedBaseModel>(DEFAULT_BASE_MODEL);
+  const [selectedJob, setSelectedJob] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
@@ -18,12 +28,17 @@ export function Playground() {
     fetchJobs().then(({ jobs }) => {
       const completed = jobs.filter((j) => j.status === "completed");
       setJobs(completed);
-      if (completed.length > 0) setSelected(completed[0]!.id);
+      if (completed.length > 0) setSelectedJob(completed[0]!.id);
     });
   }, []);
 
+  const canSend =
+    !streaming &&
+    input.trim().length > 0 &&
+    (mode === "base" || (mode === "adapter" && selectedJob !== null));
+
   async function send() {
-    if (!input.trim() || !selected) return;
+    if (!canSend) return;
     const userMsg: Message = { role: "user", content: input };
     setMessages((prev) => [...prev, userMsg, { role: "assistant", content: "" }]);
     setInput("");
@@ -32,7 +47,9 @@ export function Playground() {
 
     try {
       const stream = streamInferenceContent({
-        adapter: { kind: "final", jobId: selected },
+        ...(mode === "base"
+          ? { baseModel }
+          : { adapter: { kind: "final", jobId: selectedJob! } }),
         messages: [...messages, userMsg],
         stream: true,
       });
@@ -61,49 +78,90 @@ export function Playground() {
   return (
     <div className="playground">
       <h2>Playground</h2>
-      {jobs.length === 0 ? (
-        <p className="muted">No completed jobs yet.</p>
-      ) : (
-        <>
-          <label>
-            Adapter:
-            <select
-              value={selected ?? ""}
-              onChange={(e) => setSelected(e.target.value)}
-            >
-              {jobs.map((j) => (
-                <option key={j.id} value={j.id}>
-                  {j.name} ({j.id.slice(0, 8)})
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="chat">
-            {messages.map((m, i) => (
-              <div key={i} className={`msg msg-${m.role}`}>
-                <span className="msg-role">{m.role}</span>
-                <span className="msg-content">{m.content}</span>
-              </div>
-            ))}
-          </div>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              send();
-            }}
+      <fieldset className="mode-select">
+        <legend>Mode</legend>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="base"
+            checked={mode === "base"}
+            onChange={() => setMode("base")}
+            disabled={streaming}
+          />
+          Base model
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="adapter"
+            checked={mode === "adapter"}
+            onChange={() => setMode("adapter")}
+            disabled={streaming}
+          />
+          Adapter
+        </label>
+      </fieldset>
+      {mode === "base" ? (
+        <label>
+          Base model:
+          <select
+            value={baseModel}
+            disabled={streaming}
+            onChange={(e) => setBaseModel(e.target.value as SupportedBaseModel)}
           >
-            <input
-              value={input}
-              disabled={streaming}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Say something…"
-            />
-            <button type="submit" disabled={streaming || !input.trim()}>
-              Send
-            </button>
-          </form>
-        </>
+            {SUPPORTED_BASE_MODELS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : jobs.length === 0 ? (
+        <p className="muted">
+          No completed jobs yet. Train one, or switch to <em>Base model</em>.
+        </p>
+      ) : (
+        <label>
+          Adapter:
+          <select
+            value={selectedJob ?? ""}
+            disabled={streaming}
+            onChange={(e) => setSelectedJob(e.target.value)}
+          >
+            {jobs.map((j) => (
+              <option key={j.id} value={j.id}>
+                {j.name} ({j.id.slice(0, 8)})
+              </option>
+            ))}
+          </select>
+        </label>
       )}
+      <div className="chat">
+        {messages.map((m, i) => (
+          <div key={i} className={`msg msg-${m.role}`}>
+            <span className="msg-role">{m.role}</span>
+            <span className="msg-content">{m.content}</span>
+          </div>
+        ))}
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          send();
+        }}
+      >
+        <input
+          value={input}
+          disabled={streaming}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Say something…"
+        />
+        <button type="submit" disabled={!canSend}>
+          Send
+        </button>
+      </form>
     </div>
   );
 }

--- a/packages/studio-app/src/styles.css
+++ b/packages/studio-app/src/styles.css
@@ -155,6 +155,9 @@ td code {
 
 .playground label { display: block; margin: 8px 0; }
 .playground select { margin-left: 8px; background: var(--panel); color: var(--text); border: 1px solid var(--border); padding: 6px 8px; }
+.playground .mode-select { border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; margin: 8px 0; }
+.playground .mode-select legend { font-size: 12px; color: var(--muted); padding: 0 6px; }
+.playground .mode-select label { display: inline-flex; align-items: center; gap: 6px; margin: 0 12px 0 0; }
 .playground .chat {
   background: var(--panel);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Add a Base / Adapter mode toggle to the Studio Playground. Base mode is the default, so users can hit inference immediately on a fresh launch without first training and selecting a completed job. Currently only `unsloth/gemma-4-e4b-it` is supported (cloud-api enforces the allow-list).
- Auto-bootstrap project state in `/api/inference/chat`. Previously the handler returned 400 when `.arkor/state.json` was absent; for anonymous credentials it now derives a project slug from the cwd basename, creates (or reuses on 409) the project, and persists state — same behaviour the trainer already had at `start()`.
- Extract `ensureProjectState` from `createTrainer`'s closure into `core/projectState.ts` and reuse it from both the trainer and the Studio server.

## Test plan
- [x] `turbo typecheck test --filter=arkor --filter=@arkor/studio-app` (11 files / 74 tests)
- [x] New `server.test.ts` cases: state-absent path bootstraps and forwards inference; state-present path skips project create
- [ ] Manual: `arkor dev` in a fresh directory → Playground → Base model → send a prompt without running training first
- [ ] Manual: existing project with completed jobs → switch to Adapter mode → confirm previous flow still works
