### PR TITLE
docs: add PostHog analytics + fix navbar primary href

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,13 +44,19 @@
     "primary": {
       "type": "button",
       "label": "Get started",
-      "href": "quickstart"
+      "href": "/quickstart"
     }
   },
   "footer": {
     "socials": {
       "github": "https://github.com/arkorlab/arkor",
       "x": "https://x.com/arkorlab"
+    }
+  },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_n8WJmqCs2Tkk7ABceBpuiq6e6aqwhayhjQzrBFTjidMH",
+      "sessionRecording": false
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add PostHog integration to `docs/docs.json` so docs page views land in the same PostHog project as arkor.ai and Studio. One event stream across all surfaces; filter by `\$current_url` if separation is needed
- `sessionRecording: false`. The visitor click/scroll capture is overkill for public docs, and keeps storage / privacy surface area down
- Restore leading slash on `navbar.primary.href` (`/quickstart`). Mintlify's local validator rejects bare `quickstart` with "Must be a valid URL or relative path". Now that we publish at `docs.arkor.ai` (subdomain, not `arkor.ai/docs` subpath), an absolute path stays inside the docs site so the original form is fine

## Test plan

- [x] `pnpm --filter @arkor/docs exec mint validate` passes locally
- [ ] After merge, PostHog dashboard receives `\$pageview` events from `docs.arkor.ai` (or the Mintlify preview URL)