### PR TITLE
feat(ci): add Codecov coverage uploads via tokenless OIDC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,6 +186,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           files: ./packages/arkor/coverage/lcov.info
           flags: arkor
           fail_ci_if_error: false
@@ -195,6 +196,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           files: ./packages/create-arkor/coverage/lcov.info
           flags: create-arkor
           fail_ci_if_error: false
@@ -204,6 +206,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           files: ./packages/cli-internal/coverage/lcov.info
           flags: cli-internal
           fail_ci_if_error: false
@@ -213,6 +216,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           files: ./packages/studio-app/coverage/lcov.info
           flags: studio-app
           fail_ci_if_error: false
@@ -226,6 +230,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           files: ./e2e/cli/coverage/lcov.info
           flags: e2e-cli
           fail_ci_if_error: false
@@ -239,6 +244,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           report_type: test_results
           files: ./packages/arkor/coverage/junit.xml
           flags: arkor
@@ -249,6 +255,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           report_type: test_results
           files: ./packages/create-arkor/coverage/junit.xml
           flags: create-arkor
@@ -259,6 +266,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           report_type: test_results
           files: ./packages/cli-internal/coverage/junit.xml
           flags: cli-internal
@@ -269,6 +277,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           report_type: test_results
           files: ./packages/studio-app/coverage/junit.xml
           flags: studio-app
@@ -279,6 +288,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
+          disable_search: true
           report_type: test_results
           files: ./e2e/cli/coverage/junit.xml
           flags: e2e-cli

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,12 +174,14 @@ jobs:
       - name: Install
         run: pnpm install
 
-      # Tests must keep going on failure so JUnit XML still gets uploaded
-      # to Codecov Test Analytics. Subsequent upload steps gate on
-      # `!cancelled()` so they run even when this step fails; the job's
-      # final outcome still reflects the test result.
+      # Tests must keep going on failure so every package still produces
+      # its lcov.info / junit.xml; turbo's default `--continue=never` would
+      # cancel sibling tasks after the first failure and starve the upload
+      # steps below. Subsequent uploads gate on `!cancelled()` so they run
+      # even when tests fail; the job's final outcome still reflects the
+      # test result.
       - name: Test with coverage
-        run: pnpm test:coverage
+        run: pnpm exec turbo run test:coverage --continue
 
       - name: Upload arkor coverage
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,11 +145,12 @@ jobs:
     name: coverage · upload to Codecov
     runs-on: ubuntu-latest
     # The matrix above already exercises tests across Node versions; this
-    # job runs once on the newest LTS to keep coverage uploads stable.
-    # Codecov uploads use OIDC (`use_oidc: true`) — no CODECOV_TOKEN secret
-    # is stored in this repo. `id-token: write` is required for the runner
-    # to mint the OIDC JWT that codecov-action exchanges for an upload
-    # token. See https://docs.codecov.com/docs/github-tokenless-uploads.
+    # job runs once on the newest LTS to keep coverage + Test Analytics
+    # uploads stable. Codecov uploads use OIDC (`use_oidc: true`) — no
+    # CODECOV_TOKEN secret is stored in this repo. `id-token: write` is
+    # required for the runner to mint the OIDC JWT that codecov-action
+    # exchanges for an upload token. See
+    # https://docs.codecov.com/docs/github-tokenless-uploads.
     permissions:
       id-token: write
     steps:
@@ -173,10 +174,15 @@ jobs:
       - name: Install
         run: pnpm install
 
