### PR TITLE
ci(release): retry npm view in verify step to tolerate registry lag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,8 +183,24 @@ jobs:
       - name: Verify published packages
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
+          MAX_ATTEMPTS=120
+          SLEEP_SECONDS=5
           for PKG in arkor create-arkor; do
-            npm view "$PKG@$VERSION" version
+            attempt=1
+            while true; do
+              RESOLVED="$(npm view "$PKG@$VERSION" version 2>/dev/null || true)"
+              if [[ "$RESOLVED" == "$VERSION" ]]; then
+                echo "$PKG@$VERSION verified"
+                break
+              fi
+              if (( attempt >= MAX_ATTEMPTS )); then
+                echo "Failed to verify $PKG@$VERSION after $MAX_ATTEMPTS attempts (last response: '${RESOLVED:-<empty>}')"
+                exit 1
+              fi
+              echo "Attempt $attempt/$MAX_ATTEMPTS: $PKG@$VERSION not yet visible on registry, retrying in ${SLEEP_SECONDS}s..."
+              attempt=$((attempt + 1))
+              sleep "$SLEEP_SECONDS"
+            done
           done
 
       - name: Create draft GitHub Release


### PR DESCRIPTION
## Summary
- The `Verify published packages` step in [release.yaml](.github/workflows/release.yaml) ran `npm view` immediately after `pnpm publish` and treated a single 404 as a fatal error.
- During the `v0.0.1-alpha.1` release the publish itself succeeded for both packages, but the verify step ran <1s after publish and got a 404 for `create-arkor` because the registry index hadn't replicated yet, failing the workflow and skipping the draft GitHub Release step.
- Wrap the `npm view` call in a poll loop (5s interval, up to 120 attempts → ~10 min budget) so transient registry replication lag — including longer lags during npm incidents — no longer fails the release.

The retry only treats an exact version match as success, so a stale "previous version" response still counts as not-yet-visible and keeps polling.

## Test plan
- [ ] Workflow YAML lints cleanly (no syntax errors)
- [ ] Next release tag triggers the workflow and the verify step succeeds on the first attempt for the normal case
- [ ] If verification never succeeds within ~10 min, the step exits 1 with the last response logged
