### PR TITLE
docs: write SDK reference (createArkor, createTrainer, callbacks, infer, control)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -36,7 +36,15 @@
       },
       {
         "group": "SDK",
-        "pages": ["sdk/overview"]
+        "pages": [
+          "sdk/overview",
+          "sdk/create-arkor",
+          "sdk/create-trainer",
+          "sdk/dataset",
+          "sdk/callbacks",
+          "sdk/infer",
+          "sdk/trainer-control"
+        ]
       }
     ]
   },

--- a/docs/sdk/callbacks.mdx
+++ b/docs/sdk/callbacks.mdx
@@ -122,7 +122,7 @@ Throwing inside a callback does **not** behave like a normal Promise rejection. 
 2. Otherwise, if `maxReconnectAttempts` was configured and the counter is exceeded, `wait()` rejects with a wrapping error.
 3. Otherwise, the SDK delays and reopens the SSE stream.
 
-`maxReconnectAttempts` defaults to `undefined` (unlimited), and there is no public way to set it from `createTrainer` today. In practice that means a thrown callback is **caught and retried**, possibly indefinitely. If `Last-Event-ID` advances across the retry, the originally failing event is also skipped.
+`maxReconnectAttempts` defaults to `undefined` (unlimited). It is not configurable through `TrainerInput`; the only way to set it is the second `context` argument to `createTrainer`, which is annotated `@internal` and may change without notice. In practice, with default settings, a thrown callback is **caught and retried**, possibly indefinitely. If `Last-Event-ID` advances across the retry, the originally failing event is also skipped.
 
 For deterministic error handling, catch inside the callback:
 

