### PR TITLE
ci(release): attest GitHub Release tarballs with actions/attest@v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: release
@@ -164,6 +165,11 @@ jobs:
             echo "## $(basename "$TARBALL")"
             tar -tf "$TARBALL"
           done
+
+      - name: Generate GitHub artifact attestations for release tarballs
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ runner.temp }}/npm-pack/*.tgz
 
       # Publish from the package directory (not from the pre-packed tarball)
       # so npm CLI reads README.md at publish time and embeds it in the


### PR DESCRIPTION
## Summary

- Add `attestations: write` to the release workflow's permissions so the job can call the GitHub Attestations API.
- Generate a GitHub Artifact Attestation for every `.tgz` produced by `pnpm pack` immediately after the existing `Pack and inspect tarballs` step, using `actions/attest@v4` against `${{ runner.temp }}/npm-pack/*.tgz`.
- npm provenance (`npm publish --provenance`) and the GitHub Release upload step are intentionally left unchanged.

## Why

The `.tgz` files attached to a GitHub Release are currently unsigned: consumers who download them from the Release page (instead of installing from npm) have no way to verify the artifact's origin. npm provenance only covers what's served from the npm registry, so a separate attestation is needed for the Release-page distribution path.

The two attestations are complementary, not redundant:

- **npm provenance** — covers tarballs served by `registry.npmjs.org` for `arkor` and `create-arkor`. Verified automatically by `npm` / `pnpm` clients and surfaced on npmjs.com.
- **`actions/attest@v4`** — covers the same-content `.tgz` files attached to the GitHub Release. Verifiable with `gh attestation verify <file> --owner arkorlab` against the GitHub Attestations API.

Because the two artifacts travel through different distribution channels, each channel needs its own signed metadata even when the underlying bytes are identical.

## Test plan

- [ ] Dispatch the workflow on a prerelease tag (e.g. `v0.0.1-alpha.5`) and confirm the new step succeeds.
- [ ] After the run, verify the published attestation: `gh attestation verify <downloaded.tgz> --owner arkorlab`.
- [ ] Confirm npm provenance still appears on the npmjs.com package page (existing behavior unchanged).
- [ ] Confirm the GitHub Release still has both `arkor-*.tgz` and `create-arkor-*.tgz` attached.