### PR TITLE
fix(ci): rename studio-app `build` → `bundle` to eliminate vite dist race

### DIFF
--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -40,7 +40,7 @@
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "pnpm --filter @arkor/studio-app build && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
+    "build": "tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@arkor/cli-internal": "workspace:*",
+    "@arkor/studio-app": "workspace:*",
     "@types/node": "^24",
     "tsdown": "^0.21.9",
     "typescript": "^5",

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -40,7 +40,7 @@
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
+    "build": "pnpm --filter @arkor/studio-app build && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -40,7 +40,7 @@
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "pnpm --filter @arkor/studio-app build && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
+    "build": "pnpm --filter @arkor/studio-app bundle && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@arkor/cli-internal": "workspace:*",
-    "@arkor/studio-app": "workspace:*",
     "@types/node": "^24",
     "tsdown": "^0.21.9",
     "typescript": "^5",

--- a/packages/arkor/scripts/copy-studio-assets.mjs
+++ b/packages/arkor/scripts/copy-studio-assets.mjs
@@ -4,6 +4,7 @@
  * published tarball serves a self-contained UI. Kept as Node (not shell) to
  * stay Windows-friendly.
  */
+import { spawnSync } from "node:child_process";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -14,11 +15,31 @@ const pkgRoot = join(__dirname, "..");
 const src = join(pkgRoot, "../studio-app/dist");
 const dst = join(pkgRoot, "dist/assets");
 