+      # Tests must keep going on failure so JUnit XML still gets uploaded
+      # to Codecov Test Analytics. Subsequent upload steps gate on
+      # `!cancelled()` so they run even when this step fails; the job's
+      # final outcome still reflects the test result.
       - name: Test with coverage
         run: pnpm test:coverage
 
       - name: Upload arkor coverage
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -185,6 +191,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload create-arkor coverage
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -193,6 +200,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload cli-internal coverage
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -201,9 +209,54 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload studio-app coverage
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           files: ./packages/studio-app/coverage/lcov.info
+          flags: studio-app
+          fail_ci_if_error: false
+
+      # Codecov Test Analytics — uploads JUnit XML produced by the vitest
+      # `junit` reporter. Tracks pass/fail history per test, surfaces flaky
+      # tests, and shows failure trends on the Codecov dashboard. See
+      # https://docs.codecov.com/docs/test-analytics.
+      - name: Upload arkor test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          report_type: test_results
+          files: ./packages/arkor/coverage/junit.xml
+          flags: arkor
+          fail_ci_if_error: false
+
+      - name: Upload create-arkor test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          report_type: test_results
+          files: ./packages/create-arkor/coverage/junit.xml
+          flags: create-arkor
+          fail_ci_if_error: false
+
+      - name: Upload cli-internal test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          report_type: test_results
+          files: ./packages/cli-internal/coverage/junit.xml
+          flags: cli-internal
+          fail_ci_if_error: false
+
+      - name: Upload studio-app test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          report_type: test_results
+          files: ./packages/studio-app/coverage/junit.xml
           flags: studio-app
           fail_ci_if_error: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,6 +217,19 @@ jobs:
           flags: studio-app
           fail_ci_if_error: false
 
+      # E2E coverage is collected via c8 wrapping vitest in e2e/cli; the
+      # spawned CLI children inherit NODE_V8_COVERAGE and their hits are
+      # remapped through tsdown's sourcemaps back into
+      # packages/{arkor,create-arkor}/src/**.
+      - name: Upload e2e-cli coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./e2e/cli/coverage/lcov.info
+          flags: e2e-cli
+          fail_ci_if_error: false
+
       # Codecov Test Analytics — uploads JUnit XML produced by the vitest
       # `junit` reporter. Tracks pass/fail history per test, surfaces flaky
       # tests, and shows failure trends on the Codecov dashboard. See
@@ -259,4 +272,14 @@ jobs:
           report_type: test_results
           files: ./packages/studio-app/coverage/junit.xml
           flags: studio-app
+          fail_ci_if_error: false
+
+      - name: Upload e2e-cli test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          report_type: test_results
+          files: ./e2e/cli/coverage/junit.xml
+          flags: e2e-cli
           fail_ci_if_error: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,3 +140,70 @@ jobs:
       - name: Build
         if: ${{ !matrix.rolldownIncompat }}
         run: pnpm build
+
+  coverage:
+    name: coverage · upload to Codecov
+    runs-on: ubuntu-latest
+    # The matrix above already exercises tests across Node versions; this
+    # job runs once on the newest LTS to keep coverage uploads stable.
+    # Codecov uploads use OIDC (`use_oidc: true`) — no CODECOV_TOKEN secret
+    # is stored in this repo. `id-token: write` is required for the runner
+    # to mint the OIDC JWT that codecov-action exchanges for an upload
+    # token. See https://docs.codecov.com/docs/github-tokenless-uploads.
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Cache Turborepo
+        uses: actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-coverage-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-coverage-
+
+      - name: Install
+        run: pnpm install
+
+      - name: Test with coverage
+        run: pnpm test:coverage
+
+      - name: Upload arkor coverage
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./packages/arkor/coverage/lcov.info
+          flags: arkor
+          fail_ci_if_error: false
+
+      - name: Upload create-arkor coverage
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./packages/create-arkor/coverage/lcov.info
+          flags: create-arkor
+          fail_ci_if_error: false
+
+      - name: Upload cli-internal coverage
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./packages/cli-internal/coverage/lcov.info
+          flags: cli-internal
+          fail_ci_if_error: false
+
+      - name: Upload studio-app coverage
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./packages/studio-app/coverage/lcov.info
+          flags: studio-app
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ packages/arkor/docs/
 # Vitest coverage reports (uploaded to Codecov in CI)
 coverage/
 
+# Raw V8 coverage data emitted by NODE_V8_COVERAGE for E2E coverage
+.v8-coverage/
+
 # Mintlify (docs/) local cache
 .mintlify/
 .mint/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ packages/arkor/docs/
 # Turbo
 .turbo/
 
+# Vitest coverage reports (uploaded to Codecov in CI)
+coverage/
+
 # Mintlify (docs/) local cache
 .mintlify/
 .mint/

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,54 @@
+# Codecov configuration. Reference: https://docs.codecov.com/docs/codecov-yaml
+#
+# We upload one lcov report per package via the GitHub Action's `flags`.
+# Each flag is scoped to its package's source path so cross-package noise
+# does not pollute per-package coverage trends.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: arkor
+      paths:
+        - packages/arkor/src
+    - name: create-arkor
+      paths:
+        - packages/create-arkor/src
+    - name: cli-internal
+      paths:
+        - packages/cli-internal/src
+    - name: studio-app
+      paths:
+        - packages/studio-app/src
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.d.ts"
+  - "**/dist/**"
+  - "**/node_modules/**"
+  - "e2e/**"
+  - "docs/**"
+  - "packages/arkor/scripts/**"
+  - "packages/create-arkor/scripts/**"
+  - "packages/arkor/src/bin.ts"
+  - "packages/create-arkor/src/bin.ts"
+  - "packages/studio-app/src/main.tsx"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -60,5 +60,7 @@ ignore:
   - "packages/arkor/scripts/**"
   - "packages/create-arkor/scripts/**"
   - "packages/arkor/src/bin.ts"
-  - "packages/create-arkor/src/bin.ts"
+  # `packages/create-arkor/src/bin.ts` is intentionally NOT ignored: it is
+  # the only source file in that package, so excluding it would leave the
+  # `create-arkor` flag with zero eligible files.
   - "packages/studio-app/src/main.tsx"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -38,6 +38,16 @@ flag_management:
     - name: studio-app
       paths:
         - packages/studio-app/src
+    # E2E coverage is collected by spawning the built CLIs under c8 and
+    # remapping the resulting V8 coverage through tsdown's sourcemaps. Hits
+    # land back in `packages/{arkor,create-arkor}/src/**`, overlapping with
+    # the unit-test flags. Codecov merges flags into the overall report;
+    # this flag exists so we can see how much of each CLI is covered by
+    # E2E specifically (vs unit tests alone).
+    - name: e2e-cli
+      paths:
+        - packages/arkor/src
+        - packages/create-arkor/src
 
 ignore:
   - "**/*.test.ts"

--- a/e2e/cli/.c8rc.json
+++ b/e2e/cli/.c8rc.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "c8 wraps vitest, sets NODE_V8_COVERAGE so the spawned CLI children write V8 coverage data, and merges the result. Sourcemaps emitted by tsdown remap dist/* hits to the original src/* files, so the resulting lcov references repo paths under packages/{arkor,create-arkor}/src/**.",
+  "all": false,
+  "include": [
+    "../../packages/arkor/dist/**",
+    "../../packages/create-arkor/dist/**"
+  ],
+  "exclude": [
+    "**/*.test.*",
+    "**/node_modules/**"
+  ],
+  "reporter": ["text", "lcov"],
+  "reports-dir": "./coverage",
+  "temp-directory": "./.v8-coverage"
+}

--- a/e2e/cli/package.json
+++ b/e2e/cli/package.json
@@ -6,13 +6,16 @@
   "type": "module",
   "scripts": {
     "pretest": "pnpm --filter create-arkor build && pnpm --filter arkor build",
+    "pretest:coverage": "pnpm --filter create-arkor build && pnpm --filter arkor build",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "c8 --config .c8rc.json vitest run"
   },
   "devDependencies": {
     "@types/node": "^24",
+    "c8": "^10.1.3",
     "typescript": "^5",
     "vitest": "^4.1.5"
   }

--- a/e2e/cli/package.json
+++ b/e2e/cli/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "pretest": "pnpm --filter create-arkor build && pnpm --filter arkor build",
-    "pretest:coverage": "pnpm --filter create-arkor build && pnpm --filter arkor build",
+    "pretest:coverage": "CREATE_ARKOR_BUILD_SOURCEMAP=1 pnpm --filter create-arkor build && pnpm --filter arkor build",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
     "test": "vitest run",

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -5,5 +5,14 @@ export default defineConfig({
     // Spawning Node + the bundled CLI bin takes ~600–1200 ms locally; the
     // default 5 s timeout is too tight for assertions that wait for `close`.
     testTimeout: 15_000,
+    // `default` keeps normal CLI output; `junit` writes the XML that
+    // codecov-action consumes for Test Analytics. E2E coverage itself is
+    // collected via c8 (NODE_V8_COVERAGE) wrapping vitest in the
+    // `test:coverage` script — vitest's own coverage option is not used
+    // here because v8 coverage of *child* CLI processes is what we want.
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./coverage/junit.xml",
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -46,7 +46,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@arkor/cloud-api-client": "^0.0.1-alpha.1",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@arkor/cli-internal": "workspace:*",
     "@types/node": "^24",
+    "@vitest/coverage-v8": "^4.1.5",
     "tsdown": "^0.21.9",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/packages/arkor/vitest.config.ts
+++ b/packages/arkor/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // `default` keeps normal CLI output; `junit` writes the XML that
+    // codecov/test-results-action consumes for Test Analytics.
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./coverage/junit.xml",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/packages/arkor/vitest.config.ts
+++ b/packages/arkor/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts", "src/bin.ts"],
+    },
+  },
+});

