### PR TITLE
fix(studio): use a dedicated error role for Playground failures

### DIFF
--- a/packages/studio-app/src/pages/Playground.tsx
+++ b/packages/studio-app/src/pages/Playground.tsx
@@ -7,7 +7,7 @@ import {
 } from "../lib/baseModels";
 
 interface Message {
-  role: "system" | "user" | "assistant";
+  role: "system" | "user" | "assistant" | "error";
   content: string;
 }
 
@@ -39,18 +39,22 @@ export function Playground() {
 
   async function send() {
     if (!canSend) return;
-    const userMsg: Message = { role: "user", content: input };
+    const userMsg = { role: "user", content: input } as const;
     setMessages((prev) => [...prev, userMsg, { role: "assistant", content: "" }]);
     setInput("");
     setStreaming(true);
     responseRef.current = "";
 
     try {
+      const history = messages.filter(
+        (m): m is { role: "system" | "user" | "assistant"; content: string } =>
+          m.role !== "error",
+      );
       const stream = streamInferenceContent({
         ...(mode === "base"
           ? { baseModel }
           : { adapter: { kind: "final", jobId: selectedJob! } }),
-        messages: [...messages, userMsg],
+        messages: [...history, userMsg],
         stream: true,
       });
       for await (const fragment of stream) {
@@ -63,13 +67,18 @@ export function Playground() {
         });
       }
     } catch (err) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: "assistant",
-          content: `[error] ${err instanceof Error ? err.message : String(err)}`,
-        },
-      ]);
+      const content = err instanceof Error ? err.message : String(err);
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        const errorMsg: Message = { role: "error", content };
+        if (last && last.role === "assistant" && last.content === "") {
+          const out = prev.slice();
+          out[out.length - 1] = errorMsg;
+          return out;
+        }
+        return [...prev, errorMsg];
+      });
+      track("studio_sse_error", { source: "inference" });
     } finally {
       setStreaming(false);
     }


### PR DESCRIPTION
## Summary

- Inference errors in the Playground used to reuse `role: "assistant"` for the error bubble while leaving the empty placeholder in place, so every failed send rendered as two `ASSISTANT` labels (one empty + one `[error] …`). Repeated failures made the chat look like ASSISTANT spam.
- Add a dedicated `"error"` role to `Message`. The catch path now (a) replaces the empty assistant placeholder when present, (b) otherwise appends the error so any partial streaming output from before the failure is preserved.
- Filter `"error"` messages out of the history forwarded to `/api/inference/chat` — cloud-api's `ChatRequestBody` only accepts `system | user | assistant`, and previous error bubbles shouldn't poison the next prompt's context.
- Wire `track("studio_sse_error", { source: "inference" })` on the failure path so Playground inference failures land in the existing SPA telemetry channel.

## Test plan

- [x] `pnpm --filter @arkor/studio-app exec tsc --noEmit`
- [x] `pnpm --filter @arkor/studio-app test` (46 passed)
- [ ] Manual: force an inference error in the Playground (e.g. stop cloud-api or pick an invalid adapter), confirm exactly one `ERROR` bubble per failed send, and that the next successful send does not include the prior error in the request body.
