### PR TITLE
chore: release arkor + create-arkor 0.0.1-alpha.4

### DIFF
--- a/e2e/cli/src/arkor-whoami.test.ts
+++ b/e2e/cli/src/arkor-whoami.test.ts
@@ -230,7 +230,7 @@ describe("arkor whoami × SDK version gate (E2E)", () => {
       res.setHeader("Deprecation", "true");
       res.setHeader(
         "Warning",
-        '299 - "Arkor SDK 0.0.1-alpha.3 is deprecated; supported range: >=2.0.0"',
+        '299 - "Arkor SDK 0.0.1-alpha.4 is deprecated; supported range: >=2.0.0"',
       );
       res.end(
         JSON.stringify({

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -2,7 +2,7 @@
 
 The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 
-> Status: alpha (`0.0.1-alpha.3`). APIs may change without notice. No compat
+> Status: alpha (`0.0.1-alpha.4`). APIs may change without notice. No compat
 > shims are offered between alpha versions — pin and re-read the changelog
 > before bumping.
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkor",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "Code-first TypeScript training SDK, CLI, and local Studio.",
   "private": false,
   "type": "module",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -114,7 +114,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.2");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.3");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -89,7 +89,7 @@ async function patchPackageJson(
           private: true,
           type: "module",
           scripts: { ...SCRIPT_DEFAULTS },
-          devDependencies: { arkor: "^0.0.1-alpha.2" },
+          devDependencies: { arkor: "^0.0.1-alpha.3" },
         },
         null,
         2,
@@ -114,7 +114,7 @@ async function patchPackageJson(
   const devDeps =
     (current.devDependencies as Record<string, string> | undefined) ?? {};
   if (!devDeps.arkor) {
-    devDeps.arkor = "^0.0.1-alpha.2";
+    devDeps.arkor = "^0.0.1-alpha.3";
     current.devDependencies = devDeps;
     dirty = true;
   }

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -3,7 +3,7 @@
 Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
 `npm create` / `pnpm create` / `yarn create` / `bun create`.
 
-> Status: alpha (`0.0.1-alpha.3`).
+> Status: alpha (`0.0.1-alpha.4`).
 
 ## Usage
 

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-arkor",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "Scaffolder for arkor training projects.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump the two public packages (`arkor`, `create-arkor`) from `0.0.1-alpha.3` to `0.0.1-alpha.4`.
- Bump the scaffold's pinned `arkor` devDependency (and its test) from `^0.0.1-alpha.2` to `^0.0.1-alpha.3`. alpha.3 is the most recent published version the e2e install tests can resolve; we deliberately don't pre-pin alpha.4 to avoid the registry-not-yet-published failure on CI.
- Update the alpha-version callouts in the per-package READMEs and the `arkor-whoami` deprecation-warning fixture. Root README no longer carries an explicit version string (#66), so it's untouched.

### What's new in alpha.4 vs alpha.3

- First release where the `docs/` MDX sources ship inside the `arkor` tarball under `docs/` (#67) — `node_modules/arkor/docs/` browsable on installed copies.
- Picks up the docs polish pass (#59, #60) and CLI auth/credentials hardening (#65).

## Test plan
- [ ] `pnpm --filter @arkor/cli-internal test` passes (scaffold test asserts `^0.0.1-alpha.3`)
- [ ] e2e install tests resolve `arkor@0.0.1-alpha.3` from the registry
- [ ] After tagging `v0.0.1-alpha.4` and running release.yaml:
  - Tarball includes `docs/` MDX files (verify with `tar -tzf` after publish)
  - `npm view arkor@0.0.1-alpha.4 dist.attestations.provenance` returns SLSA v1 provenance
  - npmjs.com page renders the README
- [ ] Manually re-point `latest` after release: `npm dist-tag add arkor@0.0.1-alpha.4 latest && npm dist-tag add create-arkor@0.0.1-alpha.4 latest`