### PR TITLE
fix(ci): pass PostHog env to release Test step

### DIFF
--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -143,6 +143,11 @@ jobs:
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
+          # Disable runtime telemetry: e2e-cli spawns the built `arkor`
+          # binary, which has the key baked in by the pretest rebuild
+          # above. Without this, every release run would emit real
+          # PostHog events from CI.
+          ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 
       - name: Pack and inspect tarballs

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -143,10 +143,10 @@ jobs:
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
-          # Disable runtime telemetry: e2e-cli spawns the built `arkor`
-          # binary, which has the key baked in by the pretest rebuild
-          # above. Without this, every release run would emit real
-          # PostHog events from CI.
+          # Disable runtime telemetry: `pnpm run test` triggers the
+          # e2e-cli pretest, which rebuilds `arkor` with the key baked
+          # in. The tests then spawn that binary, so without this flag
+          # every release run would emit real PostHog events from CI.
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -140,6 +140,9 @@ jobs:
         run: pnpm run build
 
       - name: Test
+        env:
+          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
+          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
         run: pnpm run test
 
       - name: Pack and inspect tarballs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,10 +151,10 @@ jobs:
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
-          # Disable runtime telemetry: e2e-cli spawns the built `arkor`
-          # binary, which has the key baked in by the pretest rebuild
-          # above. Without this, every release run would emit real
-          # PostHog events from CI.
+          # Disable runtime telemetry: `pnpm run test` triggers the
+          # e2e-cli pretest, which rebuilds `arkor` with the key baked
+          # in. The tests then spawn that binary, so without this flag
+          # every release run would emit real PostHog events from CI.
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,6 +148,9 @@ jobs:
         run: pnpm run build
 
       - name: Test
+        env:
+          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
+          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
         run: pnpm run test
 
       - name: Pack and inspect tarballs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,6 +151,11 @@ jobs:
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
+          # Disable runtime telemetry: e2e-cli spawns the built `arkor`
+          # binary, which has the key baked in by the pretest rebuild
+          # above. Without this, every release run would emit real
+          # PostHog events from CI.
+          ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 
       - name: Pack and inspect tarballs


### PR DESCRIPTION
## Summary

The Test step in `release.yaml` is missing the `ARKOR_POSTHOG_*` env block, so the e2e-cli `pretest` rebuild silently overwrites the key-populated `dist/` produced by the Build step with a blank-key version. The packed tarball then ships with telemetry effectively disabled.

## Timeline (release workflow run 25130743192)

1. **Build step** (env present): `pnpm run build` → turbo → arkor's `tsdown` config replaces `__ARKOR_POSTHOG_KEY__` with `process.env.ARKOR_POSTHOG_KEY`. `packages/arkor/dist/bin.mjs` ends up with the real key embedded.
2. **Test step** (env missing): `pnpm run test` → turbo → `@arkor/e2e-cli`'s `pretest` runs `pnpm --filter create-arkor build && pnpm --filter arkor build`. With no env, tsdown substitutes an empty string, **overwriting `dist/bin.mjs` with a blank-key build**.
3. **Pack & Publish**: the overwritten `dist/` is what gets packed and pushed to npm.

## Evidence

Unpacking the published `alpha.4` tarball and grepping `dist/bin.mjs` shows the PostHog client constructed with an empty key as its first argument:

```js
Z = new be(``, { host: `https://us.i.posthog.com`, flushAt: 1, flushInterval: 0 })
```

The runtime guard at `packages/arkor/src/core/telemetry.ts:33` (`if (!POSTHOG_KEY) return false;`) prevents anything from being sent, but the root cause is that the key was never baked in to begin with. Both `ARKOR_POSTHOG_KEY` and `ARKOR_POSTHOG_HOST` are registered as repository secrets (confirmed via `gh secret list`).

## Fix

Add the same `env:` block already present on the Build step to the Test step in `release.yaml`. Mirror the change on `release-dry-run.yaml` for parity so the two workflows stay diff-able.

## Out of scope

- `alpha.4` is already published and cannot be re-published; the fix takes effect from `alpha.5` onwards.
- The `e2e/cli/package.json` `pretest` rebuild is intentional (e2e tests need fresh build artefacts) and stays as-is.
- No `turbo.json` env additions: turbo's cache key wiring would help locally, but CI runs on fresh runners with no cache hit, so it has no effect on the release path. Going minimal.
- No production code changes.

## Test plan

- [ ] Wait for `alpha.5` release. Locally: `npm pack arkor@0.0.1-alpha.5` (or download the tarball from the GitHub Release), extract, and run `grep -E '^.{0,30}phc_' dist/bin.mjs` — expect a hit on the embedded key.
- [ ] Same verification on `create-arkor@0.0.1-alpha.5` (its scaffolded `arkor` dep transitively needs the key, but `create-arkor` itself is unaffected; the grep should still cleanly succeed on the `arkor` tarball).
- [ ] Confirm telemetry events show up in the PostHog project after a real `arkor dev` run against `alpha.5`.

## References

- #44 (eng-472): introduced PostHog telemetry
- #45 (eng-502): wired env into the Build step (this PR extends the same wiring to the Test step)
