### PR TITLE
feat(cli): add PostHog telemetry to all CLI commands

### DIFF
--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -144,6 +144,32 @@ import {
 `runTrainer(file?)` is exported for power-user embedding (e.g. running
 training from a custom Node script). `arkor start` uses it under the hood.
 
+## Telemetry
+
+The CLI sends anonymous usage events to PostHog so we can see which commands
+are being run and where they fail. Three events are emitted per invocation:
+
+- `cli_command_started`
+- `cli_command_completed` (includes `duration_ms`)
+- `cli_command_failed` (includes `duration_ms`, `error_name`, and the first
+  200 chars of `error_message`)
+
+Each event carries `command`, `sdk_version`, `node_version`, `platform`, and
+`auth_mode` (`auth0` / `anon` / `none`). The distinct ID is your Auth0 `sub`
+when logged in, your `anonymousId` after `arkor login --anonymous`, or a
+locally generated UUID stored at `~/.arkor/telemetry-id`.
+
+To opt out, set either of the following before running any `arkor` command:
+
+```sh
+export DO_NOT_TRACK=1
+# or
+export ARKOR_TELEMETRY_DISABLED=1
+```
+
+When opted out the PostHog client is never instantiated and no network
+request is made.
+
 ## License
 
-MIT — see [LICENSE.md](./LICENSE.md).
+MIT. See [LICENSE.md](./LICENSE.md).

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -54,6 +54,7 @@
     "esbuild": "^0.28.0",
     "hono": "^4.7.0",
     "open": "^10.0.0",
+    "posthog-node": "^5.30.6",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -54,7 +54,7 @@
     "esbuild": "^0.28.0",
     "hono": "^4.7.0",
     "open": "^10.0.0",
-    "posthog-node": "~5.21.0",
+    "posthog-node": "^5.30.6",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -54,7 +54,7 @@
     "esbuild": "^0.28.0",
     "hono": "^4.7.0",
     "open": "^10.0.0",
-    "posthog-node": "^5.30.6",
+    "posthog-node": "~5.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/arkor/src/cli/main.ts
+++ b/packages/arkor/src/cli/main.ts
@@ -129,12 +129,16 @@ export async function main(argv: string[]): Promise<void> {
     .option("-p, --port <port>", "Port to bind (default: 4000)", "4000")
     .option("--no-browser", "Do not open the browser")
     .action(
-      withTelemetry("dev", async (opts: { port: string; browser?: boolean }) => {
-        await runDev({
-          port: Number(opts.port) || 4000,
-          noBrowser: opts.browser === false,
-        });
-      }),
+      withTelemetry(
+        "dev",
+        async (opts: { port: string; browser?: boolean }) => {
+          await runDev({
+            port: Number(opts.port) || 4000,
+            noBrowser: opts.browser === false,
+          });
+        },
+        { longRunning: true },
+      ),
     );
 
   try {

--- a/packages/arkor/src/cli/main.ts
+++ b/packages/arkor/src/cli/main.ts
@@ -8,6 +8,7 @@ import { runBuild } from "./commands/build";
 import { runStart } from "./commands/start";
 import { resolvePackageManager, type TemplateId } from "@arkor/cli-internal";
 import { getRecordedDeprecation } from "../core/deprecation";
+import { shutdownTelemetry, withTelemetry } from "../core/telemetry";
 import { detectedUpgradeCommand } from "../core/upgrade-hint";
 import { SDK_VERSION } from "../core/version";
 import { ui } from "./prompts";
@@ -33,7 +34,7 @@ export async function main(argv: string[]): Promise<void> {
     )
     .option("--skip-git", "Skip the git init prompt and do not initialise git")
     .action(
-      async (opts: {
+      withTelemetry("init", async (opts: {
         yes?: boolean;
         name?: string;
         template?: string;
@@ -63,7 +64,7 @@ export async function main(argv: string[]): Promise<void> {
           git: opts.git,
           skipGit: opts.skipGit,
         });
-      },
+      }),
     );
 
   program
@@ -72,7 +73,7 @@ export async function main(argv: string[]): Promise<void> {
     .option("--anonymous", "Issue a throwaway anonymous token instead")
     .option("--no-browser", "Print the URL instead of opening a browser")
     .action(
-      async (opts: {
+      withTelemetry("login", async (opts: {
         anonymous?: boolean;
         browser?: boolean;
       }) => {
@@ -80,51 +81,61 @@ export async function main(argv: string[]): Promise<void> {
           anonymous: opts.anonymous,
           noBrowser: opts.browser === false,
         });
-      },
+      }),
     );
 
   program
     .command("logout")
     .description("Delete ~/.arkor/credentials.json")
     .option("-y, --yes", "Skip confirmation")
-    .action(async (opts: { yes?: boolean }) => {
-      await runLogout({ yes: opts.yes });
-    });
+    .action(
+      withTelemetry("logout", async (opts: { yes?: boolean }) => {
+        await runLogout({ yes: opts.yes });
+      }),
+    );
 
   program
     .command("whoami")
     .description("Print the current identity and reachable orgs")
-    .action(async () => {
-      await runWhoami();
-    });
+    .action(
+      withTelemetry("whoami", async () => {
+        await runWhoami();
+      }),
+    );
 
   program
     .command("build")
     .description("Bundle src/arkor/index.ts into .arkor/build/index.mjs")
     .argument("[entry]", "path to the source entry (default: src/arkor/index.ts)")
-    .action(async (entry?: string) => {
-      await runBuild({ entry });
-    });
+    .action(
+      withTelemetry("build", async (entry?: string) => {
+        await runBuild({ entry });
+      }),
+    );
 
   program
     .command("start")
     .description("Run the build artifact at .arkor/build/index.mjs")
     .argument("[entry]", "rebuild from this entry before running (optional)")
-    .action(async (entry?: string) => {
-      await runStart({ entry });
-    });
+    .action(
+      withTelemetry("start", async (entry?: string) => {
+        await runStart({ entry });
+      }),
+    );
 
   program
     .command("dev")
     .description("Launch Arkor Studio locally")
     .option("-p, --port <port>", "Port to bind (default: 4000)", "4000")
     .option("--no-browser", "Do not open the browser")
-    .action(async (opts: { port: string; browser?: boolean }) => {
-      await runDev({
-        port: Number(opts.port) || 4000,
-        noBrowser: opts.browser === false,
-      });
-    });
+    .action(
+      withTelemetry("dev", async (opts: { port: string; browser?: boolean }) => {
+        await runDev({
+          port: Number(opts.port) || 4000,
+          noBrowser: opts.browser === false,
+        });
+      }),
+    );
 
   try {
     await program.parseAsync(argv, { from: "user" });
@@ -136,5 +147,6 @@ export async function main(argv: string[]): Promise<void> {
         `${notice.message} (current: ${SDK_VERSION}).${sunset} Run \`${detectedUpgradeCommand()}\`.`,
       );
     }
+    await shutdownTelemetry();
   }
 }

--- a/packages/arkor/src/core/telemetry.test.ts
+++ b/packages/arkor/src/core/telemetry.test.ts
@@ -34,6 +34,7 @@ interface TelemetryModule {
   withTelemetry: <TArgs extends unknown[]>(
     command: string,
     handler: (...args: TArgs) => Promise<void>,
+    options?: { longRunning?: boolean },
   ) => (...args: TArgs) => Promise<void>;
   shutdownTelemetry: () => Promise<void>;
 }
@@ -244,5 +245,31 @@ describe("withTelemetry", () => {
     await expect(wrapped()).rejects.toThrow();
     const failed = captureMock.mock.calls[1][0];
     expect(failed.properties.error_message.length).toBe(200);
+  });
+
+  it("skips cli_command_completed for longRunning commands on success", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry(
+      "dev",
+      async () => {},
+      { longRunning: true },
+    );
+    await wrapped();
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    expect(captureMock.mock.calls[0][0].event).toBe("cli_command_started");
+  });
+
+  it("still emits cli_command_failed for longRunning commands that throw during bring-up", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry(
+      "dev",
+      async () => {
+        throw new Error("port in use");
+      },
+      { longRunning: true },
+    );
+    await expect(wrapped()).rejects.toThrow("port in use");
+    const events = captureMock.mock.calls.map((c) => c[0].event);
+    expect(events).toEqual(["cli_command_started", "cli_command_failed"]);
   });
 });

