### PR TITLE
ci(release): publish from package directory; bundle CONTRIBUTING.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,18 +165,23 @@ jobs:
             tar -tf "$TARBALL"
           done
 
+      # Publish from the package directory (not from the pre-packed tarball)
+      # so npm CLI reads README.md at publish time and embeds it in the
+      # registry packument's `readme` field. `npm publish <tarball>` does
+      # not perform that injection, which leaves the page on npmjs.com
+      # blank.
       - name: Publish arkor to npm
+        working-directory: packages/arkor
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          npm publish "$RUNNER_TEMP/npm-pack/arkor-$VERSION.tgz" \
+          npm publish \
             --access public \
             --tag "${{ steps.meta.outputs.npm_tag }}" \
             --provenance
 
       - name: Publish create-arkor to npm
+        working-directory: packages/create-arkor
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          npm publish "$RUNNER_TEMP/npm-pack/create-arkor-$VERSION.tgz" \
+          npm publish \
             --access public \
             --tag "${{ steps.meta.outputs.npm_tag }}" \
             --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build
 dist/
 
+# Generated copies of root files (see packages/*/scripts/copy-root-files.mjs)
+packages/*/CONTRIBUTING.md
+
 # Turbo
 .turbo/
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -33,13 +33,14 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "CONTRIBUTING.md"
   ],
   "engines": {
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "pnpm --filter @arkor/studio-app build && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs",
+    "build": "pnpm --filter @arkor/studio-app build && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",

--- a/packages/arkor/scripts/copy-root-files.mjs
+++ b/packages/arkor/scripts/copy-root-files.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copy single-source root files (currently `CONTRIBUTING.md`) into the
+ * package directory so they end up in the published tarball. Kept as Node
+ * (not shell) to stay Windows-friendly.
+ */
+import { copyFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, "..");
+const repoRoot = join(pkgRoot, "../..");
+
+const FILES = ["CONTRIBUTING.md"];
+
+for (const name of FILES) {
+  const src = join(repoRoot, name);
+  const dst = join(pkgRoot, name);
+  if (!existsSync(src)) {
+    console.error(`[copy-root-files] missing ${src}`);
+    process.exit(1);
+  }
+  await copyFile(src, dst);
+  console.log(`Copied ${src} -> ${dst}`);
+}

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -19,13 +19,14 @@
     "create-arkor": "./dist/bin.mjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "CONTRIBUTING.md"
   ],
   "engines": {
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json --noEmit && tsdown",
+    "build": "tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-root-files.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",

--- a/packages/create-arkor/scripts/copy-root-files.mjs
+++ b/packages/create-arkor/scripts/copy-root-files.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copy single-source root files (currently `CONTRIBUTING.md`) into the
+ * package directory so they end up in the published tarball. Kept as Node
+ * (not shell) to stay Windows-friendly.
+ */
+import { copyFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, "..");
+const repoRoot = join(pkgRoot, "../..");
+
+const FILES = ["CONTRIBUTING.md"];
+
+for (const name of FILES) {
+  const src = join(repoRoot, name);
+  const dst = join(pkgRoot, name);
+  if (!existsSync(src)) {
+    console.error(`[copy-root-files] missing ${src}`);
+    process.exit(1);
+  }
+  await copyFile(src, dst);
+  console.log(`Copied ${src} -> ${dst}`);
+}


### PR DESCRIPTION
## Summary
- Switch the two publish steps in [release.yaml](.github/workflows/release.yaml) from `npm publish <tarball>` to `npm publish` from the package directory (`working-directory: packages/{arkor,create-arkor}`). The pre-pack-and-inspect step is kept for tarball visibility but is no longer the source of the upload.
- Copy the repo-root `CONTRIBUTING.md` into each package directory during build via a new `scripts/copy-root-files.mjs` (mirroring the existing `copy-studio-assets.mjs` pattern), add `CONTRIBUTING.md` to each package's `files` allowlist, and gitignore the generated copies (`packages/*/CONTRIBUTING.md`).

### Why publish from the directory

Verified against the live registry: `0.0.1-alpha.0/1/2` all shipped with `readme: ''` in their packument despite each tarball containing `README.md` at 4–5 kB. The mismatch is because **`pnpm publish <tarball>` and `npm publish <tarball>` both upload the tarball as-is — neither walks back to disk to read `README.md` and inject its content into the publish manifest's `readme` field**, which is what npmjs.com renders. `pnpm publish` from a package directory is also affected (verified against the `pnpm` package itself: `npm view pnpm readme` returns 0 bytes), so this PR sticks with `npm publish` rather than reverting to pnpm.

`0.0.1-alpha.3` will be the first release where the README renders on npmjs.com.

### Why bundle CONTRIBUTING.md

Contributors who only have the installed package (no checkout) can read the contribution guide locally. `LICENSE` / `LICENCE` / `README` are auto-included by npm regardless of `files`, but `CONTRIBUTING.md` is not — hence the explicit allowlist and the build-time copy. Single source of truth stays at the repo root; the per-package copies are generated and gitignored.

## Test plan
- [ ] `pnpm run build` produces `packages/{arkor,create-arkor}/CONTRIBUTING.md` (4.4 kB)
- [ ] `npm pack --dry-run` (or the workflow's `Pack and inspect tarballs` step) lists `CONTRIBUTING.md` and `LICENSE.md` in both tarballs
- [ ] After tagging `v0.0.1-alpha.3` and running release.yaml, `npm view arkor@0.0.1-alpha.3 readme | wc -c` is non-zero and the npmjs.com page renders the README
- [ ] Provenance attestation is still attached (`npm view arkor@0.0.1-alpha.3 dist.attestations`)
