### PR TITLE
docs(readme): align README with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   Ship custom open-weight models the same way you ship your TypeScript app.
-  Type-safe configs, hot reload, a local Studio (web UI) to start and watch runs, and managed GPUs.
+  Type-safe configs, a local Studio (web UI) to start and watch runs, and managed GPUs.
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
 </p>
 
 > [!WARNING]
-> Arkor is **alpha** (`0.0.1-alpha.3`). APIs change without notice. We're shipping in public, and feedback shapes what lands next.
+> Arkor is **alpha**. APIs change without notice. We're shipping in public, and feedback shapes what lands next.
 
 <!--
   Demo media goes here once recorded:
@@ -46,7 +46,7 @@ pnpm dev
 ```
 
 **No signup required:** 
-`arkor dev` opens **Studio**, a local web UI at `http://localhost:4000`, and silently bootstraps an anonymous workspace so you can fire off a real training run right away. 
+`arkor dev` opens **Studio**, a local web UI at `http://localhost:4000`. On first launch it either signs you in (if your deployment has Auth0 configured) or silently provisions an anonymous workspace, so you can fire off a real training run right away. 
 
 Run `arkor login` later if you want to claim your work under an account.
 
@@ -70,7 +70,7 @@ Arkor stands on that foundation.
 
 What we wanted, and didn't find, was a path that fits how TypeScript and Node developers already work: a workflow where fine-tuning, evaluation, and serving live in the same codebase as the product, with the same editor, types, and review flow. 
 
-Type-safe configs instead of separate config files. Hot reload over your training code. A local Studio for the dev loop.
+Type-safe configs instead of separate config files. A local Studio for the dev loop.
 
 The phrase we keep coming back to: **ship the model the same way you ship the product.** If that sounds right, you're the audience.
 
@@ -81,7 +81,7 @@ The phrase we keep coming back to: **ship the model the same way you ship the pr
 - [x] **React to training in code, not in a dashboard.** Lifecycle callbacks (`onStarted`, `onLog`, `onCheckpoint`, `onCompleted`, `onFailed`) fire as the run streams from the cloud, fully typed.
 - [x] **Sanity-check the model before the run finishes.** Inside `onCheckpoint`, call `infer({ messages })` against the model as it's being trained.
 - [x] **Watch the run in a local Studio.** `arkor dev` opens a UI with a jobs list, live loss chart, log tail, and a Playground for chatting with your fine-tuned models.
-- [x] **Try it without an account.** Anonymous workspace by default; run `arkor login` (Auth0 PKCE) to claim your work later.
+- [x] **Try it without an account.** When the deployment has no Auth0 configured, `arkor dev` provisions an anonymous workspace silently. Either way, `arkor login` (Auth0 PKCE) attaches the work to your account.
 
 ## What's coming next
 
@@ -94,7 +94,7 @@ The phrase we keep coming back to: **ship the model the same way you ship the pr
 ### SDK and CLI
 
 - [ ] **Train on a local GPU.** Today every run goes to Arkor's managed GPUs.
-- [ ] **Bring your own dataset.** Any HuggingFace name, a JSONL file, or a blob URL.
+- [ ] **Bring your own dataset from a JSONL file.** Today, any HuggingFace name and any blob URL (with optional auth token) already work.
 - [ ] **More base models beyond Gemma.**
 
 ### Studio
@@ -140,8 +140,6 @@ export const arkor = createArkor({ trainer });
 `src/arkor/index.ts` is the file the CLI and Studio look for. 
 Your `trainer` lives in a sibling file and is registered through `createArkor`.
 
-To add another trainer, drop a file and register it; no scaffolder rerun needed.
-
 <!--
   Studio screenshots go here once captured:
     - assets/studio-jobs.png        Jobs list
@@ -167,7 +165,7 @@ my-arkor-app/
 | ------------------------------------ | ---------------------------------------------------------------------- |
 | `arkor init`                         | Scaffold a new project in the current directory                        |
 | `arkor login` / `logout` / `whoami`  | Auth0 PKCE / anonymous tokens                                          |
-| `arkor dev`                          | Launch the local Studio web UI (with hot reload)                       |
+| `arkor dev`                          | Launch the local Studio web UI                                         |
 | `arkor build`                        | Bundle `src/arkor/index.ts` to `.arkor/build/index.mjs`                |
 | `arkor start`                        | Run the build artifact (auto-builds when missing)                      |
 
@@ -175,7 +173,7 @@ my-arkor-app/
 
 ## Architecture
 
