### PR TITLE
Update scaffold Arkor dependency spec and add CI override

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,12 +129,16 @@ jobs:
       # step above is used as-is.
       - name: Test (rolldown-incompatible Node)
         if: ${{ matrix.rolldownIncompat }}
+        env:
+          ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC: file:${{ github.workspace }}/packages/arkor
         run: |
           pnpm exec turbo run test --filter='!@arkor/e2e-cli'
           pnpm --filter @arkor/e2e-cli exec vitest run
 
       - name: Test
         if: ${{ !matrix.rolldownIncompat }}
+        env:
+          ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC: file:${{ github.workspace }}/packages/arkor
         run: pnpm test
 
       - name: Build

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -180,6 +180,20 @@ jobs:
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 
+      # Re-pack after Test so the dry-run publish exercises the same
+      # dist/ that the real release would upload. The pre-Test pack
+      # only existed to feed ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC; the
+      # e2e-cli pretest rebuilt dist/ since.
+      - name: Re-pack release tarballs
+        run: |
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          rm -rf "$PACK_DIR"
+          mkdir -p "$PACK_DIR"
+
+          for PKG_DIR in packages/arkor packages/create-arkor; do
+            (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
+          done
+
       - name: Dry run publish (arkor)
         run: |
           VERSION="${{ steps.meta.outputs.version }}"

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -139,17 +139,6 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Test
-        env:
-          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
-          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
-          # Disable runtime telemetry: `pnpm run test` triggers the
-          # e2e-cli pretest, which rebuilds `arkor` with the key baked
-          # in. The tests then spawn that binary, so without this flag
-          # every release run would emit real PostHog events from CI.
-          ARKOR_TELEMETRY_DISABLED: "1"
-        run: pnpm run test
-
       - name: Pack and inspect tarballs
         run: |
           PACK_DIR="$RUNNER_TEMP/npm-pack"
@@ -160,10 +149,36 @@ jobs:
             (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
           done
 
+          # Resolve the freshly-packed `arkor` tarball without hard-coding
+          # the filename, then expose it to subsequent steps as a
+          # `file:` spec so the e2e scaffold install tests use *this*
+          # build instead of fetching `arkor` from the registry.
+          shopt -s nullglob
+          ARKOR_TARBALLS=("$PACK_DIR"/arkor-*.tgz)
+          shopt -u nullglob
+          if [[ ${#ARKOR_TARBALLS[@]} -ne 1 ]]; then
+            echo "Expected exactly one arkor-*.tgz in $PACK_DIR, got ${#ARKOR_TARBALLS[@]}"
+            ls -la "$PACK_DIR" || true
+            exit 1
+          fi
+          ARKOR_TARBALL="${ARKOR_TARBALLS[0]}"
+          echo "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC=file:$ARKOR_TARBALL" >> "$GITHUB_ENV"
+
           for TARBALL in "$PACK_DIR"/*.tgz; do
             echo "## $(basename "$TARBALL")"
             tar -tf "$TARBALL"
           done
+
+      - name: Test
+        env:
+          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
+          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
+          # Disable runtime telemetry: `pnpm run test` triggers the
+          # e2e-cli pretest, which rebuilds `arkor` with the key baked
+          # in. The tests then spawn that binary, so without this flag
+          # every release run would emit real PostHog events from CI.
+          ARKOR_TELEMETRY_DISABLED: "1"
+        run: pnpm run test
 
       - name: Dry run publish (arkor)
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,11 +178,6 @@ jobs:
             tar -tf "$TARBALL"
           done
 
-      - name: Generate GitHub artifact attestations for release tarballs
-        uses: actions/attest@v4
-        with:
-          subject-path: ${{ runner.temp }}/npm-pack/*.tgz
-
       - name: Test
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
@@ -193,6 +188,27 @@ jobs:
           # every release run would emit real PostHog events from CI.
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
+
+      # Re-pack after Test so the attestation and the GitHub Release
+      # artifacts capture the same dist/ that `npm publish` (from the
+      # package directory, below) will upload — the e2e-cli pretest
+      # rebuilds dist/, so the pre-Test pack that fed
+      # ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC is now stale for that
+      # purpose.
+      - name: Re-pack release tarballs
+        run: |
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          rm -rf "$PACK_DIR"
+          mkdir -p "$PACK_DIR"
+
+          for PKG_DIR in packages/arkor packages/create-arkor; do
+            (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
+          done
+
+      - name: Generate GitHub artifact attestations for release tarballs
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ runner.temp }}/npm-pack/*.tgz
 
       # Publish from the package directory (not from the pre-packed tarball)
       # so npm CLI reads README.md at publish time and embeds it in the

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,17 +148,6 @@ jobs:
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
         run: pnpm run build
 
-      - name: Test
-        env:
-          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
-          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
-          # Disable runtime telemetry: `pnpm run test` triggers the
-          # e2e-cli pretest, which rebuilds `arkor` with the key baked
-          # in. The tests then spawn that binary, so without this flag
-          # every release run would emit real PostHog events from CI.
-          ARKOR_TELEMETRY_DISABLED: "1"
-        run: pnpm run test
-
       - name: Pack and inspect tarballs
         run: |
           PACK_DIR="$RUNNER_TEMP/npm-pack"
@@ -169,6 +158,21 @@ jobs:
             (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
           done
 
+          # Resolve the freshly-packed `arkor` tarball without hard-coding
+          # the filename, then expose it to subsequent steps as a
+          # `file:` spec so the e2e scaffold install tests use *this*
+          # build instead of fetching `arkor` from the registry.
+          shopt -s nullglob
+          ARKOR_TARBALLS=("$PACK_DIR"/arkor-*.tgz)
+          shopt -u nullglob
+          if [[ ${#ARKOR_TARBALLS[@]} -ne 1 ]]; then
+            echo "Expected exactly one arkor-*.tgz in $PACK_DIR, got ${#ARKOR_TARBALLS[@]}"
+            ls -la "$PACK_DIR" || true
+            exit 1
+          fi
+          ARKOR_TARBALL="${ARKOR_TARBALLS[0]}"
+          echo "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC=file:$ARKOR_TARBALL" >> "$GITHUB_ENV"
+
           for TARBALL in "$PACK_DIR"/*.tgz; do
             echo "## $(basename "$TARBALL")"
             tar -tf "$TARBALL"
@@ -178,6 +182,17 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: ${{ runner.temp }}/npm-pack/*.tgz
+
+      - name: Test
+        env:
+          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
+          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
+          # Disable runtime telemetry: `pnpm run test` triggers the
+          # e2e-cli pretest, which rebuilds `arkor` with the key baked
+          # in. The tests then spawn that binary, so without this flag
+          # every release run would emit real PostHog events from CI.
+          ARKOR_TELEMETRY_DISABLED: "1"
+        run: pnpm run test
 
       # Publish from the package directory (not from the pre-packed tarball)
       # so npm CLI reads README.md at publish time and embeds it in the

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -10,6 +10,7 @@ import {
 
 let cwd: string;
 const ORIG_UA = process.env.npm_config_user_agent;
+const ORIG_ARKOR_SPEC = process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC;
 
 beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "cli-internal-test-"));
@@ -17,6 +18,11 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env.npm_config_user_agent = ORIG_UA;
+  if (ORIG_ARKOR_SPEC === undefined) {
+    delete process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC;
+  } else {
+    process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = ORIG_ARKOR_SPEC;
+  }
   rmSync(cwd, { recursive: true, force: true });
 });
 
@@ -114,7 +120,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.3");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.4");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");
@@ -130,6 +136,23 @@ describe("scaffold", () => {
     const second = await scaffold({ cwd, name: "n", template: "minimal" });
     const secondEntry = second.files.find((f) => f.path === ".gitignore");
     expect(secondEntry?.action).toBe("ok");
+  });
+
+  it("uses ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC override when set", async () => {
+    process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC =
+      "file:/tmp/arkor/arkor-0.0.1-alpha.4.tgz";
+    const { files } = await scaffold({
+      cwd,
+      name: "override-app",
+      template: "minimal",
+    });
+    const pkg = JSON.parse(
+      readFileSync(join(cwd, "package.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.arkor).toBe("file:/tmp/arkor/arkor-0.0.1-alpha.4.tgz");
+    const pkgEntry = files.find((f) => f.path === "package.json");
+    expect(pkgEntry?.action).toBe("created");
   });
 
   it("renders each template with a distinct trainer body", async () => {

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -166,6 +166,29 @@ describe("scaffold", () => {
     expect(pkgEntry?.action).toBe("created");
   });
 
+  it.each([
+    { label: "empty string", value: "" },
+    { label: "whitespace only", value: "   " },
+  ])(
+    "falls back to the default spec when ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC is $label",
+    async ({ value }) => {
+      // Without the trim+length guard, an empty/whitespace override would
+      // be written verbatim into package.json (`"arkor": ""`), which is
+      // not a valid dependency spec. Treat both as "unset".
+      process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = value;
+      await scaffold({
+        cwd,
+        name: "blank-override",
+        template: "minimal",
+      });
+      const pkg = JSON.parse(
+        readFileSync(join(cwd, "package.json"), "utf8"),
+      ) as Record<string, unknown>;
+      const devDeps = pkg.devDependencies as Record<string, string>;
+      expect(devDeps.arkor).toBe("^0.0.1-alpha.4");
+    },
+  );
+
   it("uses ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC override when patching an existing package.json", async () => {
     // The spec resolution is shared between the create path (above)
     // and the patch path that runs when `package.json` already exists

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -147,8 +147,11 @@ describe("scaffold", () => {
   });
 
   it("uses ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC override when set", async () => {
-    process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC =
-      "file:/tmp/arkor/arkor-0.0.1-alpha.4.tgz";
+    // The value is opaque to scaffold — only that it's faithfully
+    // round-tripped into package.json matters, so use a relative
+    // `file:` spec that is platform-neutral (no Unix-only `/tmp`).
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.4.tgz";
+    process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     const { files } = await scaffold({
       cwd,
       name: "override-app",
@@ -158,9 +161,44 @@ describe("scaffold", () => {
       readFileSync(join(cwd, "package.json"), "utf8"),
     ) as Record<string, unknown>;
     const devDeps = pkg.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("file:/tmp/arkor/arkor-0.0.1-alpha.4.tgz");
+    expect(devDeps.arkor).toBe(overrideSpec);
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("created");
+  });
+
+  it("uses ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC override when patching an existing package.json", async () => {
+    // The spec resolution is shared between the create path (above)
+    // and the patch path that runs when `package.json` already exists
+    // but has no `devDependencies.arkor`. Cover the patch path too so
+    // the override doesn't silently regress to the default there.
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.4.tgz";
+    process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
+    writeFileSync(
+      join(cwd, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "existing-app",
+          version: "1.0.0",
+          private: true,
+          devDependencies: { typescript: "^5.0.0" },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const { files } = await scaffold({
+      cwd,
+      name: "existing-app",
+      template: "minimal",
+    });
+    const pkg = JSON.parse(
+      readFileSync(join(cwd, "package.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.arkor).toBe(overrideSpec);
+    expect(devDeps.typescript).toBe("^5.0.0");
+    const pkgEntry = files.find((f) => f.path === "package.json");
+    expect(pkgEntry?.action).toBe("patched");
   });
 
   it("renders each template with a distinct trainer body", async () => {

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -14,10 +14,18 @@ const ORIG_ARKOR_SPEC = process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC;
 
 beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "cli-internal-test-"));
+  delete process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC;
 });
 
 afterEach(() => {
-  process.env.npm_config_user_agent = ORIG_UA;
+  // Node coerces env-var assignments to strings, so a plain
+  // `process.env.X = undefined` writes the literal string "undefined".
+  // Mirror the spec restore: delete on undefined, otherwise reassign.
+  if (ORIG_UA === undefined) {
+    delete process.env.npm_config_user_agent;
+  } else {
+    process.env.npm_config_user_agent = ORIG_UA;
+  }
   if (ORIG_ARKOR_SPEC === undefined) {
     delete process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC;
   } else {

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -30,6 +30,11 @@ const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
+const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.4";
+
+function resolveArkorScaffoldSpec(): string {
+  return process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC ?? DEFAULT_ARKOR_SPEC;
+}
 
 const SCRIPT_DEFAULTS: Record<string, string> = {
   dev: "arkor dev",
@@ -89,7 +94,7 @@ async function patchPackageJson(
           private: true,
           type: "module",
           scripts: { ...SCRIPT_DEFAULTS },
-          devDependencies: { arkor: "^0.0.1-alpha.3" },
+          devDependencies: { arkor: resolveArkorScaffoldSpec() },
         },
         null,
         2,
@@ -114,7 +119,7 @@ async function patchPackageJson(
   const devDeps =
     (current.devDependencies as Record<string, string> | undefined) ?? {};
   if (!devDeps.arkor) {
-    devDeps.arkor = "^0.0.1-alpha.3";
+    devDeps.arkor = resolveArkorScaffoldSpec();
     current.devDependencies = devDeps;
     dirty = true;
   }

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -33,7 +33,12 @@ const PACKAGE_JSON_PATH = "package.json";
 const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.4";
 
 function resolveArkorScaffoldSpec(): string {
-  return process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC ?? DEFAULT_ARKOR_SPEC;
+  // Treat unset, empty, and whitespace-only values the same: fall back to
+  // the default. Without this, `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC=""`
+  // (or just spaces) would write `"arkor": ""` into the scaffolded
+  // package.json, which is not a valid dependency spec.
+  const override = process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC?.trim();
+  return override && override.length > 0 ? override : DEFAULT_ARKOR_SPEC;
 }
 
 const SCRIPT_DEFAULTS: Record<string, string> = {

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
     },
     "test": {
       "dependsOn": ["^build"],
+      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC"],
       "outputs": []
     },
     "typecheck": {

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC"],
+      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC", "SKIP_E2E_INSTALL"],
       "outputs": []
     },
     "typecheck": {


### PR DESCRIPTION
## Summary
- Update the default `arkor` dependency spec used by `scaffold` to `^0.0.1-alpha.4`
- Add `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC` so CI can override the scaffolded dependency spec, including local tarball or `file:` specs
- Use the same spec resolution logic for both new `package.json` creation and existing `package.json` patching
- Update tests for the new default spec and add coverage for the override behavior

## Testing
- `pnpm --filter @arkor/cli-internal test`
