### PR TITLE
docs: write Get started (introduction + quickstart)

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -17,7 +17,7 @@ Arkor is for that exact workflow.
 
 Custom open-weight models are a real option today because of years of work in the Python ML ecosystem and the people and companies who built it out. Arkor stands on that foundation: the training itself runs on the same stack everyone else uses.
 
-What Arkor adds is a TypeScript surface on top of that stack, so fine-tuning, evaluation, and serving live in the same codebase as the product you are shipping, with the same editor, types, and review flow.
+What Arkor adds is a TypeScript surface on top of that stack. Today it covers fine-tuning; evaluation and serving are next. The aim is for the model workflow to live in the same codebase as the product you are shipping, with the same editor, types, and review flow.
 
 ## What "ship the model the same way you ship the product" means
 
@@ -30,15 +30,15 @@ In practice:
 
 ## What works today
 
-Arkor is alpha (`0.0.1-alpha.3`) and honest about it. APIs change without notice as the design settles.
+Arkor is alpha and honest about it. APIs change without notice as the design settles. The current version is published to [npm](https://www.npmjs.com/package/arkor).
 
 What you can do right now:
 
 - Fine-tune an open-weight LLM (Gemma-based today) from a single file.
 - Pick from three end-to-end templates that finish in minutes: `triage` (support classification), `translate` (9 languages), and `redaction` (PII extraction).
 - React to training in code via lifecycle callbacks, not a dashboard.
-- Run training on Arkor's managed GPUs with no separate infra setup. Try it without an account; run `arkor login` later to claim your work.
-- Watch the run live in the local Studio and chat with checkpoints in the Playground.
+- Run training on Arkor's managed GPUs with no separate infra setup. Try it without an account; run `npx arkor login` later to claim your work.
+- Watch the run live in the local Studio. Once it finishes, chat with the trained model in the Playground.
 
 What is not in yet:
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -5,14 +5,58 @@ description: "Arkor is the TypeScript framework for fine-tuning open-weight LLMs
 
 # Introduction
 
-Arkor lets TypeScript and Node developers ship custom open-weight models the same way they ship the rest of the product: type-safe configs, hot reload, and a local Studio for the dev loop.
+Arkor lets TypeScript and Node developers fine-tune open-weight LLMs the same way they ship the rest of their product: type-safe configs, hot reload, lifecycle callbacks in your own code, and a local Studio for the dev loop.
 
-{/* TODO: write the real introduction.
+## Who Arkor is for
 
-Topics to cover:
-- Who Arkor is for (product engineers without a dedicated ML team)
-- The shape of an Arkor project (`src/arkor/index.ts`, trainer, deploy, eval)
-- What "ship the model the same way you ship the product" means in practice
-- How Arkor stands on the Python ML ecosystem rather than replacing it
-- Pointer to Quickstart
-*/}
+You are a product engineer (or a small team of them) shipping a TypeScript or Node app. You want a custom open-weight model behind one of your features, but you do not have a dedicated ML team and you do not want to maintain a separate Python codebase to get there.
+
+Arkor is for that exact workflow.
+
+## How Arkor relates to the Python ML ecosystem
+
+Custom open-weight models are a real option today because of years of work in the Python ML ecosystem and the people and companies who built it out. Arkor stands on that foundation: the training itself runs on the same stack everyone else uses.
+
+What Arkor adds is a TypeScript surface on top of that stack, so fine-tuning, evaluation, and serving live in the same codebase as the product you are shipping, with the same editor, types, and review flow.
+
+## What "ship the model the same way you ship the product" means
+
+In practice:
+
+- **Type-safe configs.** `createTrainer({ model, dataset, lora, ... })` is checked at compile time. No YAML drift, no separate config language.
+- **Hot reload over training code.** Edit your trainer, the dev server picks it up. No notebook restart.
+- **Callbacks in your own code.** `onLog`, `onCheckpoint`, `onCompleted`, `onFailed` fire on your TypeScript functions, fully typed. From inside `onCheckpoint` you can call `infer({ messages })` against the partial model and sanity-check it before the run finishes.
+- **A local Studio.** Run `arkor dev` and a web UI shows job status, a live loss chart, the log tail, and a Playground for chatting with your fine-tuned model. No external dashboard, no signup.
+
+## What works today
+
+Arkor is alpha (`0.0.1-alpha.3`) and honest about it. APIs change without notice as the design settles.
+
+What you can do right now:
+
+- Fine-tune an open-weight LLM (Gemma-based today) from a single file.
+- Pick from three end-to-end templates that finish in minutes: `triage` (support classification), `translate` (9 languages), and `redaction` (PII extraction).
+- React to training in code via lifecycle callbacks, not a dashboard.
+- Run training on Arkor's managed GPUs with no separate infra setup. Try it without an account; run `arkor login` later to claim your work.
+- Watch the run live in the local Studio and chat with checkpoints in the Playground.
+
+What is not in yet:
+
+- Local GPU training. Today every run goes to managed GPUs.
+- Bring-your-own dataset beyond the curated demos.
+- Base models beyond Gemma.
+- Self-hosting the training backend.
+
+The full state of "what works / what is coming" lives in the [README](https://github.com/arkorlab/arkor#what-works-today).
+
+## Try it
+
+```bash
+pnpm create arkor my-arkor-app
+cd my-arkor-app
+pnpm dev
+```
+
+The first run finishes in roughly 7 to 12 minutes depending on the template.
+
+Continue with the [Quickstart](/quickstart) for a step-by-step walkthrough.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -5,7 +5,7 @@ description: "Arkor is the TypeScript framework for fine-tuning open-weight LLMs
 
 # Introduction
 
-Arkor lets TypeScript and Node developers fine-tune open-weight LLMs the same way they ship the rest of their product: type-safe configs, hot reload, lifecycle callbacks in your own code, and a local Studio for the dev loop.
+Arkor lets TypeScript and Node developers fine-tune open-weight LLMs the same way they ship the rest of their product: type-safe configs, lifecycle callbacks in your own code, and a local Studio for the dev loop.
 
 ## Who Arkor is for
 
@@ -24,7 +24,7 @@ What Arkor adds is a TypeScript surface on top of that stack. Today it covers fi
 In practice:
 
 - **Type-safe configs.** `createTrainer({ model, dataset, lora, ... })` is checked at compile time. No YAML drift, no separate config language.
-- **Hot reload over training code.** Edit your trainer, the dev server picks it up. No notebook restart.
+- **Fast iteration on training code.** Edit your trainer, run `npx arkor build` (or refresh Studio's Run training page so its manifest endpoint rebuilds), and the next run uses the latest code. No notebook restart.
 - **Callbacks in your own code.** `onLog`, `onCheckpoint`, `onCompleted`, `onFailed` fire on your TypeScript functions, fully typed. From inside `onCheckpoint` you can call `infer({ messages })` against the partial model and sanity-check it before the run finishes.
 - **A local Studio.** Run `arkor dev` and a web UI shows job status, a live loss chart, the log tail, and a Playground for chatting with your fine-tuned model. No external dashboard, no signup.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quickstart"
-description: "Scaffold an Arkor project, fine-tune a small open-weight LLM, and chat with it from a local Studio in about 5 minutes."
+description: "Scaffold an Arkor project, fine-tune a small open-weight LLM, and chat with it from a local Studio."
 ---
 
 # Quickstart
 
-In about 5 minutes of setup, plus 7 to 12 minutes of training time, you will go from zero to a fine-tuned model you can chat with in a local Playground.
+In a few minutes you will go from zero to a fine-tuned model you can chat with in a local Playground. The training itself takes 7 to 12 minutes; setup time depends on your connection and what is already installed.
 
 ## Prerequisites
 
@@ -73,15 +73,17 @@ Open Studio in your browser and you will see three things to look at:
 
 - **Jobs.** A list of training runs. Click into one to see live status.
 - **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
-- **Playground.** Once a checkpoint is available, pick the adapter from the selector and chat with the partially trained model. Compare it against the base model side by side.
+- **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Compare it against the base model side by side. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
 
 ## 4. Claim your work (optional)
 
 Anonymous workspaces are useful for trying things out, but the work is tied to that local machine. Once you decide you want to keep what you trained:
 
 ```bash
-arkor login
+npx arkor login
 ```
+
+The scaffolded project installs `arkor` as a local devDependency, so prefer `npx arkor <command>` (or `pnpm exec arkor <command>`) over a bare `arkor` invocation unless you have installed the CLI globally. The generated project README uses the same convention.
 
 This runs an Auth0 PKCE flow on a loopback port and links your local credentials to an account. From then on, runs from this machine show up under that account on any device.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -57,23 +57,23 @@ The two files that matter for now:
 
 Open `trainer.ts`. The shape is the same across templates; only the dataset, output schema, and example prompts differ.
 
-## 3. Start the dev loop
+## 3. Open Studio and start a run
 
 ```bash
 pnpm dev
 ```
 
-This runs `arkor dev`, which:
+This runs `arkor dev`, which boots Studio at `http://localhost:4000`. Studio is the UI; `arkor dev` itself does not start training and does not watch your trainer files.
 
-1. Boots a local Studio at `http://localhost:4000`.
-2. Bootstraps an anonymous workspace silently. No signup required.
-3. Watches your `src/arkor/` files for changes.
+In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which compiles `src/arkor/index.ts` and submits the job to the managed backend. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
 
-Open Studio in your browser and you will see three things to look at:
+Once a run is in flight, three views matter:
 
 - **Jobs.** A list of training runs. Click into one to see live status.
 - **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
 - **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Compare it against the base model side by side. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
+
+If you edit `src/arkor/trainer.ts` after the first build, run `npx arkor build` (or delete `.arkor/build/`) before the next run so the rebuilt code is what trains.
 
 ## 4. Claim your work (optional)
 
@@ -90,5 +90,5 @@ This runs an Auth0 PKCE flow on a loopback port and links your local credentials
 ## 5. Where to go next
 
 - **Concepts.** Read [Concepts](/concepts/overview) to build a mental model of `createArkor`, `createTrainer`, the lifecycle callbacks, and Studio.
-- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Save the file and watch Studio pick up the next run.
+- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Run `npx arkor build` (or delete `.arkor/build/`) before the next run so your edits land.
 - **Try another template.** Run `pnpm create arkor` again with a different `--template` to compare.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -65,15 +65,15 @@ pnpm dev
 
 This runs `arkor dev`, which boots Studio at `http://localhost:4000`. Studio is the UI; `arkor dev` itself does not start training and does not watch your trainer files.
 
-In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which compiles `src/arkor/index.ts` and submits the job to the managed backend. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
+In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which submits the job to the managed backend using the existing `.arkor/build/index.mjs` artifact. On the very first run that artifact does not exist yet, so `arkor start` auto-builds from `src/arkor/index.ts` first. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
 
 Once a run is in flight, three views matter:
 
 - **Jobs.** A list of training runs. Click into one to see live status.
 - **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
-- **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Compare it against the base model side by side. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
+- **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Use the mode toggle to switch between the base model and the adapter. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
 
-While `arkor dev` is running, Studio rebuilds your trainer on each request to its manifest endpoint (with cache-busted re-imports), so edits to `src/arkor/` flow into the next Run training click automatically. No manual rebuild step.
+If you edit `src/arkor/` between runs, run `npx arkor build` (or refresh Studio's Run training page so its manifest endpoint rebuilds the artifact) before the next click. `arkor start` reuses the existing build artifact between clicks otherwise, so the new edits would not flow through.
 
 ## 4. Claim your work (optional)
 
@@ -90,5 +90,5 @@ This runs an Auth0 PKCE flow on a loopback port and links your local credentials
 ## 5. Where to go next
 
 - **Concepts.** Read [Concepts](/concepts/overview) to build a mental model of `createArkor`, `createTrainer`, the lifecycle callbacks, and Studio.
-- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. With `arkor dev` running, Studio picks up the edits on the next Run training click.
+- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Run `npx arkor build` (or refresh Studio's Run training page) before the next click so your edits land.
 - **Try another template.** Run `pnpm create arkor` again with a different `--template` to compare.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -65,7 +65,7 @@ pnpm dev
 
 This runs `arkor dev`, which boots Studio at `http://localhost:4000`. Studio is the UI; `arkor dev` itself does not start training and does not watch your trainer files.
 
-In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which submits the job to the managed backend using the existing `.arkor/build/index.mjs` artifact. On the very first run that artifact does not exist yet, so `arkor start` auto-builds from `src/arkor/index.ts` first. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
+In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which submits the job to the managed backend using `.arkor/build/index.mjs`. If that artifact is missing, `arkor start` auto-builds it from `src/arkor/index.ts`; in the Studio flow you rarely see this path because Studio's `/api/manifest` endpoint already rebuilt the artifact when the Run training page loaded. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
 
 Once a run is in flight, three views matter:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,22 +1,92 @@
 ---
 title: "Quickstart"
-description: "Scaffold an Arkor project, fine-tune a small open-weight LLM, and chat with it from a local Studio."
+description: "Scaffold an Arkor project, fine-tune a small open-weight LLM, and chat with it from a local Studio in about 5 minutes."
 ---
 
 # Quickstart
 
+In about 5 minutes of setup, plus 7 to 12 minutes of training time, you will go from zero to a fine-tuned model you can chat with in a local Playground.
+
+## Prerequisites
+
+- **Node.js 22.6 or newer.** Node 24 is recommended.
+- **pnpm.** Other package managers (npm, yarn, bun) work too; the examples below use pnpm.
+- A working internet connection. Training runs on Arkor's managed GPUs.
+
+No account, no credit card, no GPU on your machine.
+
+## 1. Scaffold a project
+
 ```bash
 pnpm create arkor my-arkor-app
 cd my-arkor-app
+```
+
+The scaffolder asks which template you want. Pick the one closest to what you eventually want to build:
+
+| Template    | Task                    | Output shape                                          | Estimated training |
+| ----------- | ----------------------- | ----------------------------------------------------- | ------------------ |
+| `triage`    | Support triage          | `{ category, urgency, summary, nextAction }`          | ~7 min             |
+| `translate` | 9-language translation  | `{ translation, detectedLanguage }`                   | ~7 min             |
+| `redaction` | PII redaction           | `{ redactedText, redactedCount, tags }`               | ~12 min            |
+
+Each template pairs the same small open-weight base (`unsloth/gemma-4-E4B-it`) with a curated public dataset on HuggingFace. The training is real and finishes in minutes, so you get to see the whole loop end to end.
+
+To skip the prompt:
+
+```bash
+pnpm create arkor my-arkor-app --template triage
+```
+
+## 2. Look at what was generated
+
+```
+my-arkor-app/
+├── src/arkor/
+│   ├── index.ts        # createArkor({ trainer })
+│   └── trainer.ts      # createTrainer({ ... })
+├── arkor.config.ts
+├── .arkor/             # state + build artifacts (gitignored)
+└── package.json        # dev / build / start
+```
+
+The two files that matter for now:
+
+- **`src/arkor/trainer.ts`** holds your trainer definition. Model, dataset, LoRA settings, hyperparameters, and lifecycle callbacks all live here.
+- **`src/arkor/index.ts`** is the entry point. It calls `createArkor({ trainer })` so the CLI and Studio can discover what to run.
+
+Open `trainer.ts`. The shape is the same across templates; only the dataset, output schema, and example prompts differ.
+
+## 3. Start the dev loop
+
+```bash
 pnpm dev
 ```
 
-{/* TODO: write the real quickstart.
+This runs `arkor dev`, which:
 
-Topics to cover:
-- Prerequisites (Node 22.6+, pnpm)
-- `pnpm create arkor` template choices (triage / translate / redaction)
-- What `pnpm dev` does (Studio at http://localhost:4000, anonymous workspace, first run)
-- Where to look in Studio (jobs, loss chart, Playground)
-- Next steps (`arkor login`, customising the trainer)
-*/}
+1. Boots a local Studio at `http://localhost:4000`.
+2. Bootstraps an anonymous workspace silently. No signup required.
+3. Watches your `src/arkor/` files for changes.
+
+Open Studio in your browser and you will see three things to look at:
+
+- **Jobs.** A list of training runs. Click into one to see live status.
+- **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
+- **Playground.** Once a checkpoint is available, pick the adapter from the selector and chat with the partially trained model. Compare it against the base model side by side.
+
+## 4. Claim your work (optional)
+
+Anonymous workspaces are useful for trying things out, but the work is tied to that local machine. Once you decide you want to keep what you trained:
+
+```bash
+arkor login
+```
+
+This runs an Auth0 PKCE flow on a loopback port and links your local credentials to an account. From then on, runs from this machine show up under that account on any device.
+
+## 5. Where to go next
+
+- **Concepts.** Read [Concepts](/concepts/overview) to build a mental model of `createArkor`, `createTrainer`, the lifecycle callbacks, and Studio.
+- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Save the file and watch Studio pick up the next run.
+- **Try another template.** Run `pnpm create arkor` again with a different `--template` to compare.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -73,7 +73,7 @@ Once a run is in flight, three views matter:
 - **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
 - **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Compare it against the base model side by side. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
 
-If you edit `src/arkor/trainer.ts` after the first build, run `npx arkor build` (or delete `.arkor/build/`) before the next run so the rebuilt code is what trains.
+While `arkor dev` is running, Studio rebuilds your trainer on each request to its manifest endpoint (with cache-busted re-imports), so edits to `src/arkor/` flow into the next Run training click automatically. No manual rebuild step.
 
 ## 4. Claim your work (optional)
 
@@ -90,5 +90,5 @@ This runs an Auth0 PKCE flow on a loopback port and links your local credentials
 ## 5. Where to go next
 
 - **Concepts.** Read [Concepts](/concepts/overview) to build a mental model of `createArkor`, `createTrainer`, the lifecycle callbacks, and Studio.
-- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Run `npx arkor build` (or delete `.arkor/build/`) before the next run so your edits land.
+- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. With `arkor dev` running, Studio picks up the edits on the next Run training click.
 - **Try another template.** Run `pnpm create arkor` again with a different `--template` to compare.


### PR DESCRIPTION
## Summary

First content PR in the docs series: replaces the skeleton TODO outlines for `introduction.mdx` and `quickstart.mdx` with real content so a visitor landing on `docs.arkor.ai` for the first time can decide whether Arkor fits and get to a running training job in about 5 minutes.

### Introduction

- Who Arkor is for: TS/Node product engineers without a dedicated ML team
- Positioning: Arkor stands on the Python ML ecosystem rather than replacing it; the TypeScript surface is what is new
- What "ship the model the same way you ship the product" means in practice (type-safe configs, hot reload, callbacks, Studio)
- Honest alpha scope: what works today, what is not in yet (local GPU, BYO dataset beyond demos, base models beyond Gemma, self-host)

### Quickstart

- Prerequisites (Node 22.6+, pnpm; no account, no GPU on the user's machine)
- `pnpm create arkor` template selection table (`triage` / `translate` / `redaction`) with output shapes and estimated training times
- Project structure walkthrough (`src/arkor/index.ts`, `src/arkor/trainer.ts`, `arkor.config.ts`, `.arkor/`)
- `pnpm dev` flow and what to look at in Studio (Jobs / loss + log / Playground)
- Optional `arkor login` (Auth0 PKCE) to claim the anonymous workspace
- Next steps pointing at Concepts and trainer customization

## Out of scope

- Cookbook reference is deferred until that section exists in a later PR (mint broken-links flagged the link).
- `docs.json` navigation is unchanged. Concepts / CLI / SDK / Studio / Cookbook expansions land in their own PRs per the docs roll-out plan.

## Test plan

- [x] `pnpm --filter @arkor/docs exec mint validate` passes
- [x] `pnpm --filter @arkor/docs exec mint broken-links` passes
- [x] `pnpm --filter @arkor/docs docs:dev` renders both pages correctly with frontmatter, headings, code blocks, and the template comparison table
- [ ] Mintlify preview deploy (`https://arkor-92aeef0e-eng-535.mintlify.app`) renders without layout issues