-`arkor dev` boots a [Hono](https://hono.dev) server on `127.0.0.1:4000` that hot-reloads your code and serves a Vite + React SPA from the same origin. 
+`arkor dev` boots a [Hono](https://hono.dev) server on `127.0.0.1:4000` that serves a Vite + React SPA from the same origin. 
 
 The SPA talks to your code via per-launch CSRF-token-gated `/api/*` routes (loopback-only, with a `Host` header guard against DNS rebinding); your code talks to the Arkor training backend over authenticated HTTPS. 
 
@@ -196,13 +194,12 @@ Works with pnpm / npm / yarn / bun.
 
 ## We're shipping in public
 
-Arkor is alpha, and the core idea (TypeScript-native fine-tuning for product engineers) is something we want to design *with* the people who'd use it. If that's you:
+Arkor is alpha, and the core idea (TypeScript-native fine-tuning for product engineers) is something we want to design *with* the people who'd use it. 
+If that's you:
 
 - **[File an issue](https://github.com/arkorlab/arkor/issues/new)** with the model + dataset + workflow you wish worked. We read everything.
 - **Star the repo** if you want updates as we move toward `0.1`.
 - **[Join Discord](https://discord.gg/YujCZYGrEZ)** for live discussion and early-access pings.
-
-We're especially curious about: which open-weight base models you'd reach for first, which datasets you'd point Arkor at, where you'd want the trained model to run, and what breaks when you try the alpha.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The phrase we keep coming back to: **ship the model the same way you ship the pr
 - [x] **React to training in code, not in a dashboard.** Lifecycle callbacks (`onStarted`, `onLog`, `onCheckpoint`, `onCompleted`, `onFailed`) fire as the run streams from the cloud, fully typed.
 - [x] **Sanity-check the model before the run finishes.** Inside `onCheckpoint`, call `infer({ messages })` against the model as it's being trained.
 - [x] **Watch the run in a local Studio.** `arkor dev` opens a UI with a jobs list, live loss chart, log tail, and a Playground for chatting with your fine-tuned models.
-- [x] **Try it without an account.** When the deployment has no Auth0 configured, `arkor dev` provisions an anonymous workspace silently. Either way, `arkor login` (Auth0 PKCE) attaches the work to your account.
+- [x] **Try it without an account.** When the deployment has no Auth0 configured, `arkor dev` provisions an anonymous workspace silently. On Auth0-configured deployments, `arkor login` runs PKCE and attaches the work to your account; without Auth0 it simply re-issues an anonymous session.
 
 ## What's coming next
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -3,8 +3,6 @@ title: "CLI"
 description: "The arkor CLI: full command reference."
 ---
 
-# CLI
-
 The `arkor` CLI is the command surface around an Arkor project. The scaffolder ([`pnpm create arkor`](/quickstart)) installs `arkor` as a local devDependency, so prefer `npx arkor <command>` (or `pnpm exec arkor <command>` / `yarn arkor <command>` / `bun arkor <command>`) over a bare `arkor` invocation unless you have installed the CLI globally.
 
 ## Commands

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -3,8 +3,6 @@ title: "SDK"
 description: "The Arkor SDK: createArkor, createTrainer, lifecycle callbacks, infer, and the helpers around them."
 ---
 
-# SDK
-
 The `arkor` package exposes the TypeScript surface that the CLI and Studio sit on top of. Everything you need for a typical project lives in three primitives plus their typed inputs.
 
 ## Minimal example


### PR DESCRIPTION
## Summary

Audit pass over `README.md` for claims that didn't match the shipped code, plus a small cleanup to the closing section.

### Accuracy fixes

- **Drop "hot reload" wording (4 places: L14 / L73 / L170 / L178).** `arkor dev` has no file watcher (no chokidar / esbuild watch / vite HMR). Studio's `/api/manifest` only rebuilds on page load via `runBuild()`. Per the existing decision to avoid this term in docs until true hot reload ships.
- **Rewrite L49 / L84 anonymous-workspace claim.** `ensureCredentialsForStudio` in `packages/arkor/src/cli/commands/dev.ts` calls `fetchCliConfig()` and runs interactive PKCE (`runLogin()`) when the deployment has Auth0 configured. Silent anon only happens when Auth0 is unavailable.
- **Drop "To add another trainer, drop a file and register it" (L143).** `ArkorInput.trainer` is a single optional slot in `packages/arkor/src/core/types.ts`. Multi-trainer is programmatic-only (separate `createArkor` calls).
- **Narrow "Bring your own dataset" coming-next bullet (L97) to JSONL.** `DatasetSource` already accepts any HuggingFace `name` and any blob URL with optional `token`. Only `{type:"file", path}` is missing today.
- **Remove hardcoded `0.0.1-alpha.3` (L32).** The npm version badge at L18 already surfaces the live version, so the inline literal would just rot on every bump.

### Other

- Tighten the "We're shipping in public" closing section (manual edit).

## Test plan

- [x] `rg -i "hot[- ]?reload" README.md` → 0 hits
- [x] `rg "0\.0\.1-alpha" README.md` → 0 hits
- [x] `rg "drop a file and register" README.md` → 0 hits
- [x] `rg "Bring your own dataset" README.md` → 1 hit, scoped to JSONL
- [x] No em dashes introduced
- [ ] Render preview on GitHub renders cleanly (badges / table / list spacing)

No code changes; doc-only PR.