--- a/packages/arkor/vitest.config.ts
+++ b/packages/arkor/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     // `default` keeps normal CLI output; `junit` writes the XML that
-    // codecov/test-results-action consumes for Test Analytics.
+    // codecov/codecov-action (with `report_type: test_results`) consumes
+    // for Test Analytics.
     reporters: ["default", "junit"],
     outputFile: {
       junit: "./coverage/junit.xml",

--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -15,10 +15,12 @@
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@types/node": "^24",
+    "@vitest/coverage-v8": "^4.1.5",
     "typescript": "^5",
     "vitest": "^4.1.5"
   }

--- a/packages/cli-internal/vitest.config.ts
+++ b/packages/cli-internal/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // `default` keeps normal CLI output; `junit` writes the XML that
+    // codecov/test-results-action consumes for Test Analytics.
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./coverage/junit.xml",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/packages/cli-internal/vitest.config.ts
+++ b/packages/cli-internal/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     // `default` keeps normal CLI output; `junit` writes the XML that
-    // codecov/test-results-action consumes for Test Analytics.
+    // codecov/codecov-action (with `report_type: test_results`) consumes
+    // for Test Analytics.
     reporters: ["default", "junit"],
     outputFile: {
       junit: "./coverage/junit.xml",

--- a/packages/cli-internal/vitest.config.ts
+++ b/packages/cli-internal/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
+    },
+  },
+});

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -31,7 +31,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'",
     "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --passWithNoTests --coverage"
   },
   "dependencies": {
     "@clack/prompts": "^0.8.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@arkor/cli-internal": "workspace:*",
     "@types/node": "^24",
+    "@vitest/coverage-v8": "^4.1.5",
     "tsdown": "^0.21.9",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/packages/create-arkor/tsdown.config.ts
+++ b/packages/create-arkor/tsdown.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
@@ -6,7 +7,14 @@ export default defineConfig({
   dts: false,
   clean: true,
   minify: true,
-  sourcemap: false,
+  // Default-off: the published `create-arkor` tarball intentionally ships
+  // without sourcemaps (it's a one-shot scaffolder; users never debug into
+  // it, and we want a minimum-size tarball). The E2E coverage path opts in
+  // by setting `CREATE_ARKOR_BUILD_SOURCEMAP=1` (see e2e/cli's
+  // `pretest:coverage`) so c8 can remap dist/bin.mjs hits back to
+  // src/bin.ts. The published `pnpm --filter create-arkor build` invoked by
+  // the release workflow does NOT set this, so no `.map` file is generated.
+  sourcemap: process.env.CREATE_ARKOR_BUILD_SOURCEMAP === "1",
   tsconfig: "./tsconfig.build.json",
   // `@arkor/cli-internal` is a private workspace package — bundle its source
   // into the published tarball so consumers don't depend on something that

--- a/packages/create-arkor/vitest.config.ts
+++ b/packages/create-arkor/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // `default` keeps normal CLI output; `junit` writes the XML that
+    // codecov/test-results-action consumes for Test Analytics.
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./coverage/junit.xml",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/packages/create-arkor/vitest.config.ts
+++ b/packages/create-arkor/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts", "src/bin.ts"],
+    },
+  },
+});

