### PR TITLE
ci(release): use npm CLI for publish so README populates the registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,20 +165,18 @@ jobs:
       - name: Publish arkor to npm
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
-          pnpm publish "$RUNNER_TEMP/npm-pack/arkor-$VERSION.tgz" \
+          npm publish "$RUNNER_TEMP/npm-pack/arkor-$VERSION.tgz" \
             --access public \
             --tag "${{ steps.meta.outputs.npm_tag }}" \
-            --provenance \
-            --no-git-checks
+            --provenance
 
       - name: Publish create-arkor to npm
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
-          pnpm publish "$RUNNER_TEMP/npm-pack/create-arkor-$VERSION.tgz" \
+          npm publish "$RUNNER_TEMP/npm-pack/create-arkor-$VERSION.tgz" \
             --access public \
             --tag "${{ steps.meta.outputs.npm_tag }}" \
-            --provenance \
-            --no-git-checks
+            --provenance
 
       - name: Verify published packages
         run: |


### PR DESCRIPTION
## Summary
- Switch the two publish steps in [release.yaml](.github/workflows/release.yaml) from `pnpm publish <tarball>` to `npm publish <tarball>`.
- Remove the `--no-git-checks` flag (pnpm-specific; npm publish does not perform git checks on a tarball publish).
- Keep `--access`, `--tag`, `--provenance` — same flags on both CLIs.

### Why
After the `0.0.1-alpha.1` release, the `arkor` and `create-arkor` pages on npmjs.com rendered with empty READMEs. The tarballs themselves contained `README.md` (4.3 kB / 3.8 kB), but the registry packument metadata had `readme = ''`:

