### PR TITLE
ci: add caching for Turborepo in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,20 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
+      # Turbo's local cache is at .turbo/cache. Keying on the commit SHA
+      # always writes a fresh entry; restore-keys falls back to the most
+      # recent prior cache for the same OS/node so unaffected task hashes
+      # hit immediately. node version is part of the key because turbo's
+      # hash currently does not factor it in, and we want to keep the
+      # matrix entries from clobbering each other if that ever changes.
+      - name: Cache Turborepo
+        uses: actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-node${{ matrix.node }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-node${{ matrix.node }}-
+
       - name: Install
         run: pnpm install
 


### PR DESCRIPTION
## Summary

Add a Turborepo cache layer to CI so unchanged tasks short-circuit on subsequent runs. Today every push and PR commit re-runs `typecheck`, `test`, and `build` from scratch across all three Node matrix entries.

## Approach

`actions/cache@v5` over `.turbo/cache` (turbo's local filesystem cache directory). No third-party actions; no Vercel Remote Cache (this repo is OSS, so we'd need to expose `TURBO_TOKEN` / `TURBO_TEAM` to forks, which we don't want).

Key strategy:

```yaml
key: turbo-${{ runner.os }}-node${{ matrix.node }}-${{ github.sha }}
restore-keys:
  - turbo-${{ runner.os }}-node${{ matrix.node }}-