--- a/packages/arkor/src/core/telemetry.test.ts
+++ b/packages/arkor/src/core/telemetry.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { captureMock, shutdownMock, constructorMock } = vi.hoisted(() => ({
+  captureMock: vi.fn(),
+  shutdownMock: vi.fn(async () => {}),
+  constructorMock: vi.fn(),
+}));
+
+vi.mock("posthog-node", () => ({
+  PostHog: class {
+    capture = captureMock;
+    shutdown = shutdownMock;
+    constructor(...args: unknown[]) {
+      constructorMock(...args);
+    }
+  },
+}));
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_DO_NOT_TRACK = process.env.DO_NOT_TRACK;
+const ORIG_DISABLED = process.env.ARKOR_TELEMETRY_DISABLED;
+
+let fakeHome: string;
+
+interface TelemetryModule {
+  isEnabled: () => boolean;
+  getIdentity: () => Promise<{
+    distinctId: string;
+    authMode: "auth0" | "anon" | "none";
+  }>;
+  withTelemetry: <TArgs extends unknown[]>(
+    command: string,
+    handler: (...args: TArgs) => Promise<void>,
+  ) => (...args: TArgs) => Promise<void>;
+  shutdownTelemetry: () => Promise<void>;
+}
+
+async function loadTelemetry(opts: {
+  key?: string;
+  host?: string;
+} = {}): Promise<TelemetryModule> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (opts.key !== undefined) g.__ARKOR_POSTHOG_KEY__ = opts.key;
+  else delete g.__ARKOR_POSTHOG_KEY__;
+  if (opts.host !== undefined) g.__ARKOR_POSTHOG_HOST__ = opts.host;
+  else delete g.__ARKOR_POSTHOG_HOST__;
+  vi.resetModules();
+  return (await import("./telemetry")) as TelemetryModule;
+}
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(join(tmpdir(), "arkor-telemetry-test-"));
+  process.env.HOME = fakeHome;
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.ARKOR_TELEMETRY_DISABLED;
+  captureMock.mockClear();
+  shutdownMock.mockClear();
+  constructorMock.mockClear();
+});
+
+afterEach(() => {
+  process.env.HOME = ORIG_HOME;
+  if (ORIG_DO_NOT_TRACK !== undefined) process.env.DO_NOT_TRACK = ORIG_DO_NOT_TRACK;
+  else delete process.env.DO_NOT_TRACK;
+  if (ORIG_DISABLED !== undefined) process.env.ARKOR_TELEMETRY_DISABLED = ORIG_DISABLED;
+  else delete process.env.ARKOR_TELEMETRY_DISABLED;
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+describe("isEnabled", () => {
+  it("returns false when DO_NOT_TRACK=1", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const mod = await loadTelemetry({ key: "phc_test" });
+    expect(mod.isEnabled()).toBe(false);
+  });
+
+  it("returns false when ARKOR_TELEMETRY_DISABLED=1", async () => {
+    process.env.ARKOR_TELEMETRY_DISABLED = "1";
+    const mod = await loadTelemetry({ key: "phc_test" });
+    expect(mod.isEnabled()).toBe(false);
+  });
+
+  it("returns false when DO_NOT_TRACK is any truthy string", async () => {
+    process.env.DO_NOT_TRACK = "true";
+    const mod = await loadTelemetry({ key: "phc_test" });
+    expect(mod.isEnabled()).toBe(false);
+  });
+
+  it("treats DO_NOT_TRACK=0 as disabled flag NOT set", async () => {
+    process.env.DO_NOT_TRACK = "0";
+    const mod = await loadTelemetry({ key: "phc_test" });
+    expect(mod.isEnabled()).toBe(true);
+  });
+
+  it("returns false when the build-time PostHog key is empty", async () => {
+    const mod = await loadTelemetry({ key: "" });
+    expect(mod.isEnabled()).toBe(false);
+  });
+
+  it("returns false when the build-time PostHog key is undefined (vitest default)", async () => {
+    const mod = await loadTelemetry({});
+    expect(mod.isEnabled()).toBe(false);
+  });
+
+  it("returns true when key is set and no opt-out flags are present", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    expect(mod.isEnabled()).toBe(true);
+  });
+});
+
+describe("getIdentity", () => {
+  function writeCreds(content: object): void {
+    const dir = join(fakeHome, ".arkor");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "credentials.json"), JSON.stringify(content));
+  }
+
+  it("returns anonymousId for anon credentials", async () => {
+    writeCreds({
+      mode: "anon",
+      token: "tok",
+      anonymousId: "anon-xyz",
+      arkorCloudApiUrl: "http://localhost",
+      orgSlug: "anon-xyz",
+    });
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const id = await mod.getIdentity();
+    expect(id).toEqual({ distinctId: "anon-xyz", authMode: "anon" });
+  });
+
+  it("returns sub for auth0 credentials with a decodable JWT", async () => {
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const payload = Buffer.from(JSON.stringify({ sub: "auth0|user-123" }))
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const accessToken = `${header}.${payload}.signature`;
+    writeCreds({
+      mode: "auth0",
+      accessToken,
+      refreshToken: "rt",
+      expiresAt: 0,
+      auth0Domain: "d",
+      audience: "a",
+      clientId: "c",
+    });
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const id = await mod.getIdentity();
+    expect(id).toEqual({ distinctId: "auth0|user-123", authMode: "auth0" });
+  });
+
+  it("creates and reuses ~/.arkor/telemetry-id when no credentials exist", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const first = await mod.getIdentity();
+    expect(first.authMode).toBe("none");
+    expect(first.distinctId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+
+    const stored = readFileSync(join(fakeHome, ".arkor", "telemetry-id"), "utf8").trim();
+    expect(stored).toBe(first.distinctId);
+
+    const second = await mod.getIdentity();
+    expect(second.distinctId).toBe(first.distinctId);
+  });
+
+  it("falls back to telemetry-id when auth0 token is malformed", async () => {
+    writeCreds({
+      mode: "auth0",
+      accessToken: "not-a-jwt",
+      refreshToken: "rt",
+      expiresAt: 0,
+      auth0Domain: "d",
+      audience: "a",
+      clientId: "c",
+    });
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const id = await mod.getIdentity();
+    expect(id.authMode).toBe("auth0");
+    expect(id.distinctId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(existsSync(join(fakeHome, ".arkor", "telemetry-id"))).toBe(true);
+  });
+});
+
+describe("withTelemetry", () => {
+  it("does not initialise the PostHog client when disabled by env var", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry("whoami", async () => {});
+    await wrapped();
+    expect(constructorMock).not.toHaveBeenCalled();
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("emits started + completed events on success", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry("whoami", async () => {});
+    await wrapped();
+    expect(captureMock).toHaveBeenCalledTimes(2);
+    const events = captureMock.mock.calls.map((c) => c[0].event);
+    expect(events).toEqual(["cli_command_started", "cli_command_completed"]);
+    const completed = captureMock.mock.calls[1][0];
+    expect(completed.properties.command).toBe("whoami");
+    expect(typeof completed.properties.duration_ms).toBe("number");
+    expect(completed.properties.auth_mode).toBe("none");
+  });
+
+  it("emits started + failed events and rethrows on error", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry("build", async () => {
+      throw new Error("boom");
+    });
+    await expect(wrapped()).rejects.toThrow("boom");
+    const events = captureMock.mock.calls.map((c) => c[0].event);
+    expect(events).toEqual(["cli_command_started", "cli_command_failed"]);
+    const failed = captureMock.mock.calls[1][0];
+    expect(failed.properties.error_name).toBe("Error");
+    expect(failed.properties.error_message).toBe("boom");
+  });
+
+  it("does not let a thrown PostHog error break the CLI", async () => {
+    captureMock.mockImplementationOnce(() => {
+      throw new Error("network down");
+    });
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const wrapped = mod.withTelemetry("whoami", async () => {});
+    await expect(wrapped()).resolves.toBeUndefined();
+  });
+
+  it("trims overly long error messages", async () => {
+    const mod = await loadTelemetry({ key: "phc_test" });
+    const longMsg = "x".repeat(500);
+    const wrapped = mod.withTelemetry("dev", async () => {
+      throw new Error(longMsg);
+    });
+    await expect(wrapped()).rejects.toThrow();
+    const failed = captureMock.mock.calls[1][0];
+    expect(failed.properties.error_message.length).toBe(200);
+  });
+});

