### PR TITLE
chore: release arkor + create-arkor 0.0.1-alpha.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 > [!WARNING]
-> Arkor is **alpha** (`0.0.1-alpha.2`). APIs change without notice. We're shipping in public, and feedback shapes what lands next.
+> Arkor is **alpha** (`0.0.1-alpha.3`). APIs change without notice. We're shipping in public, and feedback shapes what lands next.
 
 <!--
   Demo media goes here once recorded:

--- a/e2e/cli/src/arkor-whoami.test.ts
+++ b/e2e/cli/src/arkor-whoami.test.ts
@@ -230,7 +230,7 @@ describe("arkor whoami × SDK version gate (E2E)", () => {
       res.setHeader("Deprecation", "true");
       res.setHeader(
         "Warning",
-        '299 - "Arkor SDK 0.0.1-alpha.2 is deprecated; supported range: >=2.0.0"',
+        '299 - "Arkor SDK 0.0.1-alpha.3 is deprecated; supported range: >=2.0.0"',
       );
       res.end(
         JSON.stringify({

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -2,7 +2,7 @@
 
 The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 
-> Status: alpha (`0.0.1-alpha.2`). APIs may change without notice. No compat
+> Status: alpha (`0.0.1-alpha.3`). APIs may change without notice. No compat
 > shims are offered between alpha versions — pin and re-read the changelog
 > before bumping.
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkor",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Code-first TypeScript training SDK, CLI, and local Studio.",
   "private": false,
   "type": "module",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -114,7 +114,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.1");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.2");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -89,7 +89,7 @@ async function patchPackageJson(
           private: true,
           type: "module",
           scripts: { ...SCRIPT_DEFAULTS },
-          devDependencies: { arkor: "^0.0.1-alpha.1" },
+          devDependencies: { arkor: "^0.0.1-alpha.2" },
         },
         null,
         2,
@@ -114,7 +114,7 @@ async function patchPackageJson(
   const devDeps =
     (current.devDependencies as Record<string, string> | undefined) ?? {};
   if (!devDeps.arkor) {
-    devDeps.arkor = "^0.0.1-alpha.1";
+    devDeps.arkor = "^0.0.1-alpha.2";
     current.devDependencies = devDeps;
     dirty = true;
   }

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -3,7 +3,7 @@
 Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
 `npm create` / `pnpm create` / `yarn create` / `bun create`.
 
-> Status: alpha (`0.0.1-alpha.2`).
+> Status: alpha (`0.0.1-alpha.3`).
 
 ## Usage
 

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-arkor",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Scaffolder for arkor training projects.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump the two public packages (`arkor`, `create-arkor`) from `0.0.1-alpha.2` to `0.0.1-alpha.3`.
- Bump the scaffold's pinned `arkor` devDependency (and its test) from `^0.0.1-alpha.1` to `^0.0.1-alpha.2`. alpha.2 is the most recent published version the e2e install tests can resolve; we deliberately don't pre-pin alpha.3 to avoid the registry-not-yet-published failure on CI.
- Update the alpha-version callouts in the root README, per-package READMEs, and the `arkor-whoami` deprecation-warning fixture.

### What's new in alpha.3 vs alpha.2

- First release where the publish flows through `npm publish` from the package directory (#47), so `npm view arkor@0.0.1-alpha.3 readme` will return content and the npmjs.com page will render the README.
- First release that ships `CONTRIBUTING.md` inside both tarballs (#47).

## Test plan
- [ ] `pnpm --filter @arkor/cli-internal test` passes (scaffold test asserts `^0.0.1-alpha.2`)
- [ ] e2e install tests resolve `arkor@0.0.1-alpha.2` from the registry
- [ ] After tagging `v0.0.1-alpha.3` and running release.yaml:
  - `npm view arkor@0.0.1-alpha.3 readme | wc -c` is non-zero
  - Tarballs include `CONTRIBUTING.md` (4.4 kB)
  - `npm view arkor@0.0.1-alpha.3 dist.attestations.provenance` returns SLSA v1 provenance
- [ ] Manually re-point `latest` after release: `npm dist-tag add arkor@0.0.1-alpha.3 latest && npm dist-tag add create-arkor@0.0.1-alpha.3 latest`