### PR TITLE
Send X-Arkor-Client during anonymous token bootstrap

### DIFF
--- a/packages/arkor/src/core/credentials.test.ts
+++ b/packages/arkor/src/core/credentials.test.ts
@@ -8,13 +8,16 @@ import {
   credentialsPath,
   getToken,
   defaultArkorCloudApiUrl,
+  requestAnonymousToken,
   type AnonymousCredentials,
   type Auth0Credentials,
 } from "./credentials";
+import { SDK_VERSION } from "./version";
 
 let fakeHome: string;
 const ORIG_HOME = process.env.HOME;
 const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
+const ORIG_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-creds-test-"));
@@ -25,6 +28,7 @@ afterEach(() => {
   process.env.HOME = ORIG_HOME;
   if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;
   else delete process.env.ARKOR_CLOUD_API_URL;
+  globalThis.fetch = ORIG_FETCH;
   rmSync(fakeHome, { recursive: true, force: true });
 });
 
@@ -95,5 +99,74 @@ describe("defaultArkorCloudApiUrl", () => {
   it("falls back to https://api.arkor.ai", () => {
     delete process.env.ARKOR_CLOUD_API_URL;
     expect(defaultArkorCloudApiUrl()).toBe("https://api.arkor.ai");
+  });
+});
+
+describe("requestAnonymousToken", () => {
+  // Without X-Arkor-Client the cloud-api SDK version gate returns 426
+  // reason=missing on /v1/auth/anonymous, which makes anonymous bootstrap
+  // (and therefore `arkor dev` on a fresh install) impossible.
+  it("sends X-Arkor-Client so the SDK version gate accepts the bootstrap call", async () => {
+    let captured: { url: string; init: RequestInit | undefined } | null = null;
+    globalThis.fetch = (async (
+      input: Parameters<typeof fetch>[0],
+      init?: RequestInit,
+    ) => {
+      captured = { url: String(input), init };
+      return new Response(
+        JSON.stringify({
+          token: "anon-tok",
+          anonymousId: "anon-aid",
+          kind: "cli",
+          personalOrg: { id: "o", slug: "anon-aid", name: "Anon" },
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await requestAnonymousToken("http://mock-cloud-api", "cli");
+
+    expect(captured).not.toBeNull();
+    const { url, init } = captured!;
+    expect(url).toBe("http://mock-cloud-api/v1/auth/anonymous");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("X-Arkor-Client")).toBe(`arkor/${SDK_VERSION}`);
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("returns the parsed token shape", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          token: "anon-tok",
+          anonymousId: "anon-aid",
+          kind: "cli",
+          personalOrg: { id: "o", slug: "anon-aid", name: "Anon" },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+
+    const result = await requestAnonymousToken(
+      "http://mock-cloud-api",
+      "cli",
+    );
+    expect(result).toEqual({
+      token: "anon-tok",
+      anonymousId: "anon-aid",
+      kind: "cli",
+      orgSlug: "anon-aid",
+    });
+  });
+
+  it("throws with status and body snippet on non-2xx", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ error: "sdk_version_unsupported", reason: "missing" }),
+        { status: 426 },
+      )) as typeof fetch;
+
+    await expect(
+      requestAnonymousToken("http://mock-cloud-api", "cli"),
+    ).rejects.toThrow(/426/);
   });
 });

--- a/packages/arkor/src/core/credentials.ts
+++ b/packages/arkor/src/core/credentials.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { anonymousTokenResponseSchema } from "./schemas";
+import { SDK_VERSION } from "./version";
 
 export interface Auth0Credentials {
   mode: "auth0";
@@ -88,7 +89,10 @@ export async function requestAnonymousToken(
 }> {
   const res = await fetch(`${baseUrl}/v1/auth/anonymous`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Arkor-Client": `arkor/${SDK_VERSION}`,
+    },
     body: JSON.stringify({ kind }),
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary

`requestAnonymousToken` was the one SDK call path that issued a raw `fetch`
instead of going through `createClient(...)`, so it never set the
`X-Arkor-Client: arkor/<version>` header. The cloud API's SDK version gate
rejects header-less requests with `426 sdk_version_unsupported`
(`reason: "missing"`) — even while `SUPPORTED_RANGE` is `*`, by design, so
that pre-header SDK builds can't silently bypass policy during rollout.

End-to-end effect: on a fresh install with no `~/.arkor/credentials.json`,
`arkor dev` fails to bootstrap an anonymous identity and exits with:

```
Error: Failed to acquire anonymous token (426): {"error":"sdk_version_unsupported","currentVersion":"unknown","supportedRange":"*","upgrade":"npm install -g arkor@latest","reason":"missing"}
```


This blocks the `npm create arkor` → `arkor dev` happy path on every
machine that hasn't been onboarded yet.

## Changes

- `packages/arkor/src/core/credentials.ts`: add
  `X-Arkor-Client: arkor/${SDK_VERSION}` to the bootstrap fetch.
- `packages/arkor/src/core/credentials.test.ts`: new `requestAnonymousToken`
  describe block covering (a) the header is present on the wire, (b) the
  response shape is mapped correctly, (c) non-2xx surfaces the status.

## Test plan

- [ ] `pnpm --filter arkor test` — green (12 files / 93 tests)
- [ ] `pnpm typecheck` — clean workspace-wide
- [ ] Manual: delete `~/.arkor/credentials.json`, run `arkor dev` against a
      deployment with the gate enabled, confirm anonymous bootstrap completes
      and Studio reaches `/api/credentials`.

## Follow-up

- Cut a new `arkor` alpha so users unblocked by this fix can `pnpm add arkor@alpha`.
- Consider a lint rule or test that fails if any `/v1/*` request in this
  package is built without going through `createClient` (would have caught
  this at PR time).
