### PR TITLE
docs: write Concepts (project structure, trainer, lifecycle, studio)

### DIFF
--- a/docs/concepts/lifecycle.mdx
+++ b/docs/concepts/lifecycle.mdx
@@ -21,10 +21,13 @@ createTrainer({
 ## When each callback fires
 
 ```
-.start()
+.start()                 ── submits the job, returns { jobId }. No callbacks here.
    │
    ▼
-onStarted ─── once, when the backend accepts the job
+.wait()                  ── opens the SSE event stream. Callbacks dispatch from here.
+   │
+   ▼
+onStarted ─── once, when the stream reports `training.started`
    │
    ▼
 onLog     ─── many times, once per training-step batch of metrics
@@ -38,13 +41,15 @@ or
 onFailed     ── once, on backend-reported failure
 ```
 
+All five callbacks are dispatched from inside `wait()`. If you call `start()` without later calling `wait()`, **no callbacks fire**, even though the run is still happening on the backend. `arkor start` calls `wait()` for you; if you wire training into your own code outside the CLI, make sure you do too.
+
 `onCompleted` and `onFailed` are mutually exclusive: exactly one of the two fires per run.
 
 Returning a promise from any callback is fine. Arkor awaits it before moving on, so you can do async work (writing to a database, posting to Slack, calling `infer`) without races.
 
 ## `onStarted({ job })`
 
-Fires once, after `start()` returns and the backend accepts the job.
+Fires once, when the SSE stream opened by `wait()` reports a `training.started` event. Note that this is not the same moment `start()` resolves: `start()` only submits the job and returns its `jobId`.
 
 ```ts
 onStarted: ({ job }) => {
@@ -113,7 +118,7 @@ onFailed: ({ job, error }) => {
 },
 ```
 
-A thrown exception inside one of your other callbacks does not trigger `onFailed`; that is for backend-side failures only. Callback exceptions surface through `wait()` instead.
+`onFailed` is for backend-reported failures only. A thrown exception inside one of your own callbacks does **not** route through `onFailed`, and it is also not guaranteed to fail `wait()` cleanly: the current runtime catches errors thrown during event dispatch and treats them as SSE failures, which feed into the reconnect loop. The original exception can end up retried or skipped rather than surfacing where you would expect. If you need deterministic behavior, catch errors inside the callback and decide what to do (log, abort, persist) before they escape.
 
 ## A complete example
 

--- a/docs/concepts/lifecycle.mdx
+++ b/docs/concepts/lifecycle.mdx
@@ -1,0 +1,146 @@
+---
+title: "Lifecycle callbacks"
+description: "The five callbacks Arkor fires during a training run, and what each one is good for."
+---
+
+# Lifecycle callbacks
+
+Arkor fires five callbacks as a training run progresses. They are all optional, and each one is a plain TypeScript function that runs in your process. This is what makes the loop feel like the rest of your application: no notebook, no out-of-band dashboard, no separate config language.
+
+```ts
+createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  callbacks: {
+    onStarted, onLog, onCheckpoint, onCompleted, onFailed,
+  },
+});
+```
+
+## When each callback fires
+
+```
+.start()
+   │
+   ▼
+onStarted ─── once, when the backend accepts the job
+   │
+   ▼
+onLog     ─── many times, once per training-step batch of metrics
+   │
+   ▼
+onCheckpoint ── several times, when an adapter checkpoint is saved
+   │
+   ▼
+onCompleted  ── once, on successful finish
+or
+onFailed     ── once, on backend-reported failure
+```
+
+`onCompleted` and `onFailed` are mutually exclusive: exactly one of the two fires per run.
+
+Returning a promise from any callback is fine. Arkor awaits it before moving on, so you can do async work (writing to a database, posting to Slack, calling `infer`) without races.
+
+## `onStarted({ job })`
+
+Fires once, after `start()` returns and the backend accepts the job.
+
+```ts
+onStarted: ({ job }) => {
+  console.log(`Run ${job.id} accepted`);
+},
+```
+
+Use it for log lines, metric counters, or sending a "training started" notification.
+
+## `onLog({ step, loss, evalLoss, learningRate, epoch, samplesPerSecond, job })`
+
+Fires repeatedly as training progresses. Each numeric field can be `null` when the backend has not produced that metric yet (for example `evalLoss` only fires on eval steps).
+
+```ts
+onLog: ({ step, loss, evalLoss }) => {
+  if (loss !== null) {
+    console.log(`step=${step} loss=${loss.toFixed(4)} evalLoss=${evalLoss ?? "-"}`);
+  }
+},
+```
+
+Common uses:
+
+- Forward to your own metrics pipeline (e.g. PostHog, Datadog).
+- Detect divergence early: if `loss` is climbing, abort the run.
+- Implement custom early stopping logic.
+
+## `onCheckpoint({ step, adapter, job, infer, artifacts })`
+
+Fires when a checkpoint is saved on the backend, while the run is still going.
+
+```ts
+onCheckpoint: async ({ step, infer }) => {
+  const res = await infer({
+    messages: [{ role: "user", content: "Can't log in" }],
+  });
+  console.log(`step=${step} sample=`, await res.text());
+},
+```
+
+`adapter` is a small object identifying the checkpoint (`{ kind: "checkpoint", jobId, step }`). `infer` is a function: it takes a chat-style request and returns a raw `Response`. You call `await res.text()` (or `res.json()`, or stream the body) to read it.
+
+This is the most useful callback in practice. It lets you sanity-check the model mid-run rather than waiting until the end. If the checkpoint is already worse than the base model, you know to stop.
+
+## `onCompleted({ job, artifacts })`
+
+Fires once, on success. `artifacts` lists what the backend produced for this run. Use it to:
+
+- Persist the final adapter ID where the rest of your app can find it.
+- Run a final smoke test before promoting the model.
+- Send a "training done" notification.
+
+```ts
+onCompleted: ({ job, artifacts }) => {
+  console.log(`Run ${job.id} done, ${artifacts.length} artifacts`);
+},
+```
+
+## `onFailed({ job, error })`
+
+Fires once if the backend reports a failure. Note that `error` is a `string` (the message the backend sent), not an `Error` instance:
+
+```ts
+onFailed: ({ job, error }) => {
+  console.error(`Run ${job.id} failed: ${error}`);
+},
+```
+
+A thrown exception inside one of your other callbacks does not trigger `onFailed`; that is for backend-side failures only. Callback exceptions surface through `wait()` instead.
+
+## A complete example
+
+```ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  lora: { r: 16, alpha: 16 },
+  maxSteps: 100,
+  callbacks: {
+    onStarted: ({ job }) => console.log(`started ${job.id}`),
+    onLog: ({ step, loss }) => {
+      if (loss !== null) console.log(`step=${step} loss=${loss.toFixed(4)}`);
+    },
+    onCheckpoint: async ({ step, infer }) => {
+      const res = await infer({
+        messages: [{ role: "user", content: "Hello!" }],
+      });
+      console.log(`ckpt @ ${step}:`, await res.text());
+    },
+    onCompleted: ({ job }) => console.log(`done ${job.id}`),
+    onFailed: ({ error }) => console.error(`failed: ${error}`),
+  },
+});
+```
+
+Once you understand callbacks, almost everything else in Arkor is just configuration on top.

--- a/docs/concepts/lifecycle.mdx
+++ b/docs/concepts/lifecycle.mdx
@@ -43,7 +43,7 @@ onFailed     ── once, on backend-reported failure
 
 All five callbacks are dispatched from inside `wait()`. If you call `start()` without later calling `wait()`, **no callbacks fire**, even though the run is still happening on the backend. `arkor start` calls `wait()` for you; if you wire training into your own code outside the CLI, make sure you do too.
 
-`onCompleted` and `onFailed` are mutually exclusive: exactly one of the two fires per run.
+`onCompleted` and `onFailed` are mutually exclusive: at most one of them fires per run. If `wait()` throws before a terminal event arrives (for example when `abortSignal` is aborted, or reconnect attempts are exhausted), it is possible that neither one fires.
 
 Returning a promise from any callback is fine. Arkor awaits it before moving on, so you can do async work (writing to a database, posting to Slack, calling `infer`) without races.
 

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -16,4 +16,4 @@ This section gives you the mental model you need before diving into the [SDK ref
 
 ## The one-paragraph version
 
-You define a `Trainer` with `createTrainer({ name, model, dataset, ... })` in `src/arkor/trainer.ts` and register it through `createArkor({ trainer })` in `src/arkor/index.ts`. The CLI and Studio find that entry point automatically. When you run `arkor dev`, training streams from Arkor's managed GPUs and your TypeScript callbacks fire as events arrive. Studio shows the same stream in a browser so you can watch it without leaving the loop.
+You define a `Trainer` with `createTrainer({ name, model, dataset, ... })` in `src/arkor/trainer.ts` and register it through `createArkor({ trainer })` in `src/arkor/index.ts`. `arkor dev` opens a local Studio in the browser; clicking **Run training** in Studio spawns `arkor start`, which calls `trainer.start()` and `trainer.wait()`. While `wait()` is open, callbacks dispatch from the SSE event stream, training streams from Arkor's managed GPUs, and the same view is reflected back into Studio.

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -1,16 +1,19 @@
 ---
 title: "Concepts"
-description: "The mental model behind Arkor: trainer, deploy, eval, and the Studio dev loop."
+description: "The mental model behind Arkor: project layout, trainer, lifecycle callbacks, and Studio."
 ---
 
 # Concepts
 
-{/* TODO: write the real concepts overview.
+This section gives you the mental model you need before diving into the [SDK reference](/sdk/overview) or [CLI reference](/cli/overview). Read these in order; each builds on the previous.
 
-Topics to cover:
-- `createArkor({ trainer, deploy, eval })` umbrella and what each slot is for
-- `createTrainer({ ... })` and its lifecycle callbacks (onStarted, onLog, onCheckpoint, onCompleted, onFailed)
-- The `src/arkor/index.ts` entry point that the CLI and Studio discover
-- Where state lives (`.arkor/`) and what `arkor build` produces
-- Managed GPUs vs (future) local GPUs
-*/}
+## What to read
+
+- [**Project structure**](/concepts/project-structure). Where Arkor expects code to live (`src/arkor/index.ts`, `src/arkor/trainer.ts`), what `.arkor/` and `~/.arkor/` are for, and what `arkor.config.ts` does (and does not) do today.
+- [**Trainer**](/concepts/trainer). The shape of `createTrainer`: required fields, dataset sources, LoRA settings, and the `Trainer.start / wait / cancel` lifecycle.
+- [**Lifecycle callbacks**](/concepts/lifecycle). The five callbacks (`onStarted`, `onLog`, `onCheckpoint`, `onCompleted`, `onFailed`), their argument shapes, and when each fires. This is where most of the value of doing fine-tuning in TypeScript lives.
+- [**Studio**](/concepts/studio). What the local web UI is for, why it runs on loopback, and how it fits into the dev loop.
+
+## The one-paragraph version
+
+You define a `Trainer` with `createTrainer({ name, model, dataset, ... })` in `src/arkor/trainer.ts` and register it through `createArkor({ trainer })` in `src/arkor/index.ts`. The CLI and Studio find that entry point automatically. When you run `arkor dev`, training streams from Arkor's managed GPUs and your TypeScript callbacks fire as events arrive. Studio shows the same stream in a browser so you can watch it without leaving the loop.

--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -1,0 +1,86 @@
+---
+title: "Project structure"
+description: "Where Arkor expects your code, and what lives in .arkor/ and ~/.arkor/."
+---
+
+# Project structure
+
+A scaffolded Arkor project looks like this:
+
+```
+my-arkor-app/
+├── src/arkor/
+│   ├── index.ts        # createArkor({ trainer })
+│   └── trainer.ts      # createTrainer({ ... })
+├── arkor.config.ts
+├── .arkor/             # per-project state (gitignored)
+└── package.json        # dev / build / start
+```
+
+Two layers of state matter beyond your source: `.arkor/` (per-project, in the repo) and `~/.arkor/` (per-user, in your home directory).
+
+## `src/arkor/`
+
+Arkor discovers your project by looking for `src/arkor/index.ts`. That file must default-export the result of `createArkor()`:
+
+```ts
+// src/arkor/index.ts
+import { createArkor } from "arkor";
+import { trainer } from "./trainer";
+
+export const arkor = createArkor({ trainer });
+```
+
+The trainer itself lives in a sibling file by convention so `index.ts` stays thin:
+
+```ts
+// src/arkor/trainer.ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  lora: { r: 16, alpha: 16 },
+  maxSteps: 100,
+});
+```
+
+You can split the trainer further (helpers, prompt builders) however you want; only `index.ts` needs to be at the canonical path.
+
+To register additional trainers in the future, drop more files and pass them through `createArkor`. Today the API accepts a single `trainer`; `deploy` and `eval` slots are reserved on the type but not yet implemented.
+
+## `arkor.config.ts`
+
+`pnpm create arkor` generates a default `arkor.config.ts`:
+
+```ts
+// arkor.config.ts
+export default {};
+```
+
+It is currently a placeholder. The runtime does not read fields from it yet. All training defaults live on the `Trainer` itself (`maxSteps`, `learningRate`, `lora`, etc.) so you control them per-trainer rather than at the project level. Leave the file alone unless you have a reason to delete it.
+
+## `.arkor/` (per-project, gitignored)
+
+Created by `arkor dev`, `arkor build`, and `arkor start`. You should not commit this directory.
+
+- **`.arkor/state.json`**. Project routing: `orgSlug`, `projectSlug`, `projectId`. This is how the CLI maps your local repo to a workspace on the managed backend. `arkor login` populates it; do not edit by hand.
+- **`.arkor/build/index.mjs`**. Output of `arkor build`: an esbuild bundle of `src/arkor/index.ts` targeting Node 22.6 with bare specifiers kept external. `arkor start` runs this.
+
+## `~/.arkor/` (per-user)
+
+Lives in your home directory, shared across all Arkor projects on the machine.
+
+- **`~/.arkor/credentials.json`**. Auth state. Either an Auth0 token (after `arkor login`) or an anonymous token (created on first `arkor dev` if you never logged in). The file is tagged with a `mode` field of `"auth0"` or `"anon"` so the CLI knows which path you are on.
+- **`~/.arkor/studio-token`** (transient). A per-launch CSRF token written by `arkor dev` (mode `0600`). Used by Studio to authorize calls back into the CLI's local server. Rotated on every `arkor dev`.
+
+`arkor logout` deletes `credentials.json`; the studio token cleans itself up on the next launch.
+
+## What the CLI looks for
+
+- `arkor dev` resolves `src/arkor/index.ts`, hot-reloads it, serves Studio at `127.0.0.1:4000`, and writes `.arkor/state.json` and `~/.arkor/studio-token` as needed.
+- `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`.
+- `arkor start` runs `.arkor/build/index.mjs`, rebuilding first if it is missing.
+
+Knowing where state lives makes the CLI predictable: if something looks wrong, peek at `.arkor/state.json` and `~/.arkor/credentials.json` before reaching for support.

--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -83,7 +83,7 @@ Lives in your home directory, shared across all Arkor projects on the machine.
 
 ## What the CLI looks for
 
-- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. The CLI itself does not file-watch your trainer, but Studio's `/api/manifest` endpoint calls `runBuild` and re-imports the artifact with a cache-bust query on every request, and the UI hits that endpoint on page loads. Effect: while `arkor dev` is running, edits to `src/arkor/` are reflected in Studio and used for the next training run without any manual rebuild. `arkor dev` does not write `.arkor/state.json` on its own.
+- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. It does not file-watch `src/arkor/`. Studio's `/api/manifest` endpoint does call `runBuild` and re-import with a cache-bust query, but only when the UI fetches it, which currently happens when the Run training page mounts (see `packages/studio-app/src/components/RunTraining.tsx`). If you stay on that page across multiple runs, the build artifact is reused. To pick up edits between runs, refresh the Run training page (or run `arkor build` from the terminal) before the next click. `arkor dev` does not write `.arkor/state.json` on its own.
 - `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`. You only need to call this directly outside the Studio dev loop (e.g. CI, or right before `arkor start` from a script).
 - `arkor start` resolves the entry through the runner, rebuilds `.arkor/build/index.mjs` if it is missing or you passed an explicit entry, and runs it (which calls `trainer.start()` and `trainer.wait()`). Triggering training from Studio internally spawns `arkor start`.
 

--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -21,10 +21,14 @@ Two layers of state matter beyond your source: `.arkor/` (per-project, in the re
 
 ## `src/arkor/`
 
-Arkor discovers your project by looking for `src/arkor/index.ts`. That file must default-export the result of `createArkor()`:
+Arkor discovers your project by looking for `src/arkor/index.ts`. That file should expose the result of `createArkor()`. The CLI accepts three export shapes (in priority order):
+
+1. **`export const arkor = createArkor({ trainer })`** (preferred, what the templates produce).
+2. **`export const trainer = createTrainer({ ... })`** as a power-user shortcut when you do not need the umbrella.
+3. **A default export** holding either an `Arkor` manifest or a `Trainer`.
 
 ```ts
-// src/arkor/index.ts
+// src/arkor/index.ts (preferred shape)
 import { createArkor } from "arkor";
 import { trainer } from "./trainer";
 
@@ -63,24 +67,24 @@ It is currently a placeholder. The runtime does not read fields from it yet. All
 
 ## `.arkor/` (per-project, gitignored)
 
-Created by `arkor dev`, `arkor build`, and `arkor start`. You should not commit this directory.
+You should not commit this directory.
 
-- **`.arkor/state.json`**. Project routing: `orgSlug`, `projectSlug`, `projectId`. This is how the CLI maps your local repo to a workspace on the managed backend. `arkor login` populates it; do not edit by hand.
+- **`.arkor/state.json`**. Project routing: `orgSlug`, `projectSlug`, `projectId`. This is how the runtime maps your local repo to a workspace on the managed backend. The file is created by `ensureProjectState()`, which is called the first time you run training (or hit base-model inference) on the project. For **anonymous** workspaces it is auto-created on that first call. For **Auth0** users the runtime errors out and asks you to run `arkor init` first. Do not edit by hand.
 - **`.arkor/build/index.mjs`**. Output of `arkor build`: an esbuild bundle of `src/arkor/index.ts` targeting Node 22.6 with bare specifiers kept external. `arkor start` runs this.
 
 ## `~/.arkor/` (per-user)
 
 Lives in your home directory, shared across all Arkor projects on the machine.
 
-- **`~/.arkor/credentials.json`**. Auth state. Either an Auth0 token (after `arkor login`) or an anonymous token (created on first `arkor dev` if you never logged in). The file is tagged with a `mode` field of `"auth0"` or `"anon"` so the CLI knows which path you are on.
-- **`~/.arkor/studio-token`** (transient). A per-launch CSRF token written by `arkor dev` (mode `0600`). Used by Studio to authorize calls back into the CLI's local server. Rotated on every `arkor dev`.
+- **`~/.arkor/credentials.json`**. Auth state. Either an Auth0 token (after `arkor login`) or an anonymous token (created on first use if you never logged in). The file is tagged with a `mode` field of `"auth0"` or `"anon"` so the CLI knows which path you are on. `arkor login` writes only this file; it does **not** create `.arkor/state.json`.
+- **`~/.arkor/studio-token`** (transient). A per-launch CSRF token written by `arkor dev` (mode `0600`). Used by Studio to authorize calls back into the CLI's local server. Rotated on every `arkor dev` run.
 
-`arkor logout` deletes `credentials.json`; the studio token cleans itself up on the next launch.
+`arkor logout` deletes `credentials.json`. The studio token is removed on process exit on a best-effort basis (it may linger if `arkor dev` crashes) and is rotated on the next launch.
 
 ## What the CLI looks for
 
-- `arkor dev` resolves `src/arkor/index.ts`, hot-reloads it, serves Studio at `127.0.0.1:4000`, and writes `.arkor/state.json` and `~/.arkor/studio-token` as needed.
+- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. It does **not** resolve, compile, watch, or hot-reload `src/arkor/index.ts`, and it does not write `.arkor/state.json` on its own.
 - `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`.
-- `arkor start` runs `.arkor/build/index.mjs`, rebuilding first if it is missing.
+- `arkor start` resolves the entry through the runner, rebuilds `.arkor/build/index.mjs` if it is missing or you passed an explicit entry, and runs it (which calls `trainer.start()` and `trainer.wait()`). Triggering training from Studio internally spawns `arkor start`.
 
 Knowing where state lives makes the CLI predictable: if something looks wrong, peek at `.arkor/state.json` and `~/.arkor/credentials.json` before reaching for support.

--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -83,8 +83,8 @@ Lives in your home directory, shared across all Arkor projects on the machine.
 
 ## What the CLI looks for
 
-- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. It does **not** resolve, compile, watch, or hot-reload `src/arkor/index.ts`, and it does not write `.arkor/state.json` on its own.
-- `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`.
+- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. The CLI itself does not file-watch your trainer, but Studio's `/api/manifest` endpoint calls `runBuild` and re-imports the artifact with a cache-bust query on every request, and the UI hits that endpoint on page loads. Effect: while `arkor dev` is running, edits to `src/arkor/` are reflected in Studio and used for the next training run without any manual rebuild. `arkor dev` does not write `.arkor/state.json` on its own.
+- `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`. You only need to call this directly outside the Studio dev loop (e.g. CI, or right before `arkor start` from a script).
 - `arkor start` resolves the entry through the runner, rebuilds `.arkor/build/index.mjs` if it is missing or you passed an explicit entry, and runs it (which calls `trainer.start()` and `trainer.wait()`). Triggering training from Studio internally spawns `arkor start`.
 
 Knowing where state lives makes the CLI predictable: if something looks wrong, peek at `.arkor/state.json` and `~/.arkor/credentials.json` before reaching for support.

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -1,0 +1,56 @@
+---
+title: "Studio"
+description: "The local web UI that watches your training runs and lets you chat with checkpoints."
+---
+
+# Studio
+
+Studio is the local web UI you get when you run `arkor dev`. It is not a separate service to sign into; it boots on your machine, talks to the same Arkor CLI process, and goes away when you stop the dev server.
+
+## What Studio is for
+
+Three jobs:
+
+1. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
+2. **Try the model out, including mid-run.** A Playground page lets you pick the base model or any saved checkpoint adapter and chat with it. Comparing a checkpoint at step 50 against the base model is a few clicks.
+3. **Stay in the dev loop.** Studio reflects whatever trainer you have in `src/arkor/`. Edit `trainer.ts`, save, and the next run shows up automatically.
+
+## Where Studio runs
+
+When you start `arkor dev`, the CLI:
+
+1. Boots a Hono server on `127.0.0.1:4000` (use `-p` to change the port).
+2. Serves a Vite + React SPA from the same origin so the UI talks to the CLI through `/api/*` on loopback.
+3. Issues a per-launch CSRF token (saved to `~/.arkor/studio-token` with mode `0600`) and requires every request to present it.
+
+The server only binds to loopback and rejects requests with a non-loopback `Host` header. There is no public URL, no inbound connection, and the token rotates every time you start `arkor dev`. You can run Studio safely on a shared dev machine without worrying about exposing your training data.
+
+## How Studio fits with the managed backend
+
+Studio is just a viewer for what your CLI is doing. The CLI talks to the managed backend over authenticated HTTPS; Studio asks the CLI (over loopback) what to render.
+
+```
+Studio (browser tab)
+   │  /api/* on loopback, CSRF-token gated
+   ▼
+arkor CLI (your machine)
+   │  authenticated HTTPS
+   ▼
+Arkor managed backend (training, inference)
+```
+
+That separation is why Studio works without you logging into anything in the browser: the CLI already has your credentials in `~/.arkor/credentials.json`, and Studio inherits them by virtue of running locally.
+
+## What you actually see
+
+The current views are intentionally small:
+
+- **Jobs.** Status, name, created time, and ID, polled every few seconds.
+- **Job detail.** Loss chart, log tail (most recent events), and live status. Streamed via Server-Sent Events so it stays current without manual refresh.
+- **Playground.** Adapter selector (base model or any checkpoint from your jobs), a chat UI, and a streaming response. Calls flow through the CLI, then to the managed inference endpoint.
+
+A walkthrough of each view with screenshots lives in the Studio section (coming next in the docs).
+
+## When not to use Studio
+
+Studio is a development tool. It runs on your machine, only on loopback, and only while `arkor dev` is up. For production usage of a fine-tuned model you would call `infer` from your own application code (or wire it into whatever serving layer you ship), not point users at Studio.

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -15,7 +15,7 @@ Three jobs:
 2. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
 3. **Try a finished model.** A Playground page lets you pick the base model or the final adapter from any completed job and chat with it. The Playground does not load intermediate checkpoints; for mid-run inference, use [`onCheckpoint`](/concepts/lifecycle) callbacks in your trainer.
 
-A note on the dev loop: Studio reflects whatever `src/arkor/` exports, but Arkor does **not** automatically rebuild your trainer on file changes. If you edit `trainer.ts`, run `arkor build` (or delete `.arkor/build/index.mjs`) before kicking off the next run so it picks up your edits.
+A note on the dev loop: while `arkor dev` is running, Studio's manifest endpoint rebuilds and re-imports your trainer on every request (with a cache-bust query, see `packages/arkor/src/studio/manifest.ts`). The UI hits that endpoint on page loads, so edits to `src/arkor/` are picked up automatically: save the file, switch tabs in Studio, and the next Run training click compiles and submits the latest code. No manual rebuild step.
 
 ## Where Studio runs
 

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -47,7 +47,7 @@ The current views are intentionally small:
 
 - **Jobs.** Status, name, created time, and ID, polled every few seconds.
 - **Job detail.** Loss chart, log tail (most recent events), and live status. Streamed via Server-Sent Events so it stays current without manual refresh.
-- **Playground.** Adapter selector (base model or any checkpoint from your jobs), a chat UI, and a streaming response. Calls flow through the CLI, then to the managed inference endpoint.
+- **Playground.** Adapter selector (base model or the final adapter from any completed job), a chat UI, and a streaming response. Calls flow through the CLI, then to the managed inference endpoint. The Playground only lists jobs that have finished. To run inference against an intermediate checkpoint while a run is still in flight, use [`onCheckpoint`](/concepts/lifecycle) callbacks instead.
 
 A walkthrough of each view with screenshots lives in the Studio section (coming next in the docs).
 

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Studio"
-description: "The local web UI that watches your training runs and lets you chat with checkpoints."
+description: "The local web UI for starting training runs, watching them stream, and chatting with finished models."
 ---
 
 # Studio
@@ -11,9 +11,11 @@ Studio is the local web UI you get when you run `arkor dev`. It is not a separat
 
 Three jobs:
 
-1. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
-2. **Try the model out, including mid-run.** A Playground page lets you pick the base model or any saved checkpoint adapter and chat with it. Comparing a checkpoint at step 50 against the base model is a few clicks.
-3. **Stay in the dev loop.** Studio reflects whatever trainer you have in `src/arkor/`. Edit `trainer.ts`, save, and the next run shows up automatically.
+1. **Start a training run.** A "Run training" button compiles your trainer (via `arkor start` under the hood) and submits the job to the managed backend.
+2. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
+3. **Try a finished model.** A Playground page lets you pick the base model or the final adapter from any completed job and chat with it. The Playground does not load intermediate checkpoints; for mid-run inference, use [`onCheckpoint`](/concepts/lifecycle) callbacks in your trainer.
+
+A note on the dev loop: Studio reflects whatever `src/arkor/` exports, but Arkor does **not** automatically rebuild your trainer on file changes. If you edit `trainer.ts`, run `arkor build` (or delete `.arkor/build/index.mjs`) before kicking off the next run so it picks up your edits.
 
 ## Where Studio runs
 

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -11,7 +11,7 @@ Studio is the local web UI you get when you run `arkor dev`. It is not a separat
 
 Three jobs:
 
-1. **Start a training run.** A "Run training" button compiles your trainer (via `arkor start` under the hood) and submits the job to the managed backend.
+1. **Start a training run.** A "Run training" button submits the job to the managed backend by spawning `arkor start` under the hood. `arkor start` runs the existing `.arkor/build/index.mjs` artifact (and only auto-builds it when missing); see the dev-loop note below for how Studio keeps that artifact fresh.
 2. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
 3. **Try a finished model.** A Playground page lets you pick the base model or the final adapter from any completed job and chat with it. The Playground does not load intermediate checkpoints; for mid-run inference, use [`onCheckpoint`](/concepts/lifecycle) callbacks in your trainer.
 

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -15,7 +15,7 @@ Three jobs:
 2. **See training happen.** A jobs list with live status, a loss chart that updates as the run streams in, and a tail of training events. You can leave it open in a tab while you work on other things.
 3. **Try a finished model.** A Playground page lets you pick the base model or the final adapter from any completed job and chat with it. The Playground does not load intermediate checkpoints; for mid-run inference, use [`onCheckpoint`](/concepts/lifecycle) callbacks in your trainer.
 
-A note on the dev loop: while `arkor dev` is running, Studio's manifest endpoint rebuilds and re-imports your trainer on every request (with a cache-bust query, see `packages/arkor/src/studio/manifest.ts`). The UI hits that endpoint on page loads, so edits to `src/arkor/` are picked up automatically: save the file, switch tabs in Studio, and the next Run training click compiles and submits the latest code. No manual rebuild step.
+A note on the dev loop: Studio's `/api/manifest` endpoint rebuilds and re-imports your trainer on every request (with a cache-bust query, see `packages/arkor/src/studio/manifest.ts`), but the UI only fetches it when the Run training page mounts. So if you edit `src/arkor/` and stay on the same Run training page, the next click reuses the existing `.arkor/build/index.mjs` and runs your old code. Refresh the page (or run `arkor build` from the terminal) between edits and clicks to pick up the new code reliably.
 
 ## Where Studio runs
 

--- a/docs/concepts/trainer.mdx
+++ b/docs/concepts/trainer.mdx
@@ -116,12 +116,24 @@ const trainer = createTrainer({
 controller.abort();
 ```
 
-`abortSignal` is **only** about your local `wait()`: aborting it stops the SSE event-stream fetch and any retry / backoff delays inside `wait()`, so `wait()` returns and your process can move on. It does **not** call `cancel()` and does **not** ask the backend to stop the run; the job keeps using GPU time on the managed side.
-
-If you want to actually stop training (and the cost), call `trainer.cancel()` separately:
+`abortSignal` is **only** about your local `wait()`: aborting it stops the SSE event-stream fetch and any retry / backoff delays inside `wait()`. The current implementation throws on abort (the backoff `delay` rejects with `signal.reason`, and the failure handler re-throws when the signal is aborted), so `wait()` rejects rather than resolving cleanly. Wrap it in `try / catch` if you abort:
 
 ```ts
-controller.abort();          // stops your local wait() loop
+try {
+  await trainer.wait();
+} catch (err) {
+  if (controller.signal.aborted) {
+    // expected: we asked wait() to stop
+  } else {
+    throw err;
+  }
+}
+```
+
+`abortSignal` does **not** call `cancel()` and does **not** ask the backend to stop the run; the job keeps using GPU time on the managed side. If you want to actually stop training (and the cost), call `trainer.cancel()` separately:
+
+```ts
+controller.abort();          // local wait() rejects
 await trainer.cancel();      // asks the backend to stop the job
 ```
 

--- a/docs/concepts/trainer.mdx
+++ b/docs/concepts/trainer.mdx
@@ -82,7 +82,7 @@ createTrainer({
 });
 ```
 
-`dryRun: true` tells the backend to validate the trainer end to end without burning real GPU time. Useful in CI or when wiring up callbacks for the first time.
+`dryRun: true` tells the backend to run a minimal end-to-end smoke test of the trainer: the full pipeline (including the training loop) executes against a truncated dataset / capped step count so it finishes quickly. It still uses GPU time, just much less of it. Useful in CI or when wiring up callbacks for the first time.
 
 ## What `createTrainer` returns
 
@@ -95,13 +95,13 @@ interface Trainer {
 }
 ```
 
-- **`start()`** kicks off the run on the managed backend and resolves with the assigned `jobId`. It does not wait for completion.
-- **`wait()`** returns once the run finishes (or fails). All registered callbacks fire while it is in flight; this is how you observe the run.
-- **`cancel()`** asks the backend to stop the run. Safe to call after the run already finished.
+- **`start()`** submits the job to the managed backend and resolves with the assigned `jobId`. It does not wait for completion, and it does **not** dispatch any callbacks on its own.
+- **`wait()`** opens the SSE event stream for the run and returns once the run finishes (or fails). All registered callbacks fire from inside `wait()`; if you call `start()` without later calling `wait()`, no callbacks ever run.
+- **`cancel()`** asks the backend to stop the run. This is a best-effort request: the backend may return an error if the run is already in a terminal state (completed, failed, or already cancelled), so be prepared to catch.
 
-`pnpm dev` (which is `arkor dev` underneath) and `arkor start` both call `start()` and `wait()` for you. You only call them directly if you wire training into your own code outside the CLI.
+`arkor start` calls `start()` and `wait()` for you (it is what Studio's "Run training" button spawns under the hood). `arkor dev` does **not** run the trainer; it only boots the Studio UI. Call `start()` and `wait()` directly only if you wire training into your own code outside the CLI.
 
-## Cancellation with `AbortSignal`
+## Stopping `wait()` with `AbortSignal`
 
 ```ts
 const controller = new AbortController();
@@ -116,7 +116,16 @@ const trainer = createTrainer({
 controller.abort();
 ```
 
-Aborting the signal is equivalent to calling `cancel()`. Useful when you want to tie the run to a timeout, a request lifetime, or a parent process that exits.
+`abortSignal` is **only** about your local `wait()`: aborting it stops the SSE event-stream fetch and any retry / backoff delays inside `wait()`, so `wait()` returns and your process can move on. It does **not** call `cancel()` and does **not** ask the backend to stop the run; the job keeps using GPU time on the managed side.
+
+If you want to actually stop training (and the cost), call `trainer.cancel()` separately:
+
+```ts
+controller.abort();          // stops your local wait() loop
+await trainer.cancel();      // asks the backend to stop the job
+```
+
+Use `abortSignal` for "I no longer care about waiting on this run" (a request timed out, a parent process is exiting). Use `cancel()` for "stop the run on the backend".
 
 ## Reacting to events
 

--- a/docs/concepts/trainer.mdx
+++ b/docs/concepts/trainer.mdx
@@ -1,0 +1,123 @@
+---
+title: "Trainer"
+description: "createTrainer: required fields, dataset sources, LoRA settings, and the start / wait / cancel lifecycle."
+---
+
+# Trainer
+
+`createTrainer` is the heart of an Arkor project. Everything Arkor knows about a fine-tuning run, from the base model down to the LoRA rank, is on the object you pass in.
+
+## Minimal example
+
+```ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+});
+```
+
+That alone is a valid trainer. Defaults are filled in for everything else.
+
+## Required fields
+
+| Field     | Type            | Notes                                                      |
+| --------- | --------------- | ---------------------------------------------------------- |
+| `name`    | `string`        | Job name shown in Studio and the managed backend.          |
+| `model`   | `string`        | A model identifier the backend recognizes (Gemma today).   |
+| `dataset` | `DatasetSource` | See [Dataset sources](#dataset-sources).                   |
+
+## Dataset sources
+
+`DatasetSource` is a discriminated union on `type`:
+
+```ts
+type DatasetSource =
+  | { type: "huggingface"; name: string; split?: string; subset?: string }
+  | { type: "blob";        url: string;  token?: string };
+```
+
+- **HuggingFace**. The most common shape. Arkor pulls the dataset by name. Use `split` to override the default split and `subset` for datasets that publish multiple subsets.
+- **Blob URL**. Any HTTPS URL the backend can fetch. Pass `token` if the URL needs an `Authorization: Bearer` header.
+
+## LoRA configuration
+
+Pass `lora` to control LoRA settings. All four fields are typed:
+
+```ts
+lora?: {
+  r: number;             // LoRA rank
+  alpha: number;         // LoRA alpha
+  maxLength?: number;    // Maximum sequence length
+  loadIn4bit?: boolean;  // QLoRA quantization
+}
+```
+
+If you omit `lora`, the backend applies sensible defaults. `r: 16, alpha: 16` is a good starting point for the bundled templates.
+
+## Common hyperparameters
+
+| Field             | Type     | What it does                                                |
+| ----------------- | -------- | ----------------------------------------------------------- |
+| `maxSteps`        | `number` | Cap on training steps. Often the simplest knob to turn.     |
+| `numTrainEpochs`  | `number` | Alternative to `maxSteps`: number of dataset passes.        |
+| `learningRate`    | `number` | Step size for the optimizer.                                |
+| `batchSize`       | `number` | Per-device training batch size.                             |
+| `optim`           | `string` | Optimizer name (the backend list governs valid values).     |
+| `lrSchedulerType` | `string` | LR schedule (linear, cosine, etc).                          |
+| `weightDecay`     | `number` | Regularization weight.                                      |
+
+If you only set `maxSteps`, the rest stay at backend defaults. That is usually what you want for the first few runs.
+
+## Smoke testing with `dryRun`
+
+```ts
+createTrainer({
+  name: "smoke",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  dryRun: true,
+});
+```
+
+`dryRun: true` tells the backend to validate the trainer end to end without burning real GPU time. Useful in CI or when wiring up callbacks for the first time.
+
+## What `createTrainer` returns
+
+```ts
+interface Trainer {
+  readonly name: string;
+  start(): Promise<{ jobId: string }>;
+  wait(): Promise<TrainingResult>;
+  cancel(): Promise<void>;
+}
+```
+
+- **`start()`** kicks off the run on the managed backend and resolves with the assigned `jobId`. It does not wait for completion.
+- **`wait()`** returns once the run finishes (or fails). All registered callbacks fire while it is in flight; this is how you observe the run.
+- **`cancel()`** asks the backend to stop the run. Safe to call after the run already finished.
+
+`pnpm dev` (which is `arkor dev` underneath) and `arkor start` both call `start()` and `wait()` for you. You only call them directly if you wire training into your own code outside the CLI.
+
+## Cancellation with `AbortSignal`
+
+```ts
+const controller = new AbortController();
+const trainer = createTrainer({
+  name: "cancellable",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  abortSignal: controller.signal,
+});
+
+// Later, from anywhere:
+controller.abort();
+```
+
+Aborting the signal is equivalent to calling `cancel()`. Useful when you want to tie the run to a timeout, a request lifetime, or a parent process that exits.
+
+## Reacting to events
+
+The whole point of doing this in TypeScript is that you can hook into the run with [lifecycle callbacks](/concepts/lifecycle): `onStarted`, `onLog`, `onCheckpoint`, `onCompleted`, `onFailed`. That is the next concept to read.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,13 @@
       },
       {
         "group": "Concepts",
-        "pages": ["concepts/overview"]
+        "pages": [
+          "concepts/overview",
+          "concepts/project-structure",
+          "concepts/trainer",
+          "concepts/lifecycle",
+          "concepts/studio"
+        ]
       },
       {
         "group": "CLI",


### PR DESCRIPTION
## Summary

Second content PR in the docs series. Fills out the Concepts section with the mental model readers need before reaching for the SDK and CLI references. All claims were verified against the actual source so the docs do not promise behavior the runtime does not deliver yet.

### Pages

- `concepts/overview.mdx` (rewrite). Hub page; reads in under a minute and points at the four new pages.
- `concepts/project-structure.mdx` (new). `src/arkor/{index,trainer}.ts`, the role of `.arkor/` (per-project state) vs `~/.arkor/` (per-user credentials and Studio token), and an honest note that `arkor.config.ts` is currently a placeholder the runtime does not read.
- `concepts/trainer.mdx` (new). `createTrainer` shape: required vs optional fields, `DatasetSource` union (huggingface / blob), full `LoraConfig` (`r`, `alpha`, `maxLength`, `loadIn4bit`), common hyperparameters, `dryRun`, the `start / wait / cancel` lifecycle, and `AbortSignal`.
- `concepts/lifecycle.mdx` (new). Timeline diagram for the five callbacks, exact argument shapes from the source (`TrainingLogContext`, `CheckpointContext`), the fact that `onFailed.error` is a `string` and not an `Error`, and a complete worked example.
- `concepts/studio.mdx` (new). What Studio is for, the loopback + CSRF security model (per-launch token at `~/.arkor/studio-token`, mode 0600), the three views (Jobs, Job detail, Playground), and when not to use it.

`docs/docs.json` navigation updated to list the four new pages under Concepts.

## Verification done against the source

To avoid spec drift between docs and code, content was checked against:
- `packages/arkor/src/core/arkor.ts` and `packages/arkor/src/core/types.ts` for `createArkor` / `createTrainer` / `LoraConfig` / `DatasetSource` / `TrainerCallbacks` shapes
- `packages/arkor/src/cli/commands/{dev,build,login,logout,whoami,init,start}.ts` for CLI behavior references
- `packages/cli-internal/src/templates.ts` for the scaffolded `arkor.config.ts` template

One discrepancy worth flagging here (not in the docs): the runtime does not currently read `arkor.config.ts`. The docs reflect this honestly rather than papering over it.

## Out of scope

- SDK / CLI / Studio reference pages land in their own PRs (3, 4, 5).
- Cookbook pages land in PR 6.
- No `docs.json` color or theme changes.

## Test plan

- [x] `pnpm --filter @arkor/docs exec mint validate` passes
- [x] `pnpm --filter @arkor/docs exec mint broken-links` passes
- [x] `pnpm --filter @arkor/docs docs:dev` renders the new pages with correct headings, code blocks, tables, and the timeline diagram in lifecycle.mdx
- [ ] Mintlify preview deploy (`https://arkor-92aeef0e-eng-536.mintlify.app`) renders without layout issues

## Conflict surface vs PR #55 (Get started)

This PR only touches `docs/concepts/*` and `docs/docs.json` (Concepts group only). PR #55 only touches `docs/introduction.mdx` and `docs/quickstart.mdx`. They merge in either order without conflict.