### PR TITLE
feat(arkor): bundle docs/ MDX sources into the published tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 # Generated copies of root files (see packages/*/scripts/copy-root-files.mjs)
 packages/*/CONTRIBUTING.md
 
+# Generated copy of docs/ (see packages/arkor/scripts/copy-docs.mjs)
+packages/arkor/docs/
+
 # Turbo
 .turbo/
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -34,13 +34,14 @@
   },
   "files": [
     "dist",
+    "docs",
     "CONTRIBUTING.md"
   ],
   "engines": {
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "pnpm --filter @arkor/studio-app bundle && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs",
+    "build": "pnpm --filter @arkor/studio-app bundle && tsc -p tsconfig.build.json --noEmit && tsdown && node scripts/copy-studio-assets.mjs && node scripts/copy-root-files.mjs && node scripts/copy-docs.mjs",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",

--- a/packages/arkor/scripts/copy-docs.mjs
+++ b/packages/arkor/scripts/copy-docs.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Copy the repo-root `docs/` source tree into the package directory so the
+ * Mintlify-authored docs ship inside the published `arkor` tarball
+ * alongside the SDK + CLI. The Mintlify config (`docs.json`), the docs
+ * workspace's own `package.json`, and `node_modules` are excluded —
+ * consumers should read the published site at https://docs.arkor.ai or
+ * the markdown files directly, not run Mintlify locally from an installed
+ * tarball.
+ *
+ * Kept as Node (not shell) to stay Windows-friendly.
+ */
+import { cp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, "..");
+const src = join(pkgRoot, "../../docs");
+const dst = join(pkgRoot, "docs");
+
+const EXCLUDE_NAMES = new Set(["docs.json", "package.json", "node_modules"]);
+
+if (!existsSync(src)) {
+  console.error(`[copy-docs] expected ${src} to exist`);
+  process.exit(1);
+}
+
+await rm(dst, { recursive: true, force: true });
+await cp(src, dst, {
+  recursive: true,
+  filter: (source) => {
+    const rel = relative(src, source);
+    if (rel === "") return true;
+    const top = rel.split(sep)[0];
+    return !EXCLUDE_NAMES.has(top);
+  },
+});
+console.log(`Copied ${src} -> ${dst} (excluded: ${[...EXCLUDE_NAMES].join(", ")})`);


### PR DESCRIPTION
## Summary
- Add `packages/arkor/scripts/copy-docs.mjs` to copy the repo-root `docs/` tree into `packages/arkor/docs/` during build. Excludes `docs.json` (Mintlify config), the docs workspace's own `package.json`, and `node_modules`.
- Wire the script into `packages/arkor/package.json` — `node scripts/copy-docs.mjs` runs at the end of `build`, after the existing `copy-studio-assets.mjs` and `copy-root-files.mjs` steps. Add `"docs"` to `files` so the copy actually ships in the tarball.
- Gitignore the generated copy at `packages/arkor/docs/` — single source of truth stays at the repo root.

### Why

Lets installed-only consumers read the docs (e.g. browsing through `node_modules/arkor/docs/`) without bouncing to the published site, and gives offline / restricted environments a usable copy. Same delivery shape as Next.js, which ships its docs source inside the `next` tarball.

The published site at https://docs.arkor.ai stays the canonical render path; this PR just adds the markdown sources alongside.

### Tarball impact

| | Before | After |
|---|---|---|
| Package size (gz) | ~368 kB | ~388 kB |
| Total files | 21 | 37 |
| New entries | — | 16 MDX/SVG files under `docs/` |

Excluded items confirmed absent from the pack list: `docs/docs.json`, `docs/package.json`, `docs/node_modules/`.

## Test plan
- [ ] `pnpm --filter arkor build` succeeds and prints `Copied .../docs -> packages/arkor/docs (excluded: docs.json, package.json, node_modules)`
- [ ] `cd packages/arkor && npm pack --dry-run` lists the MDX files under `docs/` and does NOT list `docs.json` / `package.json` / `node_modules`
- [ ] `pnpm --filter arkor test` passes (111/111)
- [ ] `pnpm --filter @arkor/cli-internal test` passes (21/21)
- [ ] Next release tarball on npmjs.com contains `docs/` (verify with `npm pack arkor@<next-version>` after publish)