### PR TITLE
Fix `/api/jobs` metadata parity and deprecation propagation in Studio

### DIFF
--- a/packages/arkor/src/core/deprecation.ts
+++ b/packages/arkor/src/core/deprecation.ts
@@ -17,6 +17,10 @@ export function getRecordedDeprecation(): DeprecationNotice | null {
   return latest;
 }
 
+export function clearRecordedDeprecation(): void {
+  latest = null;
+}
+
 /**
  * Inspect a Response for `Deprecation: true` and record the notice. Use this
  * after raw `fetch()` calls that bypass `createClient`'s wrapped fetch

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -172,6 +172,31 @@ describe("Studio server", () => {
     expect(res.status).toBe(403);
   });
 
+  it("returns project state from the Studio training cwd", async () => {
+    await writeCredentials(ANON_CREDS);
+    await writeState(
+      {
+        orgSlug: "state-org",
+        projectSlug: "state-project",
+        projectId: "p-state",
+      },
+      trainCwd,
+    );
+    const app = build();
+    const res = await app.request("/api/credentials", {
+      headers: {
+        host: "127.0.0.1:4000",
+        "x-arkor-studio-token": STUDIO_TOKEN,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      orgSlug: "state-org",
+      projectSlug: "state-project",
+    });
+  });
+
   it("accepts the studio token via ?studioToken= for job event streams", async () => {
     await writeCredentials({
       mode: "anon",
@@ -443,6 +468,44 @@ process.exit(0);
       expect(res.headers.get("Warning")).toContain("jobs endpoint deprecated");
       expect(res.headers.get("Sunset")).toBe("Wed, 01 Jan 2030 00:00:00 GMT");
       expect(getRecordedDeprecation()?.message).toBe("jobs endpoint deprecated");
+    });
+
+    it("uses the Studio training cwd for job event streams", async () => {
+      await writeCredentials(ANON_CREDS);
+      await writeState(
+        {
+          orgSlug: "events-org",
+          projectSlug: "events-project",
+          projectId: "p-events",
+        },
+        trainCwd,
+      );
+
+      let capturedUrl: string | null = null;
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        _init?: RequestInit,
+      ) => {
+        capturedUrl = typeof input === "string" ? input : input.toString();
+        return new Response("event: end\ndata: {}\n\n", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/jobs/job-1/events", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUrl).not.toBeNull();
+      expect(capturedUrl!).toContain("/v1/jobs/job-1/events/stream");
+      expect(capturedUrl!).toContain("orgSlug=events-org");
+      expect(capturedUrl!).toContain("projectSlug=events-project");
     });
   });
 

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
 import { writeState } from "../core/state";
+import { getRecordedDeprecation } from "../core/deprecation";
 
 const ANON_CREDS = {
   mode: "anon" as const,
@@ -368,6 +369,80 @@ process.exit(0);
       expect(text).toMatch(/Cannot find module|MODULE_NOT_FOUND|ENOENT/);
       expect(text).toContain("exit=");
       expect(text).not.toContain("exit=0");
+    });
+  });
+
+  describe("/api/jobs", () => {
+    const ORIG_FETCH = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = ORIG_FETCH;
+    });
+
+    it("forwards SDK version metadata and deprecation headers", async () => {
+      await writeCredentials(ANON_CREDS);
+      await writeState(
+        { orgSlug: "anon-org", projectSlug: "jobs-project", projectId: "p-jobs" },
+        trainCwd,
+      );
+
+      let captured: {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+      } | null = null;
+
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const req = input instanceof Request ? input : null;
+        const headers = new Headers(req?.headers);
+        if (init?.headers) {
+          for (const [key, value] of new Headers(init.headers)) {
+            headers.set(key, value);
+          }
+        }
+        const lowerHeaders: Record<string, string> = {};
+        for (const [key, value] of headers) {
+          lowerHeaders[key.toLowerCase()] = value;
+        }
+        captured = {
+          url: req ? req.url : input.toString(),
+          method: init?.method ?? req?.method ?? "GET",
+          headers: lowerHeaders,
+        };
+        return new Response(JSON.stringify({ jobs: [] }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            Deprecation: "true",
+            Warning: '299 - "jobs endpoint deprecated"',
+            Sunset: "Wed, 01 Jan 2030 00:00:00 GMT",
+          },
+        });
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/jobs", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(captured).not.toBeNull();
+      expect(captured!.url).toContain("/v1/jobs");
+      expect(captured!.url).toContain("orgSlug=anon-org");
+      expect(captured!.url).toContain("projectSlug=jobs-project");
+      expect(captured!.method).toBe("GET");
+      expect(captured!.headers.authorization).toBe("Bearer tok");
+      expect(captured!.headers["x-arkor-client"]).toMatch(/^arkor\/\S+$/);
+      expect(res.headers.get("Deprecation")).toBe("true");
+      expect(res.headers.get("Warning")).toContain("jobs endpoint deprecated");
+      expect(res.headers.get("Sunset")).toBe("Wed, 01 Jan 2030 00:00:00 GMT");
+      expect(getRecordedDeprecation()?.message).toBe("jobs endpoint deprecated");
     });
   });
 

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   existsSync,
   mkdtempSync,
@@ -400,6 +400,80 @@ process.exit(0);
     });
   });
 
+  describe("/api/me", () => {
+    const ORIG_FETCH = globalThis.fetch;
+
+    beforeEach(() => {
+      clearRecordedDeprecation();
+    });
+
+    afterEach(() => {
+      globalThis.fetch = ORIG_FETCH;
+    });
+
+    it("forwards SDK version metadata and deprecation headers without onDeprecation noise", async () => {
+      await writeCredentials(ANON_CREDS);
+
+      let capturedHeaders: Record<string, string> = {};
+      globalThis.fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const req = input instanceof Request ? input : null;
+        const headers = new Headers(req?.headers);
+        if (init?.headers) {
+          for (const [key, value] of new Headers(init.headers)) {
+            headers.set(key, value);
+          }
+        }
+        capturedHeaders = {};
+        for (const [key, value] of headers) {
+          capturedHeaders[key.toLowerCase()] = value;
+        }
+        return new Response(JSON.stringify({ user: { id: "u1" } }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            Deprecation: "true",
+            Warning: '299 - "me endpoint deprecated"',
+            Sunset: "Wed, 01 Jan 2030 00:00:00 GMT",
+          },
+        });
+      }) as typeof fetch;
+
+      // The cloud-api-client wrapper around `onDeprecation` synchronously
+      // checks `typeof result.then` on the callback's return value; a plain
+      // `void` return throws and gets swallowed with a stderr log. The
+      // wrapper in `createRpc` returns null to short-circuit that check —
+      // assert that no such log fires here.
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      try {
+        const app = build();
+        const res = await app.request("/api/me", {
+          headers: {
+            host: "127.0.0.1:4000",
+            "x-arkor-studio-token": STUDIO_TOKEN,
+          },
+        });
+
+        expect(res.status).toBe(200);
+        expect(capturedHeaders["x-arkor-client"]).toMatch(/^arkor\/\S+$/);
+        expect(res.headers.get("Deprecation")).toBe("true");
+        expect(res.headers.get("Warning")).toContain("me endpoint deprecated");
+        expect(res.headers.get("Sunset")).toBe("Wed, 01 Jan 2030 00:00:00 GMT");
+        expect(getRecordedDeprecation()?.message).toBe("me endpoint deprecated");
+        for (const call of errorSpy.mock.calls) {
+          const first = String(call[0] ?? "");
+          expect(first).not.toContain("onDeprecation handler threw");
+        }
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
   describe("/api/jobs", () => {
     const ORIG_FETCH = globalThis.fetch;
 
@@ -515,6 +589,48 @@ process.exit(0);
       expect(capturedUrl!).toContain("/v1/jobs/job-1/events/stream");
       expect(capturedUrl!).toContain("orgSlug=events-org");
       expect(capturedUrl!).toContain("projectSlug=events-project");
+    });
+
+    it("forwards deprecation headers and records the notice for job event streams", async () => {
+      await writeCredentials(ANON_CREDS);
+      await writeState(
+        {
+          orgSlug: "events-org",
+          projectSlug: "events-project",
+          projectId: "p-events",
+        },
+        trainCwd,
+      );
+
+      globalThis.fetch = (async () => {
+        return new Response("event: end\ndata: {}\n\n", {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+            Deprecation: "true",
+            Warning: '299 - "events endpoint deprecated"',
+            Sunset: "Wed, 01 Jan 2030 00:00:00 GMT",
+          },
+        });
+      }) as typeof fetch;
+
+      const app = build();
+      const res = await app.request("/api/jobs/job-1/events", {
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Deprecation")).toBe("true");
+      expect(res.headers.get("Warning")).toContain(
+        "events endpoint deprecated",
+      );
+      expect(res.headers.get("Sunset")).toBe("Wed, 01 Jan 2030 00:00:00 GMT");
+      expect(getRecordedDeprecation()?.message).toBe(
+        "events endpoint deprecated",
+      );
     });
   });
 

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -13,7 +13,10 @@ import { join, resolve } from "node:path";
 import { buildStudioApp } from "./server";
 import { writeCredentials } from "../core/credentials";
 import { writeState } from "../core/state";
-import { getRecordedDeprecation } from "../core/deprecation";
+import {
+  clearRecordedDeprecation,
+  getRecordedDeprecation,
+} from "../core/deprecation";
 
 const ANON_CREDS = {
   mode: "anon" as const,
@@ -399,6 +402,12 @@ process.exit(0);
 
   describe("/api/jobs", () => {
     const ORIG_FETCH = globalThis.fetch;
+
+    beforeEach(() => {
+      // Module-level deprecation state is shared across tests; reset so that
+      // a leftover notice from a prior test can't masquerade as a hit here.
+      clearRecordedDeprecation();
+    });
 
     afterEach(() => {
       globalThis.fetch = ORIG_FETCH;

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -11,7 +11,7 @@ import {
   requestAnonymousToken,
   type Credentials,
 } from "../core/credentials";
-import { recordDeprecation } from "../core/deprecation";
+import { recordDeprecation, tapDeprecation } from "../core/deprecation";
 import { SDK_VERSION } from "../core/version";
 import { ensureProjectState } from "../core/projectState";
 import { readState } from "../core/state";
@@ -177,7 +177,17 @@ export function buildStudioApp(options: StudioServerOptions) {
       baseUrl,
       token: getToken,
       clientVersion: SDK_VERSION,
-      onDeprecation: recordDeprecation,
+      // The wrapper around `recordDeprecation` is a workaround for a
+      // bug in `@arkor/cloud-api-client` where a `void` return is fed
+      // into `typeof result.then === 'function'`, which throws and
+      // logs `[@arkor/cloud-api-client] onDeprecation handler threw;
+      // ignoring:` on every deprecated response. Returning `null`
+      // short-circuits that check (`null !== null` is false) without
+      // changing the recorded-deprecation behavior.
+      onDeprecation: (notice) => {
+        recordDeprecation(notice);
+        return null;
+      },
     });
   }
 
@@ -253,12 +263,19 @@ export function buildStudioApp(options: StudioServerOptions) {
           : {}),
       },
     });
+    // This route bypasses `createRpc()` (the SSE body has to be streamed
+    // straight through), so deprecation propagation has to be wired by
+    // hand: record the notice into the SDK's latest-wins store and
+    // forward the Deprecation/Warning/Sunset headers to the browser
+    // alongside the event stream.
+    tapDeprecation(upstream, SDK_VERSION);
     const headers = new Headers();
     headers.set(
       "content-type",
       upstream.headers.get("content-type") ?? "text/event-stream",
     );
     headers.set("cache-control", "no-cache, no-transform");
+    copyDeprecationHeaders(upstream.headers, headers);
     return new Response(upstream.body, { status: upstream.status, headers });
   });
 

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -218,16 +218,23 @@ export function buildStudioApp(options: StudioServerOptions) {
   });
 
   app.get("/api/jobs", async (c) => {
-    const state = await readState();
+    const state = await readState(trainCwd);
     if (!state) return c.json({ jobs: [] });
-    const rpc = createClient({ baseUrl, token: getToken });
+    const rpc = createClient({
+      baseUrl,
+      token: getToken,
+      clientVersion: SDK_VERSION,
+      onDeprecation: recordDeprecation,
+    });
     const res = await rpc.v1.jobs.$get({
       query: { orgSlug: state.orgSlug, projectSlug: state.projectSlug },
     });
     const body = await res.text();
+    const headers = new Headers({ "content-type": "application/json" });
+    copyDeprecationHeaders(res.headers, headers);
     return new Response(body, {
       status: res.status,
-      headers: { "content-type": "application/json" },
+      headers,
     });
   });
 

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -177,7 +177,7 @@ export function buildStudioApp(options: StudioServerOptions) {
   app.get("/api/credentials", async (c) => {
     const token = await getToken();
     const creds = await getCredentials();
-    const state = await readState();
+    const state = await readState(trainCwd);
     return c.json({
       token,
       mode: creds.mode,
@@ -240,7 +240,7 @@ export function buildStudioApp(options: StudioServerOptions) {
 
   app.get("/api/jobs/:id/events", async (c) => {
     const id = c.req.param("id");
-    const state = await readState();
+    const state = await readState(trainCwd);
     if (!state) return c.json({ error: "No project state" }, 400);
     const token = await getToken();
     const url = `${baseUrl}/v1/jobs/${encodeURIComponent(id)}/events/stream?orgSlug=${encodeURIComponent(state.orgSlug)}&projectSlug=${encodeURIComponent(state.projectSlug)}`;

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -172,6 +172,15 @@ export function buildStudioApp(options: StudioServerOptions) {
     return c.mode === "anon" ? c.token : c.accessToken;
   }
 
+  function createRpc() {
+    return createClient({
+      baseUrl,
+      token: getToken,
+      clientVersion: SDK_VERSION,
+      onDeprecation: recordDeprecation,
+    });
+  }
+
   // ---- API routes ---------------------------------------------------------
 
   app.get("/api/credentials", async (c) => {
@@ -188,12 +197,7 @@ export function buildStudioApp(options: StudioServerOptions) {
   });
 
   app.get("/api/me", async (c) => {
-    const rpc = createClient({
-      baseUrl,
-      token: getToken,
-      clientVersion: SDK_VERSION,
-      onDeprecation: recordDeprecation,
-    });
+    const rpc = createRpc();
     const res = await rpc.v1.me.$get();
     const body = await res.text();
     const headers = new Headers({ "content-type": "application/json" });
@@ -220,12 +224,7 @@ export function buildStudioApp(options: StudioServerOptions) {
   app.get("/api/jobs", async (c) => {
     const state = await readState(trainCwd);
     if (!state) return c.json({ jobs: [] });
-    const rpc = createClient({
-      baseUrl,
-      token: getToken,
-      clientVersion: SDK_VERSION,
-      onDeprecation: recordDeprecation,
-    });
+    const rpc = createRpc();
     const res = await rpc.v1.jobs.$get({
       query: { orgSlug: state.orgSlug, projectSlug: state.projectSlug },
     });


### PR DESCRIPTION
## Summary

This PR aligns the Studio `/api/jobs` route with other Cloud API call paths by:

- Passing `clientVersion: SDK_VERSION` when creating the Cloud API client
- Wiring `onDeprecation: recordDeprecation` to capture deprecation warnings consistently
- Forwarding deprecation-related response headers (`Deprecation`, `Warning`, `Sunset`) from Cloud API responses
- Reading project state from `trainCwd` via `readState(trainCwd)` to match `buildStudioApp({ cwd })` behavior

## Why

Previously, `/api/jobs` did not include SDK client metadata and did not surface deprecation signals consistently, causing behavior drift from other Studio API routes (e.g. `/api/me`).  
It also read state from the process default location instead of the configured training cwd in test/runtime contexts.

## Testing

- Added a regression test for `/api/jobs` to verify:
  - `X-Arkor-Client` is sent
  - deprecation headers are forwarded
  - deprecation warnings are recorded
- Confirmed targeted test passes.
- Confirmed typecheck passes.
