### PR TITLE
Title: Harden Studio CSRF token handling against DNS rebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ my-arkor-app/
 
 `arkor dev` boots a [Hono](https://hono.dev) server on `127.0.0.1:4000` that serves a Vite + React SPA from the same origin. 
 
-The SPA talks to your code via per-launch CSRF-token-gated `/api/*` routes (loopback-only, with a `Host` header guard against DNS rebinding); your code talks to the Arkor training backend over authenticated HTTPS. 
+The Studio server rejects non-loopback `Host` headers before serving HTML, and the SPA talks to your code via per-launch CSRF-token-gated `/api/*` routes; your code talks to the Arkor training backend over authenticated HTTPS. 
 
 Training runs on managed GPUs; checkpoints stream back as SSE events that fire your `callbacks.*` in process.
 

--- a/docs/cli/dev.mdx
+++ b/docs/cli/dev.mdx
@@ -40,7 +40,7 @@ When the process exits (normal exit, `SIGINT`, `SIGTERM`, or `SIGHUP`) the studi
 The Studio server enforces three checks on every `/api/*` request:
 
 1. The `Host` header must be `127.0.0.1` or `localhost` (defense against DNS rebinding).
-2. The CSRF token must be present, either as the `X-Arkor-Studio-Token` header or `?studioToken=...` (used by `EventSource`, which cannot send custom headers). Token comparison is `timingSafeEqual`.
+2. The CSRF token must be present as the `X-Arkor-Studio-Token` header. The job-event stream also accepts `?studioToken=...` because `EventSource` cannot send custom headers; mutation routes do not accept query-string tokens. Token comparison is `timingSafeEqual`.
 3. CORS is intentionally not configured: the SPA is same-origin so CORS adds no value, and reflecting `*` would let "simple" cross-origin POSTs (`text/plain`, `urlencoded`) skip preflight. Without a token, the middleware rejects them.
 
 This means `arkor dev` is safe on a shared dev machine: another tab cannot read the meta, a stale tab from a previous launch holds an old token that no longer matches, and an attacker page in a different origin cannot forge requests.

--- a/docs/studio/overview.mdx
+++ b/docs/studio/overview.mdx
@@ -35,8 +35,8 @@ Arkor managed backend
 
 Three checks run on every `/api/*` request:
 
-1. **Host header guard.** Only `127.0.0.1` and `localhost` are accepted. A victim navigated to a malicious site that DNS-rebinds onto `127.0.0.1` would still send `Host: evil.com`, which the middleware rejects with HTTP 403.
-2. **Per-launch CSRF token.** `arkor dev` generates a 32-byte token (base64url) on every launch, injects it into `index.html` as `<meta name="arkor-studio-token">`, and requires it on every `/api/*` call (header `X-Arkor-Studio-Token`, or `?studioToken=` for `EventSource` requests). Cross-origin tabs cannot read the meta, so a "simple" cross-origin POST that skips preflight is still rejected. Comparison is `timingSafeEqual`.
+1. **Host header guard.** Only `127.0.0.1` and `localhost` are accepted for every request, including static HTML. A victim navigated to a malicious site that DNS-rebinds onto `127.0.0.1` would still send `Host: evil.com`, which the server rejects with HTTP 403 before serving token-bearing HTML.
+2. **Per-launch CSRF token.** `arkor dev` generates a 32-byte token (base64url) on every launch, injects it into `index.html` as `<meta name="arkor-studio-token">`, and requires it on every `/api/*` call as `X-Arkor-Studio-Token`. The job-event stream also accepts `?studioToken=` because `EventSource` cannot send custom headers; mutation routes do not accept query-string tokens. Cross-origin tabs cannot read the meta, so a "simple" cross-origin POST that skips preflight is still rejected. Comparison is `timingSafeEqual`.
 3. **No CORS.** The SPA is same-origin so CORS adds no value. Reflecting `*` would let "simple" cross-origin POSTs (`text/plain`, `urlencoded`) through; the token check is what rejects them.
 
 The token is rotated on every `arkor dev` launch, so a stale tab from a previous run will fail with HTTP 403 until you reload it.

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -107,12 +107,14 @@ React SPA from the same origin. Two roles:
 
 Studio is loopback-only and per-launch CSRF-token-gated:
 
-- `/api/*` requires the `X-Arkor-Studio-Token` header (or
-  `?studioToken=` query for `EventSource`). The token is generated on
-  every `arkor dev` launch and injected into the served `index.html` as
-  a `<meta>` tag the same-origin SPA reads at startup.
-- The middleware also rejects requests whose `Host` isn't `127.0.0.1` or
-  `localhost` — defense against DNS rebinding.
+- Every request, including static HTML, rejects `Host` values other than
+  `127.0.0.1` or `localhost` — defense against DNS rebinding before the
+  token-bearing HTML is served.
+- `/api/*` requires the `X-Arkor-Studio-Token` header. The job-event stream
+  route also accepts `?studioToken=` because `EventSource` cannot send custom
+  headers. Mutation routes never accept the token from the query string.
+  The token is generated on every `arkor dev` launch and injected into the
+  served `index.html` as a `<meta>` tag the same-origin SPA reads at startup.
 
 ## Public exports
 

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -89,6 +89,17 @@ describe("Studio server", () => {
     );
   });
 
+  it("rejects non-loopback static requests without leaking the studio token", async () => {
+    const app = build();
+    const res = await app.request("/", {
+      headers: { host: "evil.example:4000" },
+    });
+    expect(res.status).toBe(403);
+    const text = await res.text();
+    expect(text).not.toContain(STUDIO_TOKEN);
+    expect(text).not.toContain("arkor-studio-token");
+  });
+
   it("rejects non-loopback API requests (DNS rebinding defense)", async () => {
     const app = build();
     const res = await app.request("/api/credentials", {
@@ -151,7 +162,16 @@ describe("Studio server", () => {
     });
   });
 
-  it("accepts the studio token via ?studioToken= for SSE-style requests", async () => {
+  it("rejects ?studioToken= on non-event API requests", async () => {
+    const app = build();
+    const res = await app.request(
+      `/api/credentials?studioToken=${encodeURIComponent(STUDIO_TOKEN)}`,
+      { headers: { host: "127.0.0.1:4000" } },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts the studio token via ?studioToken= for job event streams", async () => {
     await writeCredentials({
       mode: "anon",
       token: "tok",
@@ -161,10 +181,12 @@ describe("Studio server", () => {
     });
     const app = build();
     const res = await app.request(
-      `/api/credentials?studioToken=${encodeURIComponent(STUDIO_TOKEN)}`,
+      `/api/jobs/job-1/events?studioToken=${encodeURIComponent(STUDIO_TOKEN)}`,
       { headers: { host: "127.0.0.1:4000" } },
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("No project state");
   });
 
   it("rejects /api/train with a file path that escapes cwd", async () => {
@@ -203,6 +225,22 @@ describe("Studio server", () => {
       body: JSON.stringify({ file: "/etc/passwd" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("rejects /api/train when the studio token is only in the query string", async () => {
+    const app = build();
+    const res = await app.request(
+      `/api/train?studioToken=${encodeURIComponent(STUDIO_TOKEN)}`,
+      {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "content-type": "text/plain",
+        },
+        body: "{}",
+      },
+    );
+    expect(res.status).toBe(403);
   });
 
   // Regression for ENG-404 — `path.resolve` doesn't follow symlinks, so a

--- a/packages/arkor/src/studio/server.ts
+++ b/packages/arkor/src/studio/server.ts
@@ -40,10 +40,11 @@ export interface StudioServerOptions {
   autoAnonymous?: boolean;
   /**
    * Per-launch CSRF token. Every `/api/*` request must include it via header
-   * `X-Arkor-Studio-Token`, or `?studioToken=` for `EventSource` (which can't
-   * carry custom headers). The token is injected into the served `index.html`
-   * as a `<meta>` tag so the same-origin SPA can read it; cross-origin tabs
-   * cannot, so even a "simple" CORS POST without preflight is rejected.
+   * `X-Arkor-Studio-Token`; the job-event stream also accepts `?studioToken=`
+   * because `EventSource` cannot carry custom headers. The token is injected
+   * into the served `index.html` as a `<meta>` tag so the same-origin SPA can
+   * read it; cross-origin tabs cannot, so even a "simple" CORS POST without
+   * preflight is rejected.
    */
   studioToken: string;
   /**
@@ -109,22 +110,38 @@ export function buildStudioApp(options: StudioServerOptions) {
 
   const app = new Hono();
 
-  // Combined defense for `/api/*`:
-  //   1. Host-header guard (defense against DNS rebinding — a victim navigated
-  //      to `evil.com` rebound onto 127.0.0.1 still sends `Host: evil.com`).
-  //   2. Per-launch CSRF token. CORS is intentionally not configured: the SPA
+  const loopbackHostPattern = /^(127\.0\.0\.1|localhost)(:\d+)?$/;
+  const jobEventsPathPattern = /^\/api\/jobs\/[^/]+\/events$/;
+
+  // Host-header guard for every route, including static HTML that carries the
+  // per-launch Studio token. This is the DNS-rebinding boundary: a victim
+  // navigated to `evil.com` rebound onto 127.0.0.1 still sends `Host: evil.com`.
+  app.use("*", async (c, next) => {
+    const host = c.req.header("host") ?? "";
+    if (!loopbackHostPattern.test(host)) {
+      if (c.req.path.startsWith("/api/")) {
+        return c.json({ error: "Studio API is loopback-only" }, 403);
+      }
+      return c.text("Studio is loopback-only", 403);
+    }
+    await next();
+  });
+
+  // CSRF defense for `/api/*`:
+  //   1. Per-launch token. CORS is intentionally not configured: the SPA
   //      is same-origin so CORS adds no value, and reflecting `*` would let
   //      "simple" cross-origin POSTs (text/plain, urlencoded) skip preflight
   //      and reach the handler. The token check rejects those — an attacker
   //      page can't read the SPA's <meta> from another origin.
+  //   2. `?studioToken=` is accepted only on the job-event stream route
+  //      because `EventSource` cannot send custom headers. Mutation routes
+  //      require the header so a leaked token in a URL is not enough to POST.
   app.use("/api/*", async (c, next) => {
-    const host = c.req.header("host") ?? "";
-    if (!/^(127\.0\.0\.1|localhost)(:\d+)?$/.test(host)) {
-      return c.json({ error: "Studio API is loopback-only" }, 403);
-    }
+    const queryTokenAllowed =
+      c.req.method === "GET" && jobEventsPathPattern.test(c.req.path);
     const provided =
       c.req.header("x-arkor-studio-token") ??
-      c.req.query("studioToken") ??
+      (queryTokenAllowed ? c.req.query("studioToken") : undefined) ??
       "";
     if (!tokensMatch(provided, studioToken)) {
       return c.json({ error: "Missing or invalid studio token" }, 403);


### PR DESCRIPTION
## Summary

- Apply the loopback Host header guard to all Studio routes, including static HTML, before the CSRF token is injected.
- Restrict `?studioToken=` authentication to the job event stream route only.
- Keep mutation routes, including `/api/train`, header-token only.
- Update Studio security docs to match the hardened behavior.

## Verification

- `pnpm exec vitest run src/studio/server.test.ts -t "non-loopback static|query string|job event streams"`
- `pnpm typecheck`
