### PR TITLE
ci(release): add `promote_to_latest` workflow input for alpha-only releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,11 @@ on:
           - alpha
           - beta
           - rc
+      promote_to_latest:
+        description: "Also point `latest` at this version (use during the alpha-only era so `npm install arkor` resolves to the newest pre-release). Ignored when npm_tag is already `latest`."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -207,6 +212,20 @@ jobs:
               attempt=$((attempt + 1))
               sleep "$SLEEP_SECONDS"
             done
+          done
+
+      # Re-point the `latest` dist-tag at the just-published version.
+      # Useful during the alpha-only era where there is no stable yet, so
+      # `npm install arkor` (no version) should resolve to the newest
+      # pre-release rather than the very first publish that happened to
+      # claim `latest` automatically. Skipped when npm_tag is already
+      # `latest` (the publish step already set it).
+      - name: Promote to latest
+        if: ${{ inputs.promote_to_latest && inputs.npm_tag != 'latest' }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          for PKG in arkor create-arkor; do
+            npm dist-tag add "$PKG@$VERSION" latest
           done
 
       - name: Create draft GitHub Release


### PR DESCRIPTION
## Summary
- Add a `promote_to_latest` boolean input (default `false`) to [release.yaml](.github/workflows/release.yaml) so a maintainer dispatching a release can opt into re-pointing the `latest` dist-tag at the just-published version.
- Add a `Promote to latest` step that runs after `Verify published packages`. It calls `npm dist-tag add <pkg>@<version> latest` for both `arkor` and `create-arkor`, gated on `inputs.promote_to_latest && inputs.npm_tag != 'latest'` so it's a no-op when the publish already wrote the `latest` tag.

### Why

`0.0.1-alpha.0` was the first publish for both packages and npm auto-set `latest = 0.0.1-alpha.0`. Subsequent prerelease publishes (`alpha.1`, `alpha.2`) used `--tag alpha`, which by design leaves `latest` untouched. The result is that `npm install arkor` (no version specifier) resolves to `0.0.1-alpha.0` — the oldest, README-blank, telemetry-key-empty release — instead of the newest pre-release.

For the alpha-only era, the desired behavior is "newest pre-release == `latest`". This input lets us flip that on per-release without changing the default workflow behavior. Once a stable release exists, dispatch with `npm_tag: latest` and `promote_to_latest: false` (the default), and `latest` follows stable.

### Auth

`npm dist-tag add` reuses the same short-lived `NODE_AUTH_TOKEN` that `setup-node` exchanges via npm Trusted Publisher OIDC at the start of the job, so no additional secret is required. The step runs immediately after `Verify`, well within token lifetime.

### Out of scope (manual one-time fix)

The currently-shipped `latest` (still pointing at `alpha.0`) won't be moved by merging this PR alone — it only affects future dispatches. To repoint the existing `latest`, a maintainer should run once locally:

```bash
npm dist-tag add arkor@0.0.1-alpha.2 latest
npm dist-tag add create-arkor@0.0.1-alpha.2 latest