--- a/docs/sdk/callbacks.mdx
+++ b/docs/sdk/callbacks.mdx
@@ -70,7 +70,7 @@ onLog: ({ step, loss, evalLoss }) => {
 }
 ```
 
-Common uses: forward metrics to your own pipeline (PostHog, Datadog), detect divergence early, implement custom early-stopping by aborting the trainer.
+Common uses: forward metrics to your own pipeline (PostHog, Datadog), detect divergence early, and implement custom early-stopping. For early-stopping, remember that aborting the [`abortSignal`](/sdk/trainer-control#abortsignal) only stops your local `wait()`; call [`trainer.cancel()`](/sdk/trainer-control#cancel) afterwards to actually stop the GPU on the backend.
 
 ## `onCheckpoint({ step, adapter, job, infer, artifacts })`
 

--- a/docs/sdk/callbacks.mdx
+++ b/docs/sdk/callbacks.mdx
@@ -1,0 +1,162 @@
+---
+title: "Lifecycle callbacks"
+description: "The five callbacks Arkor fires while a training run streams from the backend."
+---
+
+# Lifecycle callbacks
+
+Pass callbacks under `createTrainer({ callbacks: { ... } })`. All five are optional; the SDK type is `Partial<TrainerCallbacks>`. They run inside `trainer.wait()`, dispatched from the backend's SSE event stream.
+
+```ts
+createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  callbacks: {
+    onStarted: ({ job }) => console.log(`run ${job.id} accepted`),
+    onLog: ({ step, loss }) => {
+      if (loss !== null) console.log(`step=${step} loss=${loss.toFixed(4)}`);
+    },
+    onCheckpoint: async ({ step, infer }) => {
+      const res = await infer({
+        messages: [{ role: "user", content: "Hello" }],
+      });
+      console.log(`ckpt @ ${step}:`, await res.text());
+    },
+    onCompleted: ({ job }) => console.log(`run ${job.id} done`),
+    onFailed: ({ error }) => console.error(`failed: ${error}`),
+  },
+});
+```
+
+## When each callback fires
+
+```
+trainer.start()    submits the job and returns { jobId }. No callbacks yet.
+   │
+   ▼
+trainer.wait()     opens the SSE stream. Callbacks dispatch from here.
+   │
+   ▼
+onStarted          once, on the `training.started` event
+onLog              many times, one per metrics frame
+onCheckpoint       several times, one per checkpoint upload
+onCompleted        once, on `training.completed`
+        ── or ──
+onFailed           once, on `training.failed` (backend-reported failure)
+```
+
+If you call `start()` without `wait()`, no callbacks ever run. `arkor start` calls both for you; programmatic callers must do the same.
+
+## `onStarted({ job })`
+
+Fires when the SSE stream reports `training.started`. Use it for log lines or a "training started" notification.
+
+```ts
+onStarted: ({ job }) => {
+  // job: TrainingJob (id, name, status, config, ...)
+}
+```
+
+## `onLog({ step, loss, evalLoss, learningRate, epoch, samplesPerSecond, job })`
+
+Fires repeatedly as training progresses. Each numeric field is `number | null`: backends only fill in fields they have on a given step (so `evalLoss` is null on non-eval steps, `learningRate` may be null between LR-scheduler updates, etc.).
+
+```ts
+onLog: ({ step, loss, evalLoss }) => {
+  if (loss !== null) {
+    forwardToMetrics({ step, loss, evalLoss });
+  }
+}
+```
+
+Common uses: forward metrics to your own pipeline (PostHog, Datadog), detect divergence early, implement custom early-stopping by aborting the trainer.
+
+## `onCheckpoint({ step, adapter, job, infer, artifacts })`
+
+Fires when an adapter checkpoint is saved on the backend, while the run is still going. `adapter` is `{ kind: "checkpoint", jobId, step }`. `infer` is described in detail on the [infer](/sdk/infer) page; in short it takes a chat-style request and returns a raw `Response`.
+
+```ts
+onCheckpoint: async ({ step, infer }) => {
+  const res = await infer({
+    messages: [{ role: "user", content: "Can't log in" }],
+  });
+  const sample = await res.text();
+  // Decide whether the model is on track
+}
+```
+
+This is where most of the value of doing fine-tuning in TypeScript lives: you can run the half-trained model against a held-out prompt before the full run finishes.
+
+## `onCompleted({ job, artifacts })`
+
+Fires once on success. `artifacts` is `unknown[]`: the raw artifact list the backend sent. Schemas evolve, so the SDK does not narrow it.
+
+```ts
+onCompleted: ({ job, artifacts }) => {
+  saveAdapterId({ jobId: job.id, count: artifacts.length });
+}
+```
+
+## `onFailed({ job, error })`
+
+Fires once on a backend-reported failure. `error` is a `string` (the message the backend sent), not an `Error` instance.
+
+```ts
+onFailed: ({ job, error }) => {
+  // error: string
+}
+```
+
+`onFailed` is **only** for backend-side failures. Exceptions thrown inside your other callbacks do not reach `onFailed`; see below for what does happen to them.
+
+## Sequencing
+
+Each callback is awaited before the next event is dispatched. You can return a promise (writing to a database, posting to Slack, calling `infer`) and the SDK will wait for it before processing the next frame. There are no concurrent callback invocations for the same trainer.
+
+## Exception handling (read carefully)
+
+Throwing inside a callback does **not** behave like a normal Promise rejection. The SDK's event loop wraps dispatch in a try/catch and routes any throw to the SSE reconnect handler (`packages/arkor/src/core/trainer.ts:335-364`, then `handleFailure` at `:307-320`):
+
+1. If `abortSignal.aborted` is set, the error re-throws and `wait()` rejects.
+2. Otherwise, if `maxReconnectAttempts` was configured and the counter is exceeded, `wait()` rejects with a wrapping error.
+3. Otherwise, the SDK delays and reopens the SSE stream.
+
+`maxReconnectAttempts` defaults to `undefined` (unlimited), and there is no public way to set it from `createTrainer` today. In practice that means a thrown callback is **caught and retried**, possibly indefinitely. If `Last-Event-ID` advances across the retry, the originally failing event is also skipped.
+
+For deterministic error handling, catch inside the callback:
+
+```ts
+onCheckpoint: async ({ step, infer }) => {
+  try {
+    await sendToReview({ step, sample: await (await infer({ ... })).text() });
+  } catch (err) {
+    // log / metric / decide whether to fail the run yourself by calling
+    // trainer.cancel() from outside the callback
+  }
+}
+```
+
+## Type sketches
+
+```ts
+interface TrainingLogContext {
+  step: number;
+  loss: number | null;
+  evalLoss: number | null;
+  learningRate: number | null;
+  epoch: number | null;
+  samplesPerSecond: number | null;
+  job: TrainingJob;
+}
+
+interface CheckpointContext {
+  step: number;
+  adapter: { kind: "checkpoint"; jobId: string; step: number };
+  job: TrainingJob;
+  infer: (args: InferArgs) => Promise<Response>;
+  artifacts?: unknown[];
+}
+```
+
+`TrainingLogContext` and `CheckpointContext` are not exported by name from `arkor`; mirror the shapes inline if you want typed callback parameters in your own code.

--- a/docs/sdk/create-arkor.mdx
+++ b/docs/sdk/create-arkor.mdx
@@ -37,7 +37,7 @@ The returned object is `Object.freeze`-d. There are no methods on it; the framew
 
 ## What works today
 
-- `trainer`: pass a `Trainer` produced by [`createTrainer`](/sdk/create-trainer). Optional in the type, but a manifest with no `trainer` cannot be run by `arkor start` (the runner throws `Training entry must export 'arkor' (from createArkor({...})) or 'trainer'...`).
+- `trainer`: pass a `Trainer` produced by [`createTrainer`](/sdk/create-trainer). Optional in the type, but a manifest with no `trainer` cannot be run by `arkor start` (the runner throws ``Training entry must export `arkor` (from createArkor({...})) or `trainer` (from createTrainer({...})), or default-export one of them.``).
 
 ## Not yet
 
@@ -63,4 +63,4 @@ if (isArkor(value)) {
 }
 ```
 
-A small type guard exported alongside `createArkor` for code that consumes manifests dynamically. It checks `_kind === "arkor"` on a frozen object. Use it sparingly; in normal code the typed export from `index.ts` already gives you the right shape.
+A small type guard exported alongside `createArkor` for code that consumes manifests dynamically. It checks that the value is a non-null object with `_kind === "arkor"` (it does **not** verify `Object.isFrozen`, even though `createArkor` itself produces a frozen value). Use it sparingly; in normal code the typed export from `index.ts` already gives you the right shape.