+// Through `pnpm build` (turbo) the workspace dep on `@arkor/studio-app`
+// guarantees the dist is already there via `^build`. Direct invocations
+// (`pnpm --filter arkor build`, `e2e/cli`'s `pretest`, fresh clones) skip
+// turbo's orchestration, so fall back to building the SPA on demand here.
 if (!existsSync(src)) {
-  console.error(
-    `[copy-studio-assets] expected ${src} to exist — run \`pnpm --filter @arkor/studio-app build\` first.`,
+  console.log(
+    `[copy-studio-assets] ${src} missing — building @arkor/studio-app first.`,
   );
-  process.exit(1);
+  const result = spawnSync(
+    process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    ["--filter", "@arkor/studio-app", "build"],
+    { stdio: "inherit", cwd: pkgRoot },
+  );
+  if (result.status !== 0) {
+    console.error(
+      `[copy-studio-assets] failed to build @arkor/studio-app (exit ${result.status}).`,
+    );
+    process.exit(result.status ?? 1);
+  }
+  if (!existsSync(src)) {
+    console.error(
+      `[copy-studio-assets] ${src} still missing after build — aborting.`,
+    );
+    process.exit(1);
+  }
 }
 
 await mkdir(join(pkgRoot, "dist"), { recursive: true });

--- a/packages/arkor/scripts/copy-studio-assets.mjs
+++ b/packages/arkor/scripts/copy-studio-assets.mjs
@@ -4,7 +4,6 @@
  * published tarball serves a self-contained UI. Kept as Node (not shell) to
  * stay Windows-friendly.
  */
-import { spawnSync } from "node:child_process";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -15,31 +14,11 @@ const pkgRoot = join(__dirname, "..");
 const src = join(pkgRoot, "../studio-app/dist");
 const dst = join(pkgRoot, "dist/assets");
 
-// Through `pnpm build` (turbo) the workspace dep on `@arkor/studio-app`
-// guarantees the dist is already there via `^build`. Direct invocations
-// (`pnpm --filter arkor build`, `e2e/cli`'s `pretest`, fresh clones) skip
-// turbo's orchestration, so fall back to building the SPA on demand here.
 if (!existsSync(src)) {
-  console.log(
-    `[copy-studio-assets] ${src} missing — building @arkor/studio-app first.`,
+  console.error(
+    `[copy-studio-assets] expected ${src} to exist — run \`pnpm --filter @arkor/studio-app build\` first.`,
   );
-  const result = spawnSync(
-    process.platform === "win32" ? "pnpm.cmd" : "pnpm",
-    ["--filter", "@arkor/studio-app", "build"],
-    { stdio: "inherit", cwd: pkgRoot },
-  );
-  if (result.status !== 0) {
-    console.error(
-      `[copy-studio-assets] failed to build @arkor/studio-app (exit ${result.status}).`,
-    );
-    process.exit(result.status ?? 1);
-  }
-  if (!existsSync(src)) {
-    console.error(
-      `[copy-studio-assets] ${src} still missing after build — aborting.`,
-    );
-    process.exit(1);
-  }
+  process.exit(1);
 }
 
 await mkdir(join(pkgRoot, "dist"), { recursive: true });

--- a/packages/arkor/scripts/copy-studio-assets.mjs
+++ b/packages/arkor/scripts/copy-studio-assets.mjs
@@ -16,7 +16,7 @@ const dst = join(pkgRoot, "dist/assets");
 
 if (!existsSync(src)) {
   console.error(
-    `[copy-studio-assets] expected ${src} to exist — run \`pnpm --filter @arkor/studio-app build\` first.`,
+    `[copy-studio-assets] expected ${src} to exist — run \`pnpm --filter @arkor/studio-app bundle\` first.`,
   );
   process.exit(1);
 }

--- a/packages/studio-app/package.json
+++ b/packages/studio-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --noEmit && vite build",
+    "bundle": "tsc --noEmit && vite build",
     "dev": "vite",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@arkor/cli-internal':
         specifier: workspace:*
         version: link:../cli-internal
+      '@arkor/studio-app':
+        specifier: workspace:*
+        version: link:../studio-app
       '@types/node':
         specifier: ^24
         version: 24.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@arkor/cli-internal':
         specifier: workspace:*
         version: link:../cli-internal
-      '@arkor/studio-app':
-        specifier: workspace:*
-        version: link:../studio-app
       '@types/node':
         specifier: ^24
         version: 24.12.2


### PR DESCRIPTION
## Summary

CI was intermittently failing with `ENOENT: no such file or directory, open '.../studio-app/dist/assets/index-*.js.map'` during the build step, with reruns succeeding. Root cause was two `vite build` invocations writing to `packages/studio-app/dist/` concurrently and clobbering each other (vite's default `emptyOutDir: true` wipes the dir before rendering chunks).

`packages/arkor`'s build script invokes `vite` inline via `pnpm --filter @arkor/studio-app build`, while turbo independently scheduled `@arkor/studio-app:build` because both tasks shared the `build` name. With no `dependsOn` relationship between them, turbo's scheduler ran them in parallel.

## Fix

Renamed `@arkor/studio-app`'s `build` script to `bundle`. Turbo now sees no `build` task on the studio-app package and never schedules a parallel vite invocation. arkor's build script calls `pnpm --filter @arkor/studio-app bundle` inline, which remains the single source of truth for the SPA build.

This was preferred over the alternative of declaring `"@arkor/studio-app": "workspace:*"` in arkor's `devDependencies`. That would have ordered the two tasks via `^build` but kept two sequential vite invocations per turbo run, plus exposed the private workspace package in the published tarball's devDeps. The rename collapses both to one invocation and keeps the tarball's devDeps to `@arkor/cli-internal` only.

Direct invocations (`pnpm --filter arkor build`, `e2e/cli`'s `pretest`, fresh clones) continue to produce a fresh SPA bundle because the inline call always re-runs vite — addressing the staleness concern raised on this PR.

## Verification

- `pnpm build` (turbo): vite invocation count drops from up to 2 concurrent → exactly 1.
- `pnpm --filter arkor build` with `studio-app/dist` missing or stale: vite runs, fresh output produced.
- `pnpm --filter arkor test` — 111/111 passing.
- `pnpm --filter arkor pack` — tarball devDeps clean (`@arkor/cli-internal` only); leak grep for `drizzle|control-plane|apps/arkor-cloud-api` returns 0 hits.

## Note for reviewers

`@arkor/studio-app`'s task names now diverge from other workspace packages (`bundle` instead of `build`). This is intentional: it's how turbo is told "do not schedule this as part of the build pipeline; arkor will drive it." `dev` / `typecheck` / `test` still match the other packages' naming.

## Test plan

- [x] `pnpm build` runs vite exactly once
- [x] Direct `pnpm --filter arkor build` produces fresh output from missing/stale dist
- [x] Unit tests pass
- [x] Tarball clean (devDeps + leak grep)
- [x] CI green on this branch (the actual race repro environment)
