### PR TITLE
docs: add public roadmap page at docs.arkor.ai/roadmap

### DIFF
--- a/docs/cli/auth.mdx
+++ b/docs/cli/auth.mdx
@@ -99,7 +99,7 @@ Both modes write to the same file at `~/.arkor/credentials.json` and are tagged 
 
 ## Token expiry
 
-For Auth0 sessions, the credentials file records both the access token and the issued refresh token, plus the `expiresAt` timestamp returned by the token exchange. The refresh token is stored today, but the CLI does **not** yet auto-refresh expired access tokens; that path is on the roadmap.
+For Auth0 sessions, the credentials file records both the access token and the issued refresh token, plus the `expiresAt` timestamp returned by the token exchange. The refresh token is stored today, but the CLI does **not** yet auto-refresh expired access tokens; that path is [on the roadmap](/roadmap#auth0-token-auto-refresh).
 
 In practice that means:
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -36,7 +36,7 @@ The `arkor` CLI is the command surface around an Arkor project. The scaffolder (
 
 ### On the roadmap
 
-The CLI does read `ARKOR_CLOUD_API_URL` and uses it as the cloud-api endpoint when set (`packages/arkor/src/core/credentials.ts`'s `defaultArkorCloudApiUrl`), but pointing at a non-default endpoint (self-hosted or staging) is **not** yet a stable user-facing knob: the env var is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. First-class support for self-hosted / staging deployments is on the roadmap.
+The CLI does read `ARKOR_CLOUD_API_URL` and uses it as the cloud-api endpoint when set (`packages/arkor/src/core/credentials.ts`'s `defaultArkorCloudApiUrl`), but pointing at a non-default endpoint (self-hosted or staging) is **not** yet a stable user-facing knob: the env var is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. First-class support for self-hosted / staging deployments is [on the roadmap](/roadmap#self-hosted-deployments).
 
 ## Programmatic invocation
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,6 +17,10 @@
   "navigation": {
     "groups": [
       {
+        "group": "Roadmap",
+        "pages": ["roadmap"]
+      },
+      {
         "group": "Get started",
         "pages": ["introduction", "quickstart"]
       },

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -3,39 +3,31 @@ title: Roadmap
 description: What we're building next in Arkor.
 ---
 
-Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
+Arkor is in alpha, so this page is intentionally sparse. Items are grouped by what state they're in: actively being built, scoped and waiting their turn, or under consideration. We don't commit to dates yet.
 
-Statuses used below: `exploring` for open design, `in progress` for active build, `shipped` once it lands in a release.
+## In progress
 
-## Now
+Nothing actively in development on the public surface this cycle. Current effort is on stabilizing what's already shipped (CLI, Studio, scaffolder).
 
-Nothing currently flagged as Now. Active work this cycle is focused on stabilizing what's already shipped (CLI, Studio, scaffolder).
-
-## Next
+## Up next
 
 <CardGroup cols={2}>
   <Card title="Auth0 token auto-refresh" icon="key" href="/cli/auth">
     <div id="auth0-token-auto-refresh" />
-    `exploring`
-
     Silent refresh on expiry, so long-running sessions stop getting interrupted by re-login.
   </Card>
 </CardGroup>
 
-## Later
+## Backlog
 
 <CardGroup cols={2}>
   <Card title="Self-hosted deployments" icon="server" href="/cli/overview">
     <div id="self-hosted-deployments" />
-    `exploring`
-
     First-class `ARKOR_CLOUD_API_URL` with documented endpoints and versioned API guarantees.
   </Card>
 
   <Card title="deploy and eval slots" icon="rocket" href="/sdk/create-arkor">
     <div id="deploy-and-eval-slots" />
-    `exploring`
-
     Grow `createArkor` into an umbrella for shipping and evaluating models, not only training.
   </Card>
 </CardGroup>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -5,7 +5,7 @@ description: What we're building next in Arkor.
 
 Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
 
-Each item carries a status: `exploring` (open design), `in progress` (actively being built), or `shipped` (in a release).
+Statuses used below: `exploring` for open design, `in progress` for active build, `shipped` once it lands in a release.
 
 ## Now
 
@@ -13,28 +13,29 @@ Nothing currently flagged as Now. Active work this cycle is focused on stabilizi
 
 ## Next
 
-### Auth0 token auto-refresh
+<CardGroup cols={2}>
+  <Card title="Auth0 token auto-refresh" icon="key" href="/cli/auth">
+    <div id="auth0-token-auto-refresh" />
+    `exploring`
 
-Status: `exploring`
-
-After signing in with Auth0, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The work is silent refresh on expiry, so long-running sessions stop getting interrupted.
-
-Related: [CLI auth](/cli/auth)
+    Silent refresh on expiry, so long-running sessions stop getting interrupted by re-login.
+  </Card>
+</CardGroup>
 
 ## Later
 
-### Self-hosted deployments
+<CardGroup cols={2}>
+  <Card title="Self-hosted deployments" icon="server" href="/cli/overview">
+    <div id="self-hosted-deployments" />
+    `exploring`
 
-Status: `exploring`
+    First-class `ARKOR_CLOUD_API_URL` with documented endpoints and versioned API guarantees.
+  </Card>
 
-`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. The destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+  <Card title="deploy and eval slots" icon="rocket" href="/sdk/create-arkor">
+    <div id="deploy-and-eval-slots" />
+    `exploring`
 
-Related: [CLI overview](/cli/overview)
-
-### `deploy` and `eval` slots
-
-Status: `exploring`
-
-`createArkor` reserves `deploy` and `eval` fields in `ArkorInput` and `Arkor` as commented-out type slots. Passing them today is a type error, and there is no runtime path. They mark the intent for `createArkor` to grow into an umbrella for shipping and evaluating models, not only training, but the shape of those APIs is not yet decided.
-
-Related: [createArkor](/sdk/create-arkor)
+    Grow `createArkor` into an umbrella for shipping and evaluating models, not only training.
+  </Card>
+</CardGroup>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,0 +1,40 @@
+---
+title: Roadmap
+description: What we're building next in Arkor.
+---
+
+Arkor is in alpha. This page lists the work that's happening, planned, or being explored. Items move between sections as priorities and findings evolve. We avoid date commitments at this stage, so expect timing to shift.
+
+Status values used below: `in progress`, `exploring`, `shipped`.
+
+## Now
+
+### Auth0 token auto-refresh
+
+Status: `in progress`
+
+After `arkor login --oauth`, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The next step is silent refresh on expiry, so long-running sessions stop being interrupted.
+
+Related: [CLI auth](/cli/auth)
+
+## Next
+
+No items currently scoped for Next. Work promotes from Later once it is sized and prioritized.
+
+## Later
+
+### Self-hosted deployments
+
+Status: `exploring`
+
+`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and can change without notice, and there are no compatibility guarantees on alternate endpoints. The eventual destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+
+Related: [CLI overview](/cli/overview)
+
+### `deploy` and `eval` slots
+
+Status: `exploring`
+
+`createArkor` reserves `deploy` and `eval` fields in `ArkorInput` and `Arkor` as commented-out type slots. Passing them today is a type error, and there is no runtime path. They mark the intent for `createArkor` to grow into an umbrella for shipping and evaluating models, not only training, but the shape of those APIs is not yet decided.
+
+Related: [createArkor](/sdk/create-arkor)

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -3,23 +3,23 @@ title: Roadmap
 description: What we're building next in Arkor.
 ---
 
-Arkor is in alpha. This page lists the work that's happening, planned, or being explored. Items move between sections as priorities and findings evolve. We avoid date commitments at this stage, so expect timing to shift.
+Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
 
-Status values used below: `in progress`, `exploring`, `shipped`.
+Each item carries a status: `exploring` (open design), `in progress` (actively being built), or `shipped` (in a release).
 
 ## Now
 
-### Auth0 token auto-refresh
-
-Status: `in progress`
-
-After `arkor login --oauth`, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The next step is silent refresh on expiry, so long-running sessions stop being interrupted.
-
-Related: [CLI auth](/cli/auth)
+Nothing currently flagged as Now. Active work this cycle is focused on stabilizing what's already shipped (CLI, Studio, scaffolder).
 
 ## Next
 
-No items currently scoped for Next. Work promotes from Later once it is sized and prioritized.
+### Auth0 token auto-refresh
+
+Status: `exploring`
+
+After signing in with Auth0, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The work is silent refresh on expiry, so long-running sessions stop getting interrupted.
+
+Related: [CLI auth](/cli/auth)
 
 ## Later
 
@@ -27,7 +27,7 @@ No items currently scoped for Next. Work promotes from Later once it is sized an
 
 Status: `exploring`
 
-`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and can change without notice, and there are no compatibility guarantees on alternate endpoints. The eventual destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. The destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
 
 Related: [CLI overview](/cli/overview)
 

--- a/docs/sdk/create-arkor.mdx
+++ b/docs/sdk/create-arkor.mdx
@@ -41,7 +41,7 @@ The returned object is `Object.freeze`-d. There are no methods on it; the framew
 
 ## Not yet
 
-- `deploy` and `eval` slots. They appear in `ArkorInput` and `Arkor` as commented-out reserved fields. Passing them today is a type error, and there is no runtime path for them. Treat them as roadmap markers, not as forward-compatible API.
+- `deploy` and `eval` slots. They appear in `ArkorInput` and `Arkor` as commented-out reserved fields. Passing them today is a type error, and there is no runtime path for them. Treat them as [roadmap markers](/roadmap#deploy-and-eval-slots), not as forward-compatible API.
 
 ## Recognized export shapes
 


### PR DESCRIPTION
## Summary

- Adds `/docs/roadmap.mdx` as the public roadmap, organized into Now / Next / Later with `in progress` / `exploring` / `shipped` status tags. Initial items are seeded from existing inline "on the roadmap" mentions: Auth0 token auto-refresh, self-hosted deployments, and the `createArkor` `deploy` / `eval` slots.
- Wires `Roadmap` as the first entry in `docs.json` `navigation.groups`, so it shows at the top of the Mintlify sidebar.
- Promotes the three existing plain-text "on the roadmap" / "roadmap markers" callouts in `cli/auth`, `cli/overview`, and `sdk/create-arkor` into internal links that jump to the matching anchor on the new page.

Why docs.arkor.ai (not arkor.ai/roadmap):
- Marketing site lives in a separate repo; alpha-stage roadmap will update often, so co-locating with docs minimizes update friction.
- Mintlify renders MDX out of the box, no new infra needed.
- If `arkor.ai` later gains MDX rendering, the page can be migrated as-is.

Out of scope:
- Marketing-site link from `arkor.ai` hero / footer (separate repo task).
- Changelog page (defer until public releases pick up).
- Blog migration from Sanity to Mintlify MDX.

## Test plan

- [ ] `cd docs && mint dev` and confirm the sidebar shows `Roadmap` at the top.
- [ ] `/roadmap` renders with three sections and `in progress` / `exploring` status tags.
- [ ] Click-through from `/cli/auth`, `/cli/overview`, `/sdk/create-arkor` lands on the correct anchor on `/roadmap` (`#auth0-token-auto-refresh`, `#self-hosted-deployments`, `#deploy-and-eval-slots`).
- [ ] No broken-link warnings in the `mint dev` console.
- [ ] Mobile sidebar exposes the Roadmap entry.