### PR TITLE
docs: add language switcher between README and README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -28,6 +28,10 @@
   <a href="https://docs.arkor.ai"><strong>ドキュメント</strong></a>
 </p>
 
+<p align="center">
+  <a href="README.md">English</a>
+</p>
+
 > [!WARNING]
 > Arkor は **alpha** 段階です。API は予告なく変更されます。私たちはオープンに開発を進めており、フィードバックが次に何が入るかを左右します。
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
   <a href="https://docs.arkor.ai"><strong>Docs</strong></a>
 </p>
 
+<p align="center">
+  <a href="README.ja.md">日本語</a>
+</p>
+
 > [!WARNING]
 > Arkor is **alpha**. APIs change without notice. We're shipping in public, and feedback shapes what lands next.
 


### PR DESCRIPTION
## Summary
- Add a centered language switcher beneath the navigation bar in both README files so readers can flip between locales from the top of the page.
- `README.md` → links to `日本語` (`README.ja.md`); `README.ja.md` → links back to `English` (`README.md`).
- Placement and styling mirror the existing nav `<p align="center">` block so the switcher reads as intentional rather than bolted on.

## Test plan
- [ ] GitHub renders both READMEs with the new centered switcher
- [ ] Clicking `日本語` from `README.md` lands at the top of `README.ja.md`
- [ ] Clicking `English` from `README.ja.md` lands at the top of `README.md`
- [ ] No regressions in the existing nav / badges / WARNING block layout