--- a/docs/sdk/create-arkor.mdx
+++ b/docs/sdk/create-arkor.mdx
@@ -1,0 +1,66 @@
+---
+title: "createArkor"
+description: "Wrap a Trainer into an Arkor project manifest the CLI and Studio can discover."
+---
+
+# `createArkor`
+
+```ts
+import { createArkor } from "arkor";
+import { trainer } from "./trainer";
+
+export const arkor = createArkor({ trainer });
+```
+
+`createArkor` produces the project manifest that `arkor dev`, `arkor start`, and Studio's `/api/manifest` endpoint look for in `src/arkor/index.ts`. Today the manifest only carries a `Trainer`; the type reserves space for `deploy` and `eval` slots, but neither is implemented.
+
+## Signature
+
+```ts
+function createArkor(input: ArkorInput): Arkor;
+
+interface ArkorInput {
+  trainer?: Trainer;
+  // future: deploy?: Deploy;
+  // future: eval?: Eval;
+}
+
+interface Arkor {
+  readonly _kind: "arkor";
+  readonly trainer?: Trainer;
+  // future: readonly deploy?: Deploy;
+  // future: readonly eval?: Eval;
+}
+```
+
+The returned object is `Object.freeze`-d. There are no methods on it; the framework reads `_kind` and `trainer` directly.
+
+## What works today
+
+- `trainer`: pass a `Trainer` produced by [`createTrainer`](/sdk/create-trainer). Optional in the type, but a manifest with no `trainer` cannot be run by `arkor start` (the runner throws `Training entry must export 'arkor' (from createArkor({...})) or 'trainer'...`).
+
+## Not yet
+
+- `deploy` and `eval` slots. They appear in `ArkorInput` and `Arkor` as commented-out reserved fields. Passing them today is a type error, and there is no runtime path for them. Treat them as roadmap markers, not as forward-compatible API.
+
+## Recognized export shapes
+
+`arkor start` (via `runTrainer`) inspects `src/arkor/index.ts` for one of three exports, in priority order:
+
+1. `export const arkor = createArkor({ ... })` (preferred, what the templates produce)
+2. `export const trainer = createTrainer({ ... })` (power-user shortcut, no manifest)
+3. `export default ...` (either an `Arkor` manifest or a bare `Trainer`)
+
+If none match, the runner throws with the message above. Templates always emit shape 1; pick that unless you know why you want one of the others.
+
+## `isArkor`
+
+```ts
+import { isArkor } from "arkor";
+
+if (isArkor(value)) {
+  // value: Arkor
+}
+```
+
+A small type guard exported alongside `createArkor` for code that consumes manifests dynamically. It checks `_kind === "arkor"` on a frozen object. Use it sparingly; in normal code the typed export from `index.ts` already gives you the right shape.