--- a/packages/create-arkor/vitest.config.ts
+++ b/packages/create-arkor/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     // `default` keeps normal CLI output; `junit` writes the XML that
-    // codecov/test-results-action consumes for Test Analytics.
+    // codecov/codecov-action (with `report_type: test_results`) consumes
+    // for Test Analytics.
     reporters: ["default", "junit"],
     outputFile: {
       junit: "./coverage/junit.xml",
@@ -13,7 +14,9 @@ export default defineConfig({
       reporter: ["text", "lcov"],
       reportsDirectory: "./coverage",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/*.d.ts", "src/bin.ts"],
+      // `src/bin.ts` is the only source file in this package, so excluding
+      // it would leave the `create-arkor` flag with zero eligible files.
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
     },
   },
 });

--- a/packages/studio-app/package.json
+++ b/packages/studio-app/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "eventsource-parser": "^3.0.0",
@@ -19,6 +20,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "typescript": "^5",
     "vite": "^6.0.0",
     "vitest": "^4.1.5"

--- a/packages/studio-app/vitest.config.ts
+++ b/packages/studio-app/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // `default` keeps normal CLI output; `junit` writes the XML that
+    // codecov/test-results-action consumes for Test Analytics.
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./coverage/junit.xml",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/packages/studio-app/vitest.config.ts
+++ b/packages/studio-app/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     // `default` keeps normal CLI output; `junit` writes the XML that
-    // codecov/test-results-action consumes for Test Analytics.
+    // codecov/codecov-action (with `report_type: test_results`) consumes
+    // for Test Analytics.
     reporters: ["default", "junit"],
     outputFile: {
       junit: "./coverage/junit.xml",

--- a/packages/studio-app/vitest.config.ts
+++ b/packages/studio-app/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.d.ts",
+        "src/main.tsx",
+        "src/styles.css",
+      ],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
 
   packages/arkor:
     dependencies:
@@ -66,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       tsdown:
         specifier: ^0.21.9
         version: 0.21.10(typescript@5.9.3)
@@ -74,19 +77,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
 
   packages/cli-internal:
     devDependencies:
       '@types/node':
         specifier: ^24
         version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
 
   packages/create-arkor:
     dependencies:
@@ -103,6 +109,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       tsdown:
         specifier: ^0.21.9
         version: 0.21.10(typescript@5.9.3)
@@ -111,7 +120,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
 
   packages/studio-app:
     dependencies:
@@ -134,6 +143,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -142,7 +154,7 @@ importers:
         version: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
 
 packages:
 
@@ -272,6 +284,10 @@ packages:
   '@babel/types@8.0.0-rc.3':
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
@@ -1735,6 +1751,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1914,6 +1939,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2825,6 +2853,10 @@ packages:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -2914,6 +2946,9 @@ packages:
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3201,12 +3236,27 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3314,6 +3364,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4464,6 +4521,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -5210,6 +5271,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@canvas/image-data@1.1.0': {}
 
@@ -6850,6 +6913,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -7025,6 +7102,12 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -8053,6 +8136,8 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
+  has-flag@4.0.0: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -8255,6 +8340,8 @@ snapshots:
   hono@4.12.14: {}
 
   hookable@6.1.1: {}
+
+  html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
 
@@ -8550,9 +8637,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@1.21.7: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -8640,6 +8742,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-extensions@2.0.0: {}
 
@@ -10415,6 +10527,10 @@ snapshots:
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tagged-tag@1.0.0: {}
@@ -10866,7 +10982,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@24.12.2)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.3))
@@ -10890,6 +11006,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.2
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -891,6 +894,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1017,6 +1028,10 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@posthog/core@1.27.7':
     resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
@@ -1690,6 +1705,9 @@ packages:
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
@@ -1986,6 +2004,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -2064,6 +2086,13 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -2086,6 +2115,16 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  c8@10.1.3:
+    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -2464,6 +2503,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2475,6 +2517,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -2699,6 +2744,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -2711,6 +2760,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -2829,6 +2882,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -3248,6 +3306,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -3339,6 +3400,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash.topath@4.5.2:
     resolution: {integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==}
 
@@ -3354,6 +3419,9 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3601,8 +3669,16 @@ packages:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3614,6 +3690,10 @@ packages:
   minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -3791,6 +3871,14 @@ packages:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
     engines: {node: '>=12.20'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   p-some@6.0.0:
     resolution: {integrity: sha512-CJbQCKdfSX3fIh8/QKgS+9rjm7OBNUTmwWswAFQAhc8j1NR1dsEDETUEuVUtQHZpV+J03LqWBEwvu0g1Yn+TYg==}
     engines: {node: '>=12.20'}
@@ -3806,6 +3894,9 @@ packages:
   pac-resolver@7.0.1:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3832,12 +3923,20 @@ packages:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -4476,6 +4575,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -4563,6 +4666,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -4840,6 +4947,10 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -4984,6 +5095,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -5061,6 +5176,10 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
@@ -5680,6 +5799,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6211,6 +6341,9 @@ snapshots:
       fast-deep-equal: 3.1.3
 
   '@oxc-project/types@0.127.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@posthog/core@1.27.7':
     dependencies:
@@ -6847,6 +6980,8 @@ snapshots:
 
   '@types/http-cache-semantics@4.2.0': {}
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
   '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
@@ -7145,6 +7280,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.7.1:
@@ -7222,6 +7359,14 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -7246,6 +7391,20 @@ snapshots:
       run-applescript: 7.1.0
 
   bytes@3.1.2: {}
+
+  c8@10.1.3:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 7.0.2
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   cac@7.0.0: {}
 
@@ -7579,6 +7738,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.344: {}
@@ -7586,6 +7747,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -7965,11 +8128,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   form-data-encoder@2.1.4: {}
 
@@ -8096,6 +8269,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globalthis@1.0.4:
     dependencies:
@@ -8650,6 +8832,12 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@1.21.7: {}
 
   jose@6.2.3: {}
@@ -8723,6 +8911,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash.topath@4.5.2: {}
 
   lodash@4.17.21: {}
@@ -8732,6 +8924,8 @@ snapshots:
   longest-streak@3.1.0: {}
 
   lowercase-keys@3.0.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9300,9 +9494,17 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
 
   minimist@1.2.8:
     optional: true
@@ -9312,6 +9514,8 @@ snapshots:
       yallist: 4.0.0
 
   minipass@5.0.0: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -9498,6 +9702,14 @@ snapshots:
 
   p-cancelable@3.0.0: {}
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   p-some@6.0.0:
     dependencies:
       aggregate-error: 4.0.1
@@ -9522,6 +9734,8 @@ snapshots:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.1.1
+
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -9561,9 +9775,16 @@ snapshots:
 
   patch-console@2.0.0: {}
 
+  path-exists@4.0.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -10459,6 +10680,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -10645,6 +10872,12 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   text-decoder@1.2.7:
     dependencies:
@@ -10946,6 +11179,12 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   vary@1.1.2: {}
 
   vfile-location@5.0.3:
@@ -11085,6 +11324,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -11147,6 +11392,8 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
     },
     "test:coverage": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "cache": false
     },
     "typecheck": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "test:coverage": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## Summary
- Wire up Vitest v8 coverage in `arkor`, `create-arkor`, `cli-internal`, and `studio-app`, each emitting `lcov.info` under `packages/<pkg>/coverage/`.
- Add a dedicated `coverage` CI job (Node 24, single run) that executes `pnpm test:coverage` and uploads each package's report to Codecov under its own flag, so per-package trends stay separated.
- Use Codecov's tokenless OIDC flow (`use_oidc: true` + `id-token: write`) — no `CODECOV_TOKEN` secret is stored in this repo.
- Add `codecov.yaml` with informational status checks (so coverage dips don't fail PRs while we establish a baseline), per-package flag scoping, and ignore rules for tests, `dist/`, scaffolding scripts, and CLI entry points.
- Skip `e2e/cli` from coverage on purpose: it spawns the built CLI in child processes, so v8 coverage from the parent vitest run wouldn't see source instrumentation. Can be revisited later via `NODE_V8_COVERAGE=`.

## Test plan
- [ ] `pnpm install` completes cleanly with the new `@vitest/coverage-v8` devDeps.
- [ ] `pnpm test:coverage` from the repo root produces `packages/{arkor,create-arkor,cli-internal,studio-app}/coverage/lcov.info`.
- [ ] CI `build` matrix still passes across all Node entries.
- [ ] CI `coverage` job runs on this PR, prints Codecov upload success for each of the four flags, and the report appears at https://app.codecov.io/gh/arkorlab/arkor.
- [ ] Confirm the Codecov PR comment surfaces per-flag coverage on this PR.

## Follow-ups (out of scope)
- Add a Codecov badge to `README.md` once the first upload lands and a baseline exists.
- Tighten `codecov.yaml` thresholds (`informational: false`, set a real `target`) once trends stabilise.
- Optional: instrument `e2e/cli` via `NODE_V8_COVERAGE=` if E2E coverage becomes useful.
