### PR TITLE
fix(studio): forward X-Arkor-Client on cloud-api passthroughs

### DIFF
--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -412,7 +412,12 @@ process.exit(0);
       // No state.json — server should derive a slug from cwd, create the
       // project on cloud-api, persist state, and forward the inference call.
 
-      const calls: Array<{ url: string; method: string; body?: string }> = [];
+      const calls: Array<{
+        url: string;
+        method: string;
+        body?: string;
+        headers: Record<string, string>;
+      }> = [];
       globalThis.fetch = (async (
         input: RequestInfo | URL,
         init?: RequestInit,
@@ -420,7 +425,13 @@ process.exit(0);
         const url = typeof input === "string" ? input : input.toString();
         const method = init?.method ?? "GET";
         const body = typeof init?.body === "string" ? init.body : undefined;
-        calls.push({ url, method, body });
+        const headers: Record<string, string> = {};
+        for (const [k, v] of Object.entries(
+          (init?.headers ?? {}) as Record<string, string>,
+        )) {
+          headers[k.toLowerCase()] = v;
+        }
+        calls.push({ url, method, body, headers });
         if (url.includes("/v1/projects") && method === "POST") {
           return new Response(
             JSON.stringify({
@@ -483,6 +494,9 @@ process.exit(0);
       expect(chat!.url).toContain("orgSlug=anon-org");
       expect(chat!.url).toContain("projectSlug=auto-slug");
       expect(chat!.body).toContain("unsloth/gemma-4-e4b-it");
+      // X-Arkor-Client must be present, otherwise cloud-api's SDK version
+      // gate rejects the proxied request with 426 (reason: "missing").
+      expect(chat!.headers["x-arkor-client"]).toMatch(/^arkor\/\S+$/);
     });
 
     it("proxies inference using existing state without re-creating a project", async () => {

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -223,6 +223,7 @@ export function buildStudioApp(options: StudioServerOptions) {
     const upstream = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token}`,
+        "X-Arkor-Client": `arkor/${SDK_VERSION}`,
         Accept: "text/event-stream",
         ...(c.req.header("Last-Event-ID")
           ? { "Last-Event-ID": c.req.header("Last-Event-ID") as string }
@@ -328,6 +329,7 @@ export function buildStudioApp(options: StudioServerOptions) {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
+        "X-Arkor-Client": `arkor/${SDK_VERSION}`,
       },
       body,
     });


### PR DESCRIPTION
## Summary

Studio's `/api/inference/chat` and `/api/jobs/:id/events` proxies hit cloud-api with raw `fetch()` and were missing the `X-Arkor-Client: arkor/<version>` header, so cloud-api's SDK version gate rejected every request with:

```
426 { "error": "sdk_version_unsupported", "currentVersion": "unknown", "reason": "missing", ... }
```


This broke base-model inference and job event streaming from Studio. The typed `CloudApiClient.chat()` / `openEventStream()` paths already sent the header correctly — only the Studio server's verbatim SSE passthroughs were affected.

## Changes

- `studio/server.ts`: add `X-Arkor-Client: arkor/${SDK_VERSION}` to the two raw-fetch proxies.
- `studio/server.test.ts`: capture request headers in the existing inference-chat test and assert `X-Arkor-Client` matches `arkor/<semver>`. The test had been passing because it never inspected outbound headers — that's the gap that let the bug ship.

## Test plan

- [x] `pnpm --filter arkor test` (111/111 passing)
- [ ] Manually verify base-model inference works in Studio against deployed cloud-api
- [ ] Manually verify mid-training event streaming works in Studio