--- a/docs/sdk/create-trainer.mdx
+++ b/docs/sdk/create-trainer.mdx
@@ -17,7 +17,7 @@ export const trainer = createTrainer({
 });
 ```
 
-`createTrainer` returns a `Trainer` object with `start` / `wait` / `cancel` methods (see [Trainer control](/sdk/trainer-control)). All shape and validation lives on the `TrainerInput` you pass in.
+`createTrainer` returns a `Trainer` object with `start` / `wait` / `cancel` methods (see [Trainer control](/sdk/trainer-control)). The function does **not** run client-side validation on `TrainerInput`: TypeScript checks the typed fields at compile time, and the rest is forwarded to the cloud-api when `start()` runs. Bad values surface as backend errors during the run, not as client-side throws at construction.
 
 ## Required fields
 

--- a/docs/sdk/create-trainer.mdx
+++ b/docs/sdk/create-trainer.mdx
@@ -1,0 +1,90 @@
+---
+title: "createTrainer"
+description: "Define a fine-tuning run: model, dataset, LoRA, hyperparameters, callbacks."
+---
+
+# `createTrainer`
+
+```ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  lora: { r: 16, alpha: 16 },
+  maxSteps: 100,
+});
+```
+
+`createTrainer` returns a `Trainer` object with `start` / `wait` / `cancel` methods (see [Trainer control](/sdk/trainer-control)). All shape and validation lives on the `TrainerInput` you pass in.
+
+## Required fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `name` | `string` | Run name, shown in Studio and on the managed backend. |
+| `model` | `string` | Base model identifier. Today the curated templates use `unsloth/gemma-4-E4B-it`. |
+| `dataset` | [`DatasetSource`](/sdk/dataset) | HuggingFace dataset name or blob URL. |
+
+## Typed optional fields
+
+These have first-class TypeScript types and are safe to use:
+
+| Field | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `lora` | `LoraConfig` | backend default | LoRA / QLoRA knobs (`r`, `alpha`, `maxLength?`, `loadIn4bit?`). |
+| `maxSteps` | `number` | backend default | Cap on training steps. |
+| `numTrainEpochs` | `number` | backend default | Number of dataset passes (alternative to `maxSteps`). |
+| `learningRate` | `number` | backend default | Optimizer step size. |
+| `batchSize` | `number` | backend default | Per-device training batch size. |
+| `optim` | `string` | backend default | Optimizer name. |
+| `lrSchedulerType` | `string` | backend default | Learning-rate schedule (e.g. `linear`, `cosine`). |
+| `weightDecay` | `number` | backend default | Regularization weight. |
+| `dryRun` | `boolean` | `false` | Smoke test (see below). |
+| `callbacks` | `Partial<TrainerCallbacks>` | `{}` | See [Lifecycle callbacks](/sdk/callbacks). |
+| `abortSignal` | `AbortSignal` | none | Stops a local `wait()`. Does **not** cancel the backend job; see [Trainer control](/sdk/trainer-control#abortsignal). |
+
+## `LoraConfig`
+
+```ts
+interface LoraConfig {
+  r: number;            // LoRA rank (often 8 / 16 / 32)
+  alpha: number;        // LoRA alpha (often 2 × r)
+  maxLength?: number;   // Truncate samples beyond this many tokens
+  loadIn4bit?: boolean; // Load the base model in 4-bit (QLoRA)
+}
+```
+
+Omit `lora` entirely to take the backend defaults. `r: 16, alpha: 16` is the starting point the bundled templates use.
+
+## `dryRun`
+
+```ts
+createTrainer({
+  name: "smoke",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  dryRun: true,
+});
+```
+
+`dryRun: true` tells the backend to truncate the dataset and cap the number of steps so the run finishes in a couple of minutes while still exercising every stage of the pipeline (data load, chat-template render, training loop, checkpoint upload, event stream).
+
+It still uses GPU time, just much less of it. Useful in CI or when wiring up callbacks for the first time, not as a way to avoid spend entirely.
+
+## Advanced: forwarded fields
+
+These are typed as `unknown` and forwarded to the cloud API verbatim (`packages/arkor/src/core/trainer.ts:100-108`). They are reserved on the input shape so the SDK can support fields the backend exposes before the SDK has caught up with first-class typing.
+
+| Field | Status |
+| --- | --- |
+| `warmupSteps`, `loggingSteps`, `saveSteps`, `evalSteps` | Forwarded as-is. Use only if you already know the backend's expected shape. |
+| `trainOnResponsesOnly` | Forwarded as-is. |
+| `datasetFormat`, `datasetSplit` | Forwarded as-is. The dedicated `dataset` field's `split` should be preferred for HuggingFace sources. |
+
+These fields are explicitly **not** stable: the backend contract for them can change between releases, and there is no compile-time check on the value you pass. Prefer the typed fields above; reach for these only when nothing else covers what you need.
+
+## Not yet
+
+- Multi-trainer projects. `createArkor` accepts a single `trainer`; there is no array form. To register a second trainer, you would either swap the export at runtime or wait for the API to gain that shape.

--- a/docs/sdk/dataset.mdx
+++ b/docs/sdk/dataset.mdx
@@ -1,0 +1,59 @@
+---
+title: "DatasetSource"
+description: "Where the trainer pulls data from: HuggingFace name or blob URL."
+---
+
+# `DatasetSource`
+
+`createTrainer` accepts one dataset, expressed as a discriminated union on `type`:
+
+```ts
+type DatasetSource =
+  | { type: "huggingface"; name: string; split?: string; subset?: string }
+  | { type: "blob";        url: string;  token?: string };
+```
+
+## HuggingFace
+
+```ts
+dataset: {
+  type: "huggingface",
+  name: "arkorlab/triage-demo",
+  // split: "train",
+  // subset: "v1",
+}
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `type` | `"huggingface"` | Discriminant. |
+| `name` | `string` | Repository name (e.g. `arkorlab/triage-demo`). Public repos work without further auth. |
+| `split` | `string?` | Override the default split. Optional. |
+| `subset` | `string?` | For datasets that publish multiple subsets. Optional. |
+
+This is the form the bundled templates (`triage` / `translate` / `redaction`) use. Most projects start here.
+
+## Blob URL
+
+```ts
+dataset: {
+  type: "blob",
+  url: "https://example.com/data.jsonl",
+  // token: process.env.DATASET_TOKEN,
+}
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `type` | `"blob"` | Discriminant. |
+| `url` | `string` | HTTPS URL the backend can fetch. |
+| `token` | `string?` | Sent as `Authorization: Bearer <token>` if present. |
+
+Use this for datasets you host yourself (signed S3 URL, internal CDN, etc.). The backend pulls the URL once at the start of the run.
+
+## Picking a form
+
+- Reach for `huggingface` when the dataset is already on the Hub. It is the most-tested path.
+- Reach for `blob` when you need a dataset that cannot live on the Hub (proprietary content, signed URL, internal-only).
+
+Local files (`{ type: "file", path: "./data.jsonl" }`) are not in `DatasetSource` today. To use one, host it as a blob URL or upload it to a private HuggingFace repo first.

--- a/docs/sdk/dataset.mdx
+++ b/docs/sdk/dataset.mdx
@@ -47,7 +47,7 @@ dataset: {
 | --- | --- | --- |
 | `type` | `"blob"` | Discriminant. |
 | `url` | `string` | HTTPS URL the backend can fetch. |
-| `token` | `string?` | Sent as `Authorization: Bearer <token>` if present. |
+| `token` | `string?` | Forwarded to the cloud-api in the job config; the backend uses it when fetching the blob. The exact HTTP wire format (header, scheme, etc.) is backend-defined and not part of the SDK contract. |
 
 Use this for datasets you host yourself (signed S3 URL, internal CDN, etc.). The backend pulls the URL once at the start of the run.
 

--- a/docs/sdk/infer.mdx
+++ b/docs/sdk/infer.mdx
@@ -1,0 +1,78 @@
+---
+title: "infer"
+description: "Run inference against a checkpoint adapter from inside onCheckpoint."
+---
+
+# `infer`
+
+`infer` is a function passed into [`onCheckpoint`](/sdk/callbacks#oncheckpoint-step-adapter-job-infer-artifacts-) on `CheckpointContext`. It runs an inference request bound to the just-saved checkpoint adapter and returns the raw `Response`. There is no top-level `infer` export; the SDK exposes it as a callback argument so that the call is automatically scoped to the right job + checkpoint step.
+
+```ts
+onCheckpoint: async ({ step, infer }) => {
+  const res = await infer({
+    messages: [
+      { role: "user", content: "I can't log in." },
+    ],
+  });
+  console.log(`step=${step} sample=`, await res.text());
+}
+```
+
+## Input
+
+```ts
+interface InferArgs {
+  messages: Array<{
+    role: "system" | "user" | "assistant";
+    content: string;
+  }>;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  /** Default: true. Set false to get a single JSON body instead of SSE. */
+  stream?: boolean;
+  signal?: AbortSignal;
+}
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `messages` | array of `{ role, content }` | Chat history. The roles match the OpenAI / HuggingFace chat-template convention. |
+| `temperature` | `number?` | Sampling temperature. Backend default if omitted. |
+| `topP` | `number?` | Nucleus sampling. Backend default if omitted. |
+| `maxTokens` | `number?` | Maximum response tokens. Backend default if omitted. |
+| `stream` | `boolean?` | Default **true** (SSE). Set `false` for a single JSON body. |
+| `signal` | `AbortSignal?` | Aborts the local fetch. Does not stop work on the backend; the model finishes generating but you stop reading. |
+
+## Output
+
+`infer` returns `Promise<Response>`: the raw Fetch `Response`. The SDK does not parse the body; you decide how to consume it:
+
+```ts
+// Streaming (default)
+const res = await infer({ messages });
+for await (const chunk of res.body!) {
+  // chunk: Uint8Array of one or more SSE frames
+}
+
+// Or read the whole stream at once
+const text = await res.text();
+
+// Or, if you set stream: false, parse the JSON body
+const res = await infer({ messages, stream: false });
+const data = await res.json();
+```
+
+When `stream: true` (the default), the body is an SSE event stream in the same shape Studio's Playground consumes. The SDK does not currently expose a frame parser for this stream; if you need decoded text deltas, copy the small `extractInferenceDelta` helper from `packages/studio-app/src/lib/api.ts` or write a parser around `eventsource-parser`.
+
+## Constraints
+
+- `infer` lives **only** on `CheckpointContext`. There is no equivalent for completed jobs from the SDK side; for that path use the cloud-api directly or trigger the run again. Studio's Playground is the UI-level route to chat with a completed adapter.
+- The call is scoped to `{ kind: "checkpoint", jobId, step }`. You cannot retarget it to a different checkpoint or a different model from inside `onCheckpoint`.
+- The function is not memoized: every call hits the backend.
+
+## When you would use it
+
+- **Sanity check during a run.** Compare a checkpoint at step 50 to one at step 100 against a fixed prompt. If the loss curve looks fine but outputs are degraded, you find out before the run finishes.
+- **Custom early-stopping.** Combine with a simple eval prompt: if outputs diverge, abort the run via `controller.abort()` (see [`abortSignal`](/sdk/trainer-control#abortsignal)) and call `trainer.cancel()` to stop the backend.
+- **Live preview into your own UI.** Send the checkpoint output to Slack, an internal review queue, or your own app's preview channel.

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -50,7 +50,7 @@ These are exported for code that drives Arkor outside the CLI flow, e.g. running
 | Symbol | Source | Purpose |
 | --- | --- | --- |
 | `runTrainer(file?)` | `core/runner.ts` | What `arkor start` calls under the hood. Resolves the entry, picks the trainer (preferring `arkor`, then `trainer`, then default export), runs `start()` + `wait()`. |
-| `readCredentials()` / `writeCredentials()` / `ensureCredentials()` | `core/credentials.ts` | Read or write `~/.arkor/credentials.json`. `ensureCredentials` returns the existing record or throws if none. |
+| `readCredentials()` / `writeCredentials()` / `ensureCredentials()` | `core/credentials.ts` | Read or write `~/.arkor/credentials.json`. `ensureCredentials` returns the existing record if present and **bootstraps a fresh anonymous identity** (calls `requestAnonymousToken` and persists it) when no credentials exist. It throws only if the bootstrap itself fails (network / token-endpoint error). |
 | `requestAnonymousToken(baseUrl, kind?)` | `core/credentials.ts` | Mint a fresh anonymous token directly. The CLI uses this on `arkor login --anonymous` and on first `arkor dev`. |
 | `credentialsPath()` | `core/credentials.ts` | Absolute path to `~/.arkor/credentials.json`. |
 | `readState(cwd?)` / `writeState(state, cwd?)` / `statePath(cwd?)` | `core/state.ts` | Read or write `.arkor/state.json` (project routing). |

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -50,7 +50,7 @@ These are exported for code that drives Arkor outside the CLI flow, e.g. running
 | Symbol | Source | Purpose |
 | --- | --- | --- |
 | `runTrainer(file?)` | `core/runner.ts` | What `arkor start` calls under the hood. Resolves the entry, picks the trainer (preferring `arkor`, then `trainer`, then default export), runs `start()` + `wait()`. |
-| `readCredentials()` / `writeCredentials()` / `ensureCredentials()` | `core/credentials.ts` | Read or write `~/.arkor/credentials.json`. `ensureCredentials` returns the existing record if present and **bootstraps a fresh anonymous identity** (calls `requestAnonymousToken` and persists it) when no credentials exist. It throws only if the bootstrap itself fails (network / token-endpoint error). |
+| `readCredentials()` / `writeCredentials()` / `ensureCredentials()` | `core/credentials.ts` | Read or write `~/.arkor/credentials.json`. `ensureCredentials` returns the existing record if present and **bootstraps a fresh anonymous identity** (calls `requestAnonymousToken` and persists it) when no credentials exist. Throws on a few paths: the credentials file exists but is unreadable / not valid JSON (`readCredentials` does a bare `JSON.parse`), or the anonymous-token bootstrap itself fails (network / token-endpoint error). The file is assumed to be SDK-written. |
 | `requestAnonymousToken(baseUrl, kind?)` | `core/credentials.ts` | Mint a fresh anonymous token directly. The CLI uses this on `arkor login --anonymous` and on first `arkor dev`. |
 | `credentialsPath()` | `core/credentials.ts` | Absolute path to `~/.arkor/credentials.json`. |
 | `readState(cwd?)` / `writeState(state, cwd?)` / `statePath(cwd?)` | `core/state.ts` | Read or write `.arkor/state.json` (project routing). |

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -1,16 +1,72 @@
 ---
 title: "SDK"
-description: "The Arkor SDK: createArkor, createTrainer, infer, and the lifecycle callbacks."
+description: "The Arkor SDK: createArkor, createTrainer, lifecycle callbacks, infer, and the helpers around them."
 ---
 
 # SDK
 
-{/* TODO: write the real SDK reference.
+The `arkor` package exposes the TypeScript surface that the CLI and Studio sit on top of. Everything you need for a typical project lives in three primitives plus their typed inputs.
 
-APIs to document:
-- `createArkor({ trainer, deploy, eval })`
-- `createTrainer({ name, model, dataset, lora, maxSteps, callbacks })`
-- Lifecycle callbacks: onStarted, onLog, onCheckpoint, onCompleted, onFailed
-- `infer({ messages })` from inside `onCheckpoint` for sanity checks
-- Dataset shapes (HuggingFace name, JSONL, blob URL)
-*/}
+## Minimal example
+
+```ts
+// src/arkor/trainer.ts
+import { createTrainer } from "arkor";
+
+export const trainer = createTrainer({
+  name: "support-bot-v1",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  lora: { r: 16, alpha: 16 },
+  maxSteps: 100,
+});
+```
+
+```ts
+// src/arkor/index.ts
+import { createArkor } from "arkor";
+import { trainer } from "./trainer";
+
+export const arkor = createArkor({ trainer });
+```
+
+That is the whole shape `arkor dev` and `arkor start` discover.
+
+## Main API
+
+| Symbol | Page |
+| --- | --- |
+| [`createArkor(input)`](/sdk/create-arkor) | Project manifest. Wraps a `Trainer` so the CLI / Studio can find it. |
+| [`createTrainer(input)`](/sdk/create-trainer) | The fine-tuning run definition: model, dataset, LoRA, hyperparameters, callbacks. |
+| [`Trainer.start / wait / cancel`](/sdk/trainer-control) | Run-control methods. `wait()` is where lifecycle callbacks fire. |
+| [`TrainerCallbacks`](/sdk/callbacks) | The five lifecycle callbacks (`onStarted`, `onLog`, `onCheckpoint`, `onCompleted`, `onFailed`). |
+| [`InferArgs` / `infer`](/sdk/infer) | Inference inside `onCheckpoint`. Returns a raw `Response`. |
+| [`DatasetSource`](/sdk/dataset) | HuggingFace dataset name or blob URL. |
+
+## Auxiliary helpers (advanced)
+
+These are exported for code that drives Arkor outside the CLI flow, e.g. running training from your own server or a script. Most projects do not need them.
+
+| Symbol | Source | Purpose |
+| --- | --- | --- |
+| `runTrainer(file?)` | `core/runner.ts` | What `arkor start` calls under the hood. Resolves the entry, picks the trainer (preferring `arkor`, then `trainer`, then default export), runs `start()` + `wait()`. |
+| `readCredentials()` / `writeCredentials()` / `ensureCredentials()` | `core/credentials.ts` | Read or write `~/.arkor/credentials.json`. `ensureCredentials` returns the existing record or throws if none. |
+| `requestAnonymousToken(baseUrl, kind?)` | `core/credentials.ts` | Mint a fresh anonymous token directly. The CLI uses this on `arkor login --anonymous` and on first `arkor dev`. |
+| `credentialsPath()` | `core/credentials.ts` | Absolute path to `~/.arkor/credentials.json`. |
+| `readState(cwd?)` / `writeState(state, cwd?)` / `statePath(cwd?)` | `core/state.ts` | Read or write `.arkor/state.json` (project routing). |
+| `isArkor(value)` | `core/arkor.ts` | Type guard for the manifest. |
+
+## Types
+
+Public type exports (from `arkor`):
+
+`Arkor`, `ArkorInput`, `ArkorProjectState`, `BlobDatasetSource`, `DatasetSource`, `HuggingfaceDatasetSource`, `JobStatus`, `LoraConfig`, `Trainer`, `TrainerCallbacks`, `TrainerInput`, `TrainingJob`, `TrainingResult`, plus `Auth0Credentials` / `AnonymousCredentials` / `Credentials` for the auth helpers.
+
+`TrainingLogContext`, `CheckpointContext`, `InferArgs` are not exported by name today; they are documented in the [callbacks](/sdk/callbacks) and [infer](/sdk/infer) pages so you can mirror them inline if you need typed callback parameters.
+
+## Not in the public surface
+
+These exist in the source tree but are intentionally not exported from `arkor`. Treat them as internal:
+
+- `SDK_VERSION`, `defaultArkorCloudApiUrl()`: used by the CLI and Studio server. Do not import via deep paths; the export contract may change.
+- The CLI command runners (`runBuild`, `runStart`, `runDev`, `runInit`, `runLogin`, `runLogout`, `runWhoami`): they live under `src/cli/commands/` and are CLI-private. If you need to drive a training run, use `runTrainer` (above) or call `trainer.start()` / `trainer.wait()` directly.

--- a/docs/sdk/trainer-control.mdx
+++ b/docs/sdk/trainer-control.mdx
@@ -1,0 +1,136 @@
+---
+title: "Trainer control"
+description: "start, wait, cancel, abortSignal, and how reconnects work."
+---
+
+# Trainer control
+
+`createTrainer` returns a `Trainer` object with three methods:
+
+```ts
+interface Trainer {
+  readonly name: string;
+  start(): Promise<{ jobId: string }>;
+  wait(): Promise<TrainingResult>;
+  cancel(): Promise<void>;
+}
+
+interface TrainingResult {
+  job: TrainingJob;
+  artifacts: unknown[];
+}
+```
+
+`arkor start` and Studio's "Run training" button both call `start()` followed by `wait()`. You only call them yourself when you wire training into your own code (a server, a script, a custom CLI).
+
+## `start()`
+
+```ts
+const { jobId } = await trainer.start();
+```
+
+- Submits the job to the cloud API and resolves once the backend has accepted it. The returned `jobId` is the same id you see in Studio and in the SDK's `TrainingJob.id`.
+- Idempotent: calling `start()` a second time on the same trainer returns the same `jobId` without resubmitting (`packages/arkor/src/core/trainer.ts:275-289`).
+- Does **not** open the event stream and does **not** dispatch any callbacks. `wait()` is what does that.
+
+## `wait()`
+
+```ts
+const { job, artifacts } = await trainer.wait();
+```
+
+- Opens the SSE event stream for the run, dispatches each frame to your callbacks, and resolves with the terminal `TrainingResult` when the stream reports `training.completed` or `training.failed`.
+- Calls `start()` for you if you have not called it yet.
+- All five [lifecycle callbacks](/sdk/callbacks) fire from inside `wait()`. If you call `start()` without `wait()`, no callbacks run, even though the run continues on the backend.
+- Reconnects on transient SSE errors (see below).
+
+## `cancel()`
+
+```ts
+await trainer.cancel();
+```
+
+- If `start()` has not been called yet, `cancel()` is a no-op (early return at `:388-389`).
+- Otherwise it sends a cancel request to the backend.
+- **Best-effort.** The SDK does not short-circuit on terminal status; if the run already completed, failed, or was cancelled, the backend may return a non-2xx and `cancel()` rejects. Wrap in `try / catch` if you call it speculatively.
+
+## `abortSignal`
+
+```ts
+const controller = new AbortController();
+
+const trainer = createTrainer({
+  name: "with-timeout",
+  model: "unsloth/gemma-4-E4B-it",
+  dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
+  abortSignal: controller.signal,
+});
+
+// Later, from anywhere:
+controller.abort();
+```
+
+`abortSignal` controls **only your local `wait()` loop**. When the signal aborts:
+
+1. The pending SSE fetch is aborted (`trainer.ts:325-328`).
+2. Any active reconnect-backoff `delay` rejects with `signal.reason` (`trainer.ts:178`).
+3. `handleFailure` re-throws when the signal is aborted (`trainer.ts:308`).
+4. `wait()` therefore **rejects**, not resolves, when you abort.
+
+It does **not** call `cancel()` and does **not** send anything to the backend. The job keeps using GPU time on the managed side.
+
+If you want both effects (stop waiting locally and stop the run on the backend), do them separately:
+
+```ts
+try {
+  await trainer.wait();
+} catch (err) {
+  if (controller.signal.aborted) {
+    // expected: we asked wait() to stop
+  } else {
+    throw err;
+  }
+}
+await trainer.cancel(); // best-effort; see above
+```
+
+Use `abortSignal` for "I no longer care about waiting on this run" (request timeout, parent process exit). Use `cancel()` for "stop the run on the backend".
+
+## Reconnects
+
+`wait()` keeps the SSE stream alive across transient failures by default:
+
+- A clean stream EOF after at least one received frame triggers an immediate reconnect at the base delay (`initialReconnectDelayMs`, default 1000 ms) without counting against the failure budget. The stream resumes via `Last-Event-ID`.
+- A connect error or a stream EOF without any received frame counts as a failure and goes through `handleFailure`: exponential backoff via `initialReconnectDelayMs * 2 ** attempt`, capped by `maxReconnectAttempts`.
+- `maxReconnectAttempts` defaults to `undefined` (unlimited). There is no public `createTrainer` option to set it today; the field exists in an internal context type. For most projects this means transient SSE failures are silently retried for as long as the job runs.
+
+This same path is what catches thrown user callbacks (see [Lifecycle callbacks § Exception handling](/sdk/callbacks#exception-handling-read-carefully)). If you need deterministic error handling, catch inside the callback rather than relying on `wait()` to reject.
+
+## Two-process pattern
+
+A common shape for non-CLI use is to keep a long-lived trainer reference and let your own code orchestrate `start`, `wait`, and `cancel`:
+
+```ts
+import { createTrainer } from "arkor";
+
+const trainer = createTrainer({ /* ... */ });
+
+const controller = new AbortController();
+process.on("SIGINT", () => controller.abort());
+
+const { jobId } = await trainer.start();
+console.log(`Started ${jobId}`);
+
+try {
+  const { artifacts } = await trainer.wait();
+  console.log(`Finished with ${artifacts.length} artifact(s).`);
+} catch (err) {
+  if (controller.signal.aborted) {
+    await trainer.cancel().catch(() => {});
+    throw new Error("Aborted by signal");
+  }
+  throw err;
+}
+```
+
+This is functionally what `arkor start` does, minus the entry resolution from `runTrainer`.

--- a/docs/sdk/trainer-control.mdx
+++ b/docs/sdk/trainer-control.mdx
@@ -101,8 +101,8 @@ Use `abortSignal` for "I no longer care about waiting on this run" (request time
 `wait()` keeps the SSE stream alive across transient failures by default:
 
 - A clean stream EOF after at least one received frame triggers an immediate reconnect at the base delay (`initialReconnectDelayMs`, default 1000 ms) without counting against the failure budget. The stream resumes via `Last-Event-ID`.
-- A connect error or a stream EOF without any received frame counts as a failure and goes through `handleFailure`: exponential backoff via `initialReconnectDelayMs * 2 ** attempt`, capped by `maxReconnectAttempts`.
-- `maxReconnectAttempts` defaults to `undefined` (unlimited). There is no public `createTrainer` option to set it today; the field exists in an internal context type. For most projects this means transient SSE failures are silently retried for as long as the job runs.
+- A connect error or a stream EOF without any received frame counts as a failure and goes through `handleFailure`: exponential backoff via `initialReconnectDelayMs * 2 ** attempt`, with the per-attempt delay clamped at `maxReconnectDelayMs` (default 60 000 ms) and the consecutive-failure count capped at `maxReconnectAttempts`.
+- `maxReconnectAttempts` defaults to `undefined` (unlimited consecutive failures). It is not configurable through `TrainerInput`; the only way to set it (along with `reconnectDelayMs` and `maxReconnectDelayMs`) is the second `context` argument to `createTrainer`, annotated `@internal` and subject to change. For most projects this means transient SSE failures are silently retried for as long as the job runs.
 
 This same path is what catches thrown user callbacks (see [Lifecycle callbacks § Exception handling](/sdk/callbacks#exception-handling-read-carefully)). If you need deterministic error handling, catch inside the callback rather than relying on `wait()` to reject.
 

--- a/docs/sdk/trainer-control.mdx
+++ b/docs/sdk/trainer-control.mdx
@@ -113,10 +113,13 @@ A common shape for non-CLI use is to keep a long-lived trainer reference and let
 ```ts
 import { createTrainer } from "arkor";
 
-const trainer = createTrainer({ /* ... */ });
-
 const controller = new AbortController();
 process.on("SIGINT", () => controller.abort());
+
+const trainer = createTrainer({
+  /* ... */
+  abortSignal: controller.signal, // wired so abort() actually rejects wait()
+});
 
 const { jobId } = await trainer.start();
 console.log(`Started ${jobId}`);


### PR DESCRIPTION
## Summary

Fills out the SDK section. Replaces the skeleton `sdk/overview.mdx` and adds six new pages covering the full public TypeScript surface from `packages/arkor/src/index.ts`. All claims were checked against `packages/arkor/src/core/types.ts` and `packages/arkor/src/core/trainer.ts` so the docs do not promise behavior the runtime does not deliver yet.

## Pages

- `sdk/overview.mdx` (rewrite): hub + main API table + auxiliary-helpers table. Explicit "not in the public surface" note for `SDK_VERSION`, `defaultArkorCloudApiUrl()`, and the CLI command runners (`runBuild`, `runStart`, etc.).
- `sdk/create-arkor.mdx` (new): `ArkorInput` accepts only `trainer` today. The `deploy` / `eval` slots are reserved type comments with no runtime path; documented as roadmap markers, not as forward-compatible API. Lists the three recognized export shapes (`arkor`, `trainer`, default) the runner accepts in priority order. `isArkor` type guard.
- `sdk/create-trainer.mdx` (new): required (`name`, `model`, `dataset`), typed optionals (`lora`, hyperparameters, `dryRun`, `abortSignal`, `callbacks`), and a separate "Advanced (forwarded as-is)" section for the `unknown`-typed fields (`warmupSteps`, `loggingSteps`, `saveSteps`, `evalSteps`, `trainOnResponsesOnly`, `datasetFormat`, `datasetSplit`) so readers know they are unstable. `dryRun` documented honestly as a short GPU run, not zero-GPU.
- `sdk/dataset.mdx` (new): `HuggingfaceDatasetSource` and `BlobDatasetSource` shapes; note that local file paths are not supported today.
- `sdk/callbacks.mdx` (new): timeline (start submits, wait dispatches), per-callback argument shapes mirrored from `core/types.ts`, and an Exception-handling section that matches the actual runtime path: throws are caught by the outer try/catch (`trainer.ts:335-364`), routed through `handleFailure` (`:307-320`), and effectively retried by the SSE reconnect loop because `maxReconnectAttempts` defaults to unlimited.
- `sdk/infer.mdx` (new): `InferArgs` shape, raw `Response` return value, consumption patterns (text / json / streaming via `response.body`). Constraint: `infer` lives only on `CheckpointContext`.
- `sdk/trainer-control.mdx` (new): exact behavior of `start` / `wait` / `cancel`, `abortSignal` stops only local `wait()` (rejects, does not call `cancel()` or message the backend), reconnect defaults (unlimited, no public knob today).

`docs/docs.json` SDK group expanded from 1 to 7 pages.

## Conflict surface

This PR only touches `docs/sdk/*` and the SDK group in `docs/docs.json`. PR #59 (eng-537, CLI reference) only touches `docs/cli/*` and the CLI group; no overlap.

## Test plan

- [x] `pnpm --filter @arkor/docs exec mint validate` passes
- [x] `pnpm --filter @arkor/docs exec mint broken-links` passes
- [x] No em dashes anywhere under `docs/sdk/` (per project memory)
- [x] Type signatures in each page match `packages/arkor/src/core/types.ts` exactly
- [ ] Mintlify preview deploy renders without layout issues