### PR TITLE
build(tsdown): minify CLI bundles to shrink published tarballs

### DIFF
--- a/packages/arkor/tsdown.config.ts
+++ b/packages/arkor/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
+  minify: true,
   sourcemap: true,
   tsconfig: "./tsconfig.build.json",
   // `@arkor/cli-internal` is a private workspace package — bundle its source

--- a/packages/create-arkor/tsdown.config.ts
+++ b/packages/create-arkor/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   format: ["esm"],
   dts: false,
   clean: true,
+  minify: true,
   sourcemap: true,
   tsconfig: "./tsconfig.build.json",
   // `@arkor/cli-internal` is a private workspace package — bundle its source

--- a/packages/create-arkor/tsdown.config.ts
+++ b/packages/create-arkor/tsdown.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   dts: false,
   clean: true,
   minify: true,
-  sourcemap: true,
+  sourcemap: false,
   tsconfig: "./tsconfig.build.json",
   // `@arkor/cli-internal` is a private workspace package — bundle its source
   // into the published tarball so consumers don't depend on something that


### PR DESCRIPTION
## Summary

Both published CLI packages were shipping unminified bundles. The Studio SPA (Vite) was already minified by default, but `packages/arkor` and `packages/create-arkor` ran tsdown without `minify`, so the `arkor` and `create-arkor` tarballs on npm were ~40% larger than necessary.

- **`packages/arkor`** — enable `minify: true`. Sourcemap stays on because `dist/index.mjs` is the SDK entry imported by user code, where bundlers/`--enable-source-maps` resolve stack traces back to original sources.
- **`packages/create-arkor`** — enable `minify: true` *and* `sourcemap: false`. This package is a one-shot scaffolder; users don't debug into it, so the ~41 kB sourcemap is pure tarball bloat.

## Size impact

`packages/arkor/dist/` (minified vs. previous):

| File | Before | After | Δ |
|---|---|---|---|
| `bin.mjs` | 44.3 kB | 27.3 kB | -38% |
| `index.mjs` | 9.1 kB | 5.2 kB | -43% |
| `runner-*.mjs` | 11.5 kB | 6.1 kB | -47% |

`packages/create-arkor/dist/bin.mjs`: now **13.0 kB** alone (no `.mjs.map`), versus a prior `bin.mjs` + `bin.mjs.map` pair where the map dominated the payload.

## Why keep sourcemaps on `arkor` but drop on `create-arkor`

tsdown's `sourcemap` is a per-config flag, not per-entry, so we can't selectively strip the map for `bin.mjs` while keeping it for `index.mjs`. Since `arkor` exposes both a CLI and an SDK from the same config, the SDK consumer DX wins: keep the maps. `create-arkor` is CLI-only and scaffolders rarely produce actionable stack traces for end users, so dropping is safe.

Shebang preservation, exec-bit (`chmod +x`), and `dist/index.d.mts` emission are unaffected — tsdown handles all three orthogonally to `minify`.

## Test plan

- [x] `pnpm --filter arkor build` succeeds; `dist/bin.mjs` keeps `#!/usr/bin/env node` and mode `755`
- [x] `pnpm --filter create-arkor build` succeeds; `dist/` contains only `bin.mjs` (no `.map`)
- [x] `node packages/arkor/dist/bin.mjs --version` prints `0.0.1-alpha.0`
- [x] `node packages/arkor/dist/bin.mjs --help` lists all subcommands
- [x] `node packages/create-arkor/dist/bin.mjs --help` renders the scaffolder usage
- [ ] After alpha publish: tarball size on npm reflects the reduction (`npm pack --dry-run` locally as a proxy)