--- a/packages/arkor/src/core/telemetry.ts
+++ b/packages/arkor/src/core/telemetry.ts
@@ -35,7 +35,7 @@ export function isEnabled(): boolean {
 }
 
 function debugLog(...args: unknown[]): void {
-  if (process.env.ARKOR_TELEMETRY_DEBUG) {
+  if (envFlag("ARKOR_TELEMETRY_DEBUG")) {
     console.error("[arkor:telemetry]", ...args);
   }
 }
@@ -147,9 +147,19 @@ function safeCapture(
   }
 }
 
+export interface TelemetryOptions {
+  // Mark commands like `dev` whose handler resolves once the server is up but
+  // the process keeps serving until the user interrupts. Skips the synthetic
+  // `cli_command_completed` (which would otherwise report a near-zero
+  // duration_ms while the session is still live); `cli_command_started` still
+  // fires, and a failure during bring-up still emits `cli_command_failed`.
+  longRunning?: boolean;
+}
+
 export function withTelemetry<TArgs extends unknown[]>(
   command: string,
   handler: (...args: TArgs) => Promise<void>,
+  options: TelemetryOptions = {},
 ): (...args: TArgs) => Promise<void> {
   return async (...args: TArgs) => {
     if (!isEnabled()) {
@@ -174,7 +184,7 @@ export function withTelemetry<TArgs extends unknown[]>(
     }
     try {
       await handler(...args);
-      if (identity) {
+      if (identity && !options.longRunning) {
         safeCapture(identity.distinctId, "cli_command_completed", {
           ...baseProps,
           duration_ms: Date.now() - start,

--- a/packages/arkor/src/core/telemetry.ts
+++ b/packages/arkor/src/core/telemetry.ts
@@ -1,0 +1,207 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { PostHog } from "posthog-node";
+import { readCredentials, type Credentials } from "./credentials";
+import { SDK_VERSION } from "./version";
+
+declare const __ARKOR_POSTHOG_KEY__: string;
+declare const __ARKOR_POSTHOG_HOST__: string;
+
+const POSTHOG_KEY: string =
+  typeof __ARKOR_POSTHOG_KEY__ !== "undefined" ? __ARKOR_POSTHOG_KEY__ : "";
+const POSTHOG_HOST: string =
+  typeof __ARKOR_POSTHOG_HOST__ !== "undefined"
+    ? __ARKOR_POSTHOG_HOST__
+    : "https://us.i.posthog.com";
+
+function envFlag(name: string): boolean {
+  const v = process.env[name];
+  if (!v) return false;
+  return v !== "0" && v.toLowerCase() !== "false";
+}
+
+export function isEnabled(): boolean {
+  if (envFlag("DO_NOT_TRACK")) return false;
+  if (envFlag("ARKOR_TELEMETRY_DISABLED")) return false;
+  if (!POSTHOG_KEY) return false;
+  return true;
+}
+
+function debugLog(...args: unknown[]): void {
+  if (process.env.ARKOR_TELEMETRY_DEBUG) {
+    console.error("[arkor:telemetry]", ...args);
+  }
+}
+
+let client: PostHog | null = null;
+let clientInitFailed = false;
+function getClient(): PostHog | null {
+  if (!isEnabled()) return null;
+  if (clientInitFailed) return null;
+  if (client) return client;
+  try {
+    client = new PostHog(POSTHOG_KEY, {
+      host: POSTHOG_HOST,
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  } catch (err) {
+    clientInitFailed = true;
+    debugLog("client init failed", err);
+    return null;
+  }
+  return client;
+}
+
+interface Identity {
+  distinctId: string;
+  authMode: "auth0" | "anon" | "none";
+}
+
+function decodeJwtSub(accessToken: string): string | null {
+  const parts = accessToken.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1];
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    const obj = JSON.parse(json) as { sub?: unknown };
+    return typeof obj.sub === "string" && obj.sub.length > 0 ? obj.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+function telemetryIdPath(): string {
+  return join(homedir(), ".arkor", "telemetry-id");
+}
+
+function readOrCreateTelemetryId(): string {
+  const path = telemetryIdPath();
+  try {
+    if (existsSync(path)) {
+      const v = readFileSync(path, "utf8").trim();
+      if (v) return v;
+    }
+  } catch (err) {
+    debugLog("read telemetry-id failed", err);
+  }
+  const id = randomUUID();
+  try {
+    mkdirSync(join(homedir(), ".arkor"), { recursive: true });
+    writeFileSync(path, id, { mode: 0o600 });
+  } catch (err) {
+    debugLog("write telemetry-id failed", err);
+  }
+  return id;
+}
+
+export async function getIdentity(): Promise<Identity> {
+  let creds: Credentials | null = null;
+  try {
+    creds = await readCredentials();
+  } catch (err) {
+    debugLog("readCredentials failed", err);
+  }
+  if (creds?.mode === "auth0") {
+    const sub = decodeJwtSub(creds.accessToken);
+    if (sub) return { distinctId: sub, authMode: "auth0" };
+    return { distinctId: readOrCreateTelemetryId(), authMode: "auth0" };
+  }
+  if (creds?.mode === "anon") {
+    return { distinctId: creds.anonymousId, authMode: "anon" };
+  }
+  return { distinctId: readOrCreateTelemetryId(), authMode: "none" };
+}
+
+interface BaseProps {
+  command: string;
+  sdk_version: string;
+  node_version: string;
+  platform: NodeJS.Platform;
+  auth_mode: "auth0" | "anon" | "none";
+}
+
+function safeCapture(
+  distinctId: string,
+  event: string,
+  properties: Record<string, unknown>,
+): void {
+  try {
+    const c = getClient();
+    if (!c) return;
+    c.capture({ distinctId, event, properties });
+  } catch (err) {
+    debugLog("capture failed", err);
+  }
+}
+
+export function withTelemetry<TArgs extends unknown[]>(
+  command: string,
+  handler: (...args: TArgs) => Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args: TArgs) => {
+    if (!isEnabled()) {
+      return handler(...args);
+    }
+    const start = Date.now();
+    let identity: Identity | null = null;
+    try {
+      identity = await getIdentity();
+    } catch (err) {
+      debugLog("getIdentity failed", err);
+    }
+    const baseProps: BaseProps = {
+      command,
+      sdk_version: SDK_VERSION,
+      node_version: process.version,
+      platform: process.platform,
+      auth_mode: identity?.authMode ?? "none",
+    };
+    if (identity) {
+      safeCapture(identity.distinctId, "cli_command_started", { ...baseProps });
+    }
+    try {
+      await handler(...args);
+      if (identity) {
+        safeCapture(identity.distinctId, "cli_command_completed", {
+          ...baseProps,
+          duration_ms: Date.now() - start,
+        });
+      }
+    } catch (err) {
+      if (identity) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        safeCapture(identity.distinctId, "cli_command_failed", {
+          ...baseProps,
+          duration_ms: Date.now() - start,
+          error_name: e.name,
+          error_message: e.message.slice(0, 200),
+        });
+      }
+      throw err;
+    }
+  };
+}
+
+export async function shutdownTelemetry(): Promise<void> {
+  const c = client;
+  if (!c) return;
+  client = null;
+  try {
+    await c.shutdown();
+  } catch (err) {
+    debugLog("shutdown failed", err);
+  }
+}

--- a/packages/arkor/tsdown.config.ts
+++ b/packages/arkor/tsdown.config.ts
@@ -20,5 +20,9 @@ export default defineConfig({
   // under vitest, where this transform doesn't run.
   define: {
     __SDK_VERSION__: JSON.stringify(pkg.version),
+    __ARKOR_POSTHOG_KEY__: JSON.stringify(process.env.ARKOR_POSTHOG_KEY ?? ""),
+    __ARKOR_POSTHOG_HOST__: JSON.stringify(
+      process.env.ARKOR_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    ),
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^10.0.0
         version: 10.2.0
       posthog-node:
-        specifier: ^5.30.6
-        version: 5.30.6
+        specifier: ~5.21.0
+        version: 5.21.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -605,11 +605,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@posthog/core@1.27.7':
-    resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
-
-  '@posthog/types@1.372.3':
-    resolution: {integrity: sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==}
+  '@posthog/core@1.10.0':
+    resolution: {integrity: sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1006,6 +1003,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1123,6 +1124,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1160,6 +1164,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1174,14 +1182,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@5.30.6:
-    resolution: {integrity: sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==}
-    engines: {node: ^20.20.0 || >=22.22.0}
-    peerDependencies:
-      rxjs: ^7.0.0
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
+  posthog-node@5.21.2:
+    resolution: {integrity: sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==}
+    engines: {node: '>=20'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -1246,6 +1249,14 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1424,6 +1435,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1797,11 +1813,9 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@posthog/core@1.27.7':
+  '@posthog/core@1.10.0':
     dependencies:
-      '@posthog/types': 1.372.3
-
-  '@posthog/types@1.372.3': {}
+      cross-spawn: 7.0.6
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2093,6 +2107,12 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -2215,6 +2235,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isexe@2.0.0: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -2244,6 +2266,8 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2256,9 +2280,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-node@5.30.6:
+  posthog-node@5.21.2:
     dependencies:
-      '@posthog/core': 1.27.7
+      '@posthog/core': 1.10.0
 
   quansync@1.0.0: {}
 
@@ -2350,6 +2374,12 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2470,6 +2500,10 @@ snapshots:
       '@types/node': 24.12.2
     transitivePeerDependencies:
       - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       open:
         specifier: ^10.0.0
         version: 10.2.0
+      posthog-node:
+        specifier: ^5.30.6
+        version: 5.30.6
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -601,6 +604,12 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@posthog/core@1.27.7':
+    resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
+
+  '@posthog/types@1.372.3':
+    resolution: {integrity: sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1164,6 +1173,15 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  posthog-node@5.30.6:
+    resolution: {integrity: sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -1779,6 +1797,12 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@posthog/core@1.27.7':
+    dependencies:
+      '@posthog/types': 1.372.3
+
+  '@posthog/types@1.372.3': {}
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -2231,6 +2255,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-node@5.30.6:
+    dependencies:
+      '@posthog/core': 1.27.7
 
   quansync@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^10.0.0
         version: 10.2.0
       posthog-node:
-        specifier: ~5.21.0
-        version: 5.21.2
+        specifier: ^5.30.6
+        version: 5.30.6
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -605,8 +605,11 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@posthog/core@1.10.0':
-    resolution: {integrity: sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==}
+  '@posthog/core@1.27.7':
+    resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
+
+  '@posthog/types@1.372.3':
+    resolution: {integrity: sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1003,10 +1006,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1124,9 +1123,6 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1164,10 +1160,6 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1182,9 +1174,14 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@5.21.2:
-    resolution: {integrity: sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==}
-    engines: {node: '>=20'}
+  posthog-node@5.30.6:
+    resolution: {integrity: sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -1249,14 +1246,6 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1435,11 +1424,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1813,9 +1797,11 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@posthog/core@1.10.0':
+  '@posthog/core@1.27.7':
     dependencies:
-      cross-spawn: 7.0.6
+      '@posthog/types': 1.372.3
+
+  '@posthog/types@1.372.3': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2107,12 +2093,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -2235,8 +2215,6 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
-  isexe@2.0.0: {}
-
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -2266,8 +2244,6 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  path-key@3.1.1: {}
-
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2280,9 +2256,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-node@5.21.2:
+  posthog-node@5.30.6:
     dependencies:
-      '@posthog/core': 1.10.0
+      '@posthog/core': 1.27.7
 
   quansync@1.0.0: {}
 
@@ -2374,12 +2350,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
-
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2500,10 +2470,6 @@ snapshots:
       '@types/node': 24.12.2
     transitivePeerDependencies:
       - msw
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds PostHog tracking to every CLI command (`init`, `login`, `logout`, `whoami`, `build`, `start`, `dev`) via a shared `withTelemetry()` wrapper, emitting `cli_command_started`, `cli_command_completed`, and `cli_command_failed` events.
- Distinct ID is resolved from `~/.arkor/credentials.json` (Auth0 `sub` or `anonymousId`), with a UUID fallback at `~/.arkor/telemetry-id` when not signed in.
- Hard opt-out: `DO_NOT_TRACK=1` or `ARKOR_TELEMETRY_DISABLED=1` short-circuits before the PostHog client is instantiated. The project key is injected at build time via tsdown's `define`, so local dev builds (no `ARKOR_POSTHOG_KEY`) ship with telemetry effectively disabled.

## Event schema
| Event | Properties |
|---|---|
| `cli_command_started` | `command`, `sdk_version`, `node_version`, `platform`, `auth_mode` |
| `cli_command_completed` | above + `duration_ms` |
| `cli_command_failed` | above + `duration_ms`, `error_name`, `error_message` (trimmed to 200 chars) |

## Test plan
- [x] `pnpm --filter arkor typecheck`
- [x] `pnpm --filter arkor build` (clean build with no `ARKOR_POSTHOG_KEY` produces a bundle that contains no key literal)
- [x] `pnpm --filter arkor build` with `ARKOR_POSTHOG_KEY=phc_fake_key_for_test` injects the key once
- [x] `pnpm --filter arkor test` (16 new telemetry tests, 106 total pass)
- [x] `DO_NOT_TRACK=1 dist/bin.mjs whoami` runs cleanly with no PostHog activity even under `ARKOR_TELEMETRY_DEBUG=1`
- [ ] Wire `ARKOR_POSTHOG_KEY` into the release workflow before the next published build
- [ ] After release, confirm a real `arkor whoami` invocation produces `cli_command_started` + `cli_command_completed` in the PostHog project, and that an intentionally failing command produces `cli_command_failed`