### PR TITLE
docs: polish pass on intro / quickstart / concepts (factual + density)

### DIFF
--- a/docs/concepts/lifecycle.mdx
+++ b/docs/concepts/lifecycle.mdx
@@ -3,8 +3,6 @@ title: "Lifecycle callbacks"
 description: "The five callbacks Arkor fires during a training run, and what each one is good for."
 ---
 
-# Lifecycle callbacks
-
 Arkor fires five callbacks as a training run progresses. They are all optional, and each one is a plain TypeScript function that runs in your process. This is what makes the loop feel like the rest of your application: no notebook, no out-of-band dashboard, no separate config language.
 
 ```ts
@@ -74,7 +72,7 @@ onLog: ({ step, loss, evalLoss }) => {
 Common uses:
 
 - Forward to your own metrics pipeline (e.g. PostHog, Datadog).
-- Detect divergence early: if `loss` is climbing, abort the run.
+- Detect divergence early: if `loss` is climbing, abort `wait()` via `abortSignal` and call `trainer.cancel()` to stop the GPU on the backend.
 - Implement custom early stopping logic.
 
 ## `onCheckpoint({ step, adapter, job, infer, artifacts })`

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -3,8 +3,6 @@ title: "Concepts"
 description: "The mental model behind Arkor: project layout, trainer, lifecycle callbacks, and Studio."
 ---
 
-# Concepts
-
 This section gives you the mental model you need before diving into the [SDK reference](/sdk/overview) or [CLI reference](/cli/overview). Read these in order; each builds on the previous.
 
 ## What to read

--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -3,8 +3,6 @@ title: "Project structure"
 description: "Where Arkor expects your code, and what lives in .arkor/ and ~/.arkor/."
 ---
 
-# Project structure
-
 A scaffolded Arkor project looks like this:
 
 ```
@@ -69,7 +67,7 @@ It is currently a placeholder. The runtime does not read fields from it yet. All
 
 You should not commit this directory.
 
-- **`.arkor/state.json`**. Project routing: `orgSlug`, `projectSlug`, `projectId`. This is how the runtime maps your local repo to a workspace on the managed backend. The file is created by `ensureProjectState()`, which is called the first time you run training (or hit base-model inference) on the project. For **anonymous** workspaces it is auto-created on that first call. For **Auth0** users the runtime errors out and asks you to run `arkor init` first. Do not edit by hand.
+- **`.arkor/state.json`**. Project routing: `orgSlug`, `projectSlug`, `projectId`. This is how the runtime maps your local repo to a workspace on the managed backend. The file is created by `ensureProjectState()`, which runs the first time you start training (or hit base-model inference). For **anonymous** workspaces it is auto-created on that first call. For **Auth0** workspaces the runtime errors out instead: today, neither `arkor login` nor `arkor init` populates the file, so you create it by hand with `{ orgSlug, projectSlug, projectId }` and the runtime takes over from there. Once it exists, do not edit it by hand.
 - **`.arkor/build/index.mjs`**. Output of `arkor build`: an esbuild bundle of `src/arkor/index.ts` targeting Node 22.6 with bare specifiers kept external. `arkor start` runs this.
 
 ## `~/.arkor/` (per-user)
@@ -83,7 +81,7 @@ Lives in your home directory, shared across all Arkor projects on the machine.
 
 ## What the CLI looks for
 
-- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. It does not file-watch `src/arkor/`. Studio's `/api/manifest` endpoint does call `runBuild` and re-import with a cache-bust query, but only when the UI fetches it, which currently happens when the Run training page mounts (see `packages/studio-app/src/components/RunTraining.tsx`). If you stay on that page across multiple runs, the build artifact is reused. To pick up edits between runs, refresh the Run training page (or run `arkor build` from the terminal) before the next click. `arkor dev` does not write `.arkor/state.json` on its own.
+- `arkor dev` starts the Studio web server at `127.0.0.1:4000` and writes `~/.arkor/studio-token`. It does not file-watch `src/arkor/`. Studio's `/api/manifest` endpoint does call `runBuild` and re-imports with a cache-bust query, but only when the Studio UI fetches it (currently on Run training page mount). If you stay on that page across multiple runs the build artifact is reused; refresh the Run training page (or run `arkor build` from the terminal) between edits to pick up changes. `arkor dev` does not write `.arkor/state.json` on its own.
 - `arkor build` reads `src/arkor/index.ts` (or the entry you pass) and writes `.arkor/build/index.mjs`. You only need to call this directly outside the Studio dev loop (e.g. CI, or right before `arkor start` from a script).
 - `arkor start` resolves the entry through the runner, rebuilds `.arkor/build/index.mjs` if it is missing or you passed an explicit entry, and runs it (which calls `trainer.start()` and `trainer.wait()`). Triggering training from Studio internally spawns `arkor start`.
 

--- a/docs/concepts/studio.mdx
+++ b/docs/concepts/studio.mdx
@@ -3,8 +3,6 @@ title: "Studio"
 description: "The local web UI for starting training runs, watching them stream, and chatting with finished models."
 ---
 
-# Studio
-
 Studio is the local web UI you get when you run `arkor dev`. It is not a separate service to sign into; it boots on your machine, talks to the same Arkor CLI process, and goes away when you stop the dev server.
 
 ## What Studio is for
@@ -43,6 +41,8 @@ Arkor managed backend (training, inference)
 
 That separation is why Studio works without you logging into anything in the browser: the CLI already has your credentials in `~/.arkor/credentials.json`, and Studio inherits them by virtue of running locally.
 
+If `~/.arkor/credentials.json` is missing, the entry point decides what to do. **`arkor dev`** (and `arkor login` itself) checks the cloud-api at launch and runs the interactive Auth0 PKCE flow when the deployment requires Auth0; otherwise it requests an anonymous token. The **Studio server's lazy bootstrap** (when an `/api/*` request arrives before credentials are on disk) only does the anonymous fallback: it never runs the Auth0 flow on its own. So on an Auth0-configured deployment, run `arkor login` (or let `arkor dev` open the browser flow at launch) before clicking around in Studio; the credentials file is shared, so Studio picks up the account session on its next request.
+
 ## What you actually see
 
 The current views are intentionally small:
@@ -51,7 +51,7 @@ The current views are intentionally small:
 - **Job detail.** Loss chart, log tail (most recent events), and live status. Streamed via Server-Sent Events so it stays current without manual refresh.
 - **Playground.** Adapter selector (base model or the final adapter from any completed job), a chat UI, and a streaming response. Calls flow through the CLI, then to the managed inference endpoint. The Playground only lists jobs that have finished. To run inference against an intermediate checkpoint while a run is still in flight, use [`onCheckpoint`](/concepts/lifecycle) callbacks instead.
 
-A walkthrough of each view with screenshots lives in the Studio section (coming next in the docs).
+A walkthrough of each view (Run training, Job detail, Playground) lives in the [Studio](/studio/overview) section.
 
 ## When not to use Studio
 

--- a/docs/concepts/trainer.mdx
+++ b/docs/concepts/trainer.mdx
@@ -3,8 +3,6 @@ title: "Trainer"
 description: "createTrainer: required fields, dataset sources, LoRA settings, and the start / wait / cancel lifecycle."
 ---
 
-# Trainer
-
 `createTrainer` is the heart of an Arkor project. Everything Arkor knows about a fine-tuning run, from the base model down to the LoRA rank, is on the object you pass in.
 
 ## Minimal example
@@ -40,7 +38,7 @@ type DatasetSource =
 ```
 
 - **HuggingFace**. The most common shape. Arkor pulls the dataset by name. Use `split` to override the default split and `subset` for datasets that publish multiple subsets.
-- **Blob URL**. Any HTTPS URL the backend can fetch. Pass `token` if the URL needs an `Authorization: Bearer` header.
+- **Blob URL**. Any HTTPS URL the backend can fetch. Pass `token` if the backend needs auth to retrieve the URL; the value is forwarded to the cloud-api and used during the dataset fetch (the exact wire format is backend-defined and not part of the SDK contract).
 
 ## LoRA configuration
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,8 +3,6 @@ title: "Introduction"
 description: "Arkor is the TypeScript framework for fine-tuning open-weight LLMs."
 ---
 
-# Introduction
-
 Arkor lets TypeScript and Node developers fine-tune open-weight LLMs the same way they ship the rest of their product: type-safe configs, lifecycle callbacks in your own code, and a local Studio for the dev loop.
 
 ## Who Arkor is for
@@ -24,13 +22,13 @@ What Arkor adds is a TypeScript surface on top of that stack. Today it covers fi
 In practice:
 
 - **Type-safe configs.** `createTrainer({ model, dataset, lora, ... })` is checked at compile time. No YAML drift, no separate config language.
-- **Fast iteration on training code.** Edit your trainer, run `npx arkor build` (or refresh Studio's Run training page so its manifest endpoint rebuilds), and the next run uses the latest code. No notebook restart.
+- **Fast iteration on training code.** Edit your trainer, rebuild, and the next run uses the latest code. No notebook restart.
 - **Callbacks in your own code.** `onLog`, `onCheckpoint`, `onCompleted`, `onFailed` fire on your TypeScript functions, fully typed. From inside `onCheckpoint` you can call `infer({ messages })` against the partial model and sanity-check it before the run finishes.
 - **A local Studio.** Run `arkor dev` and a web UI shows job status, a live loss chart, the log tail, and a Playground for chatting with your fine-tuned model. No external dashboard, no signup.
 
 ## What works today
 
-Arkor is alpha and honest about it. APIs change without notice as the design settles. The current version is published to [npm](https://www.npmjs.com/package/arkor).
+Arkor is alpha. APIs change without notice as the design settles. The current version is published to [npm](https://www.npmjs.com/package/arkor).
 
 What you can do right now:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,8 +3,6 @@ title: "Quickstart"
 description: "Scaffold an Arkor project, fine-tune a small open-weight LLM, and chat with it from a local Studio."
 ---
 
-# Quickstart
-
 In a few minutes you will go from zero to a fine-tuned model you can chat with in a local Playground. The training itself takes 7 to 12 minutes; setup time depends on your connection and what is already installed.
 
 ## Prerequisites
@@ -65,7 +63,7 @@ pnpm dev
 
 This runs `arkor dev`, which boots Studio at `http://localhost:4000`. Studio is the UI; `arkor dev` itself does not start training and does not watch your trainer files.
 
-In the browser, click **Run training**. Studio runs `arkor start` for you in the background, which submits the job to the managed backend using `.arkor/build/index.mjs`. If that artifact is missing, `arkor start` auto-builds it from `src/arkor/index.ts`; in the Studio flow you rarely see this path because Studio's `/api/manifest` endpoint already rebuilt the artifact when the Run training page loaded. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
+In the browser, click **Run training**. Studio submits the job to the managed backend in the background and streams the output back into the page. The first time you trigger anything, an anonymous workspace is created automatically: no signup, no credit card.
 
 Once a run is in flight, three views matter:
 
@@ -73,7 +71,7 @@ Once a run is in flight, three views matter:
 - **Loss chart and event log.** As the run streams from the managed GPU, the loss curve updates and the log tail shows training events. The first run takes 7 to 12 minutes depending on the template.
 - **Playground.** After a job completes, pick the final adapter from the selector and chat with it. Use the mode toggle to switch between the base model and the adapter. To run inference on intermediate checkpoints while a run is still in flight, use `onCheckpoint` callbacks instead of Studio.
 
-If you edit `src/arkor/` between runs, run `npx arkor build` (or refresh Studio's Run training page so its manifest endpoint rebuilds the artifact) before the next click. `arkor start` reuses the existing build artifact between clicks otherwise, so the new edits would not flow through.
+If you edit `src/arkor/` between runs, refresh the Run training page (or run `npx arkor build`) before the next click so the new code is what runs.
 
 ## 4. Claim your work (optional)
 
@@ -90,5 +88,5 @@ This runs an Auth0 PKCE flow on a loopback port and links your local credentials
 ## 5. Where to go next
 
 - **Concepts.** Read [Concepts](/concepts/overview) to build a mental model of `createArkor`, `createTrainer`, the lifecycle callbacks, and Studio.
-- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Run `npx arkor build` (or refresh Studio's Run training page) before the next click so your edits land.
+- **Customize the trainer.** Open `src/arkor/trainer.ts` and tweak `lora.r`, `maxSteps`, or add more callbacks. Refresh the Run training page (or run `npx arkor build`) before the next click so your edits land.
 - **Try another template.** Run `pnpm create arkor` again with a different `--template` to compare.


### PR DESCRIPTION
## Summary

Final read-through pass on the docs surface that is already merged on `main` (introduction, quickstart, concepts × 5). Two kinds of changes:

1. **Factual corrections** — places where the prose drifted from what the runtime actually does. All checked against `packages/arkor/src/cli/commands/{dev,login}.ts`, `core/credentials.ts`, and the project memory `project_auth_login_decision.md`.
2. **Density trims** — the entry pages had implementation details bleeding in (manifest endpoints, internal file paths) that distracted first-time readers. Moved that nuance to the reference, kept the entry pages tight.

## What changed

### Factual

- `concepts/studio.mdx` auth-bootstrap paragraph: previous text said `arkor dev` defaults to anonymous and that there is an `--oauth` flag / prompt. Neither is accurate. Per `dev.ts`'s `ensureCredentialsForStudio` and `login.ts`, `arkor dev` runs the Auth0 PKCE flow when the cloud-api reports Auth0 is configured; the user-facing flag is `--anonymous`, not `--oauth`. Reworded to match the decision tree captured in the project memory: `arkor dev` / `arkor login` do Auth0 when configured, and the Studio server's lazy bootstrap is anon-only.
- `concepts/trainer.mdx` blob `token` row: dropped the unverifiable `Authorization: Bearer` claim. Same fix landed earlier on `sdk/dataset.mdx` and `cookbook/customizing-templates.mdx`; this brings the concepts page in line.
- `concepts/lifecycle.mdx` `onLog` Common uses: \"abort the run\" alone is misleading because \`abortSignal\` only stops \`wait()\` locally; the GPU keeps running until \`cancel()\`. Spelled out the two-step.
- \`concepts/project-structure.mdx\` \`.arkor/state.json\` paragraph: Auth0 users do not actually get \`state.json\` from \`arkor login\` or \`arkor init\`; they create the file by hand. Matches the existing wording in \`cli/auth.mdx\`.

### Density / clarity

- \`introduction.mdx\` \"Fast iteration\" bullet: drop the manifest-endpoint parenthetical.
- \`introduction.mdx\` \"Arkor is alpha and honest about it\": drop the \"and honest about it\" filler; the next sentence already establishes the API-stability stance.
- \`quickstart.mdx\` step 3: drop the \"rarely see this path because \`/api/manifest\` already rebuilt\" aside.
- \`quickstart.mdx\` rebuild note + step 5 \"Customize the trainer\" pointer: simpler \"Refresh the Run training page (or run \`npx arkor build\`)\" wording.
- \`concepts/project-structure.mdx\` \"What the CLI looks for\" \`arkor dev\` bullet: drop the parenthetical naming \`packages/studio-app/src/components/RunTraining.tsx\` (too internal for a concepts page).

## Out of scope

- \`cli/overview.mdx\` and \`sdk/overview.mdx\` skeletons on \`main\` are deliberately untouched here so this PR does not conflict with the in-flight CLI / SDK reference PRs (#59 / #60), which replace those skeletons wholesale.
- One smaller wording fix on \`cli/auth.mdx\` belongs to the CLI reference PR (#59) and lands there as a separate commit.

## Test plan

- [x] \`pnpm --filter @arkor/docs exec mint validate\` passes
- [x] No em dashes in the touched files (per project memory)
- [ ] Mintlify preview deploy renders the touched pages without layout regression