### PR TITLE
feat(cli): make `arkor dev` browser launch opt-in via --open

### DIFF
--- a/packages/arkor/src/cli/commands/dev.ts
+++ b/packages/arkor/src/cli/commands/dev.ts
@@ -19,7 +19,7 @@ import { ui } from "../prompts";
 
 export interface DevOptions {
   port?: number;
-  noBrowser?: boolean;
+  open?: boolean;
 }
 
 /**
@@ -174,7 +174,7 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
   const url = `http://localhost:${port}`;
   serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
   process.stdout.write(`Arkor Studio running on ${url}\n`);
-  if (!options.noBrowser) {
+  if (options.open) {
     try {
       await open(url);
     } catch {

--- a/packages/arkor/src/cli/main.ts
+++ b/packages/arkor/src/cli/main.ts
@@ -127,14 +127,14 @@ export async function main(argv: string[]): Promise<void> {
     .command("dev")
     .description("Launch Arkor Studio locally")
     .option("-p, --port <port>", "Port to bind (default: 4000)", "4000")
-    .option("--no-browser", "Do not open the browser")
+    .option("--open", "Open the Studio URL in a browser after starting")
     .action(
       withTelemetry(
         "dev",
-        async (opts: { port: string; browser?: boolean }) => {
+        async (opts: { port: string; open?: boolean }) => {
           await runDev({
             port: Number(opts.port) || 4000,
-            noBrowser: opts.browser === false,
+            open: opts.open === true,
           });
         },
         { longRunning: true },


### PR DESCRIPTION
## Summary

`arkor dev` previously opened the Studio URL in the user's default browser unless `--no-browser` was passed. Aligning with the convention used by `vite dev`, `next dev`, etc., the auto-open is now opt-in: the server prints the URL and stays put unless the user passes `--open`.

## Changes

- `cli/commands/dev.ts`: replace `DevOptions.noBrowser` with `DevOptions.open`; only call `open(url)` when `options.open === true`.
- `cli/main.ts`: replace the `--no-browser` flag with `--open` and update the option's description.
- `arkor login`'s `--no-browser` flag is intentionally untouched — it's a different command with a different UX (PKCE flow needs a browser by default to be useful).

## Migration

- Anyone scripting `arkor dev --no-browser` can drop the flag; the new default matches that behaviour.
- Anyone relying on the auto-open should add `--open`.

## Test plan

- [x] `pnpm --filter arkor test` (111/111 passing — no test exercised the auto-open behaviour, so no test changes needed)
- [ ] `arkor dev` manually: verify the browser does NOT open, URL is printed, Studio is reachable
- [ ] `arkor dev --open` manually: verify the browser opens to the Studio URL
