### PR TITLE
docs: give each section's first page a unique title

### DIFF
--- a/docs/cli/auth.mdx
+++ b/docs/cli/auth.mdx
@@ -106,7 +106,7 @@ Both modes write to the same file at `~/.arkor/credentials.json` and are tagged 
 
 ## Token expiry
 
-For OAuth sessions, the credentials file records both the access token and the issued refresh token, plus the `expiresAt` timestamp returned by the token exchange. The refresh token is stored today, but the CLI does **not** yet auto-refresh expired access tokens; that path is on the roadmap.
+For OAuth sessions, the credentials file records both the access token and the issued refresh token, plus the `expiresAt` timestamp returned by the token exchange. The refresh token is stored today, but the CLI does **not** yet auto-refresh expired access tokens; that path is [on the roadmap](/roadmap#auth0-token-auto-refresh).
 
 In practice that means:
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI"
+title: "Command reference"
 description: "The arkor CLI: full command reference."
 ---
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -36,7 +36,7 @@ The `arkor` CLI is the command surface around an Arkor project. The scaffolder (
 
 ### On the roadmap
 
-The CLI does read `ARKOR_CLOUD_API_URL` and uses it as the cloud-api endpoint when set (`packages/arkor/src/core/credentials.ts`'s `defaultArkorCloudApiUrl`), but pointing at a non-default endpoint (self-hosted or staging) is **not** yet a stable user-facing knob: the env var is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. First-class support for self-hosted / staging deployments is on the roadmap.
+The CLI does read `ARKOR_CLOUD_API_URL` and uses it as the cloud-api endpoint when set (`packages/arkor/src/core/credentials.ts`'s `defaultArkorCloudApiUrl`), but pointing at a non-default endpoint (self-hosted or staging) is **not** yet a stable user-facing knob: the env var is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. First-class support for self-hosted / staging deployments is [on the roadmap](/roadmap#self-hosted-deployments).
 
 ## Programmatic invocation
 

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Concepts"
+title: "Mental model"
 description: "The mental model behind Arkor: project layout, trainer, lifecycle callbacks, and Studio."
 ---
 

--- a/docs/cookbook/overview.mdx
+++ b/docs/cookbook/overview.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Cookbook"
+title: "Recipes"
 description: "Recipes that show what TypeScript unlocks for an Arkor training run today."
 ---
-
-# Cookbook
 
 Arkor is alpha. The framework's surface is intentionally small: one trainer, one manifest slot, a handful of lifecycle callbacks. What makes that small surface worthwhile is that **all of it is your TypeScript code**. Anything you can express in TS, you can wire into a training run, with the same editor, types, and review flow as the rest of your product.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,6 +21,10 @@
         "default": true,
         "groups": [
           {
+            "group": "Roadmap",
+            "pages": ["roadmap"]
+          },
+          {
             "group": "Get started",
             "pages": ["introduction", "quickstart"]
           },

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -3,39 +3,31 @@ title: Roadmap
 description: What we're building next in Arkor.
 ---
 
-Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
+Arkor is in alpha, so this page is intentionally sparse. Items are grouped by what state they're in: actively being built, scoped and waiting their turn, or under consideration. We don't commit to dates yet.
 
-Statuses used below: `exploring` for open design, `in progress` for active build, `shipped` once it lands in a release.
+## In progress
 
-## Now
+Nothing actively in development on the public surface this cycle. Current effort is on stabilizing what's already shipped (CLI, Studio, scaffolder).
 
-Nothing currently flagged as Now. Active work this cycle is focused on stabilizing what's already shipped (CLI, Studio, scaffolder).
-
-## Next
+## Up next
 
 <CardGroup cols={2}>
   <Card title="Auth0 token auto-refresh" icon="key" href="/cli/auth">
     <div id="auth0-token-auto-refresh" />
-    `exploring`
-
     Silent refresh on expiry, so long-running sessions stop getting interrupted by re-login.
   </Card>
 </CardGroup>
 
-## Later
+## Backlog
 
 <CardGroup cols={2}>
   <Card title="Self-hosted deployments" icon="server" href="/cli/overview">
     <div id="self-hosted-deployments" />
-    `exploring`
-
     First-class `ARKOR_CLOUD_API_URL` with documented endpoints and versioned API guarantees.
   </Card>
 
   <Card title="deploy and eval slots" icon="rocket" href="/sdk/create-arkor">
     <div id="deploy-and-eval-slots" />
-    `exploring`
-
     Grow `createArkor` into an umbrella for shipping and evaluating models, not only training.
   </Card>
 </CardGroup>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -16,18 +16,58 @@ Nothing actively in development on the public surface this cycle. Current effort
     <div id="auth0-token-auto-refresh" />
     Silent refresh on expiry, so long-running sessions stop getting interrupted by re-login.
   </Card>
+
+  <Card title="Bring your own dataset (JSONL)" icon="file-lines" href="/sdk/dataset">
+    <div id="jsonl-dataset" />
+    Upload a local JSONL file as the training dataset, alongside the existing HuggingFace name and blob URL paths.
+  </Card>
+
+  <Card title="Train on a local GPU" icon="microchip" href="/sdk/create-trainer">
+    <div id="local-gpu-training" />
+    Run training on your own GPU instead of routing every job through Arkor's managed GPUs.
+  </Card>
+
+  <Card title="Dry-run from Studio" icon="flask" href="/concepts/studio">
+    <div id="studio-dry-run" />
+    Surface the existing dry-run option in the Studio UI for fast smoke tests before kicking off a full training run.
+  </Card>
 </CardGroup>
 
 ## Backlog
 
 <CardGroup cols={2}>
-  <Card title="Self-hosted deployments" icon="server" href="/cli/overview">
+  <Card title="Self-hosted training backend" icon="server" href="/cli/overview">
     <div id="self-hosted-deployments" />
-    First-class `ARKOR_CLOUD_API_URL` with documented endpoints and versioned API guarantees.
+    Run the training backend on your own infrastructure, with a documented `ARKOR_CLOUD_API_URL` knob and versioned API guarantees.
   </Card>
 
   <Card title="deploy and eval slots" icon="rocket" href="/sdk/create-arkor">
     <div id="deploy-and-eval-slots" />
     Grow `createArkor` into an umbrella for shipping and evaluating models, not only training.
+  </Card>
+
+  <Card title="More base models" icon="cubes" href="/sdk/create-trainer">
+    <div id="more-base-models" />
+    Expand support beyond Gemma to additional open-weight model families.
+  </Card>
+
+  <Card title="Download trained models" icon="download">
+    <div id="download-trained-models" />
+    Export a trained model as a file you can run on your own machine or deploy target, instead of staying on Arkor's managed inference.
+  </Card>
+
+  <Card title="Synthetic data from a seed set" icon="flask-vial">
+    <div id="synthetic-data" />
+    Generate training data from a small seed set, for cases where you don't already have a labeled dataset.
+  </Card>
+
+  <Card title="Distillation templates" icon="link">
+    <div id="distillation-templates" />
+    Templates that pair compatible teacher and student models so distillation runs work out of the box.
+  </Card>
+
+  <Card title="On-device model templates" icon="mobile-screen">
+    <div id="on-device-templates" />
+    Templates aimed at small models suitable for WebGPU and mobile targets.
   </Card>
 </CardGroup>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -5,7 +5,7 @@ description: What we're building next in Arkor.
 
 Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
 
-Each item carries a status: `exploring` (open design), `in progress` (actively being built), or `shipped` (in a release).
+Statuses used below: `exploring` for open design, `in progress` for active build, `shipped` once it lands in a release.
 
 ## Now
 
@@ -13,28 +13,29 @@ Nothing currently flagged as Now. Active work this cycle is focused on stabilizi
 
 ## Next
 
-### Auth0 token auto-refresh
+<CardGroup cols={2}>
+  <Card title="Auth0 token auto-refresh" icon="key" href="/cli/auth">
+    <div id="auth0-token-auto-refresh" />
+    `exploring`
 
-Status: `exploring`
-
-After signing in with Auth0, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The work is silent refresh on expiry, so long-running sessions stop getting interrupted.
-
-Related: [CLI auth](/cli/auth)
+    Silent refresh on expiry, so long-running sessions stop getting interrupted by re-login.
+  </Card>
+</CardGroup>
 
 ## Later
 
-### Self-hosted deployments
+<CardGroup cols={2}>
+  <Card title="Self-hosted deployments" icon="server" href="/cli/overview">
+    <div id="self-hosted-deployments" />
+    `exploring`
 
-Status: `exploring`
+    First-class `ARKOR_CLOUD_API_URL` with documented endpoints and versioned API guarantees.
+  </Card>
 
-`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. The destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+  <Card title="deploy and eval slots" icon="rocket" href="/sdk/create-arkor">
+    <div id="deploy-and-eval-slots" />
+    `exploring`
 
-Related: [CLI overview](/cli/overview)
-
-### `deploy` and `eval` slots
-
-Status: `exploring`
-
-`createArkor` reserves `deploy` and `eval` fields in `ArkorInput` and `Arkor` as commented-out type slots. Passing them today is a type error, and there is no runtime path. They mark the intent for `createArkor` to grow into an umbrella for shipping and evaluating models, not only training, but the shape of those APIs is not yet decided.
-
-Related: [createArkor](/sdk/create-arkor)
+    Grow `createArkor` into an umbrella for shipping and evaluating models, not only training.
+  </Card>
+</CardGroup>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,6 +1,6 @@
 ---
-title: Roadmap
-description: What we're building next in Arkor.
+title: "Roadmap"
+description: "What we're building next in Arkor."
 ---
 
 Arkor is in alpha, so this page is intentionally sparse. Items are grouped by what state they're in: actively being built, scoped and waiting their turn, or under consideration. We don't commit to dates yet.

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,0 +1,40 @@
+---
+title: Roadmap
+description: What we're building next in Arkor.
+---
+
+Arkor is in alpha. This page lists the work that's happening, planned, or being explored. Items move between sections as priorities and findings evolve. We avoid date commitments at this stage, so expect timing to shift.
+
+Status values used below: `in progress`, `exploring`, `shipped`.
+
+## Now
+
+### Auth0 token auto-refresh
+
+Status: `in progress`
+
+After `arkor login --oauth`, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The next step is silent refresh on expiry, so long-running sessions stop being interrupted.
+
+Related: [CLI auth](/cli/auth)
+
+## Next
+
+No items currently scoped for Next. Work promotes from Later once it is sized and prioritized.
+
+## Later
+
+### Self-hosted deployments
+
+Status: `exploring`
+
+`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and can change without notice, and there are no compatibility guarantees on alternate endpoints. The eventual destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+
+Related: [CLI overview](/cli/overview)
+
+### `deploy` and `eval` slots
+
+Status: `exploring`
+
+`createArkor` reserves `deploy` and `eval` fields in `ArkorInput` and `Arkor` as commented-out type slots. Passing them today is a type error, and there is no runtime path. They mark the intent for `createArkor` to grow into an umbrella for shipping and evaluating models, not only training, but the shape of those APIs is not yet decided.
+
+Related: [createArkor](/sdk/create-arkor)

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -3,23 +3,23 @@ title: Roadmap
 description: What we're building next in Arkor.
 ---
 
-Arkor is in alpha. This page lists the work that's happening, planned, or being explored. Items move between sections as priorities and findings evolve. We avoid date commitments at this stage, so expect timing to shift.
+Arkor is in alpha, so this page is intentionally sparse: it lists what's queued behind the current cycle and where we're heading, not a calendar. Items move between sections as we learn, and we don't commit to dates yet.
 
-Status values used below: `in progress`, `exploring`, `shipped`.
+Each item carries a status: `exploring` (open design), `in progress` (actively being built), or `shipped` (in a release).
 
 ## Now
 
-### Auth0 token auto-refresh
-
-Status: `in progress`
-
-After `arkor login --oauth`, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The next step is silent refresh on expiry, so long-running sessions stop being interrupted.
-
-Related: [CLI auth](/cli/auth)
+Nothing currently flagged as Now. Active work this cycle is focused on stabilizing what's already shipped (CLI, Studio, scaffolder).
 
 ## Next
 
-No items currently scoped for Next. Work promotes from Later once it is sized and prioritized.
+### Auth0 token auto-refresh
+
+Status: `exploring`
+
+After signing in with Auth0, the CLI persists the refresh token alongside the access token, but it does not yet exchange the refresh token automatically when the access token expires. Today users re-authenticate by running `arkor login` again. The work is silent refresh on expiry, so long-running sessions stop getting interrupted.
+
+Related: [CLI auth](/cli/auth)
 
 ## Later
 
@@ -27,7 +27,7 @@ No items currently scoped for Next. Work promotes from Later once it is sized an
 
 Status: `exploring`
 
-`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and can change without notice, and there are no compatibility guarantees on alternate endpoints. The eventual destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
+`ARKOR_CLOUD_API_URL` is already read internally as the cloud-api endpoint, but pointing at a non-default endpoint (self-hosted, staging) is not a stable user-facing knob. The variable is internal-only and may change without notice, and there are no compatibility guarantees on alternate endpoints. The destination is first-class support for self-hosted and staging targets, with a documented configuration surface and versioned API guarantees.
 
 Related: [CLI overview](/cli/overview)
 

--- a/docs/sdk/create-arkor.mdx
+++ b/docs/sdk/create-arkor.mdx
@@ -41,7 +41,7 @@ The returned object is `Object.freeze`-d. There are no methods on it; the framew
 
 ## Not yet
 
-- `deploy` and `eval` slots. They appear in `ArkorInput` and `Arkor` as commented-out reserved fields. Passing them today is a type error, and there is no runtime path for them. Treat them as roadmap markers, not as forward-compatible API.
+- `deploy` and `eval` slots. They appear in `ArkorInput` and `Arkor` as commented-out reserved fields. Passing them today is a type error, and there is no runtime path for them. Treat them as [roadmap markers](/roadmap#deploy-and-eval-slots), not as forward-compatible API.
 
 ## Recognized export shapes
 

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SDK"
+title: "API reference"
 description: "The Arkor SDK: createArkor, createTrainer, lifecycle callbacks, infer, and the helpers around them."
 ---
 

--- a/docs/studio/overview.mdx
+++ b/docs/studio/overview.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Studio"
+title: "What Studio is"
 description: "The local web UI you get from arkor dev: start runs, watch them stream, chat with finished adapters."
 ---
-
-# Studio
 
 Studio is the local web UI that boots when you run [`arkor dev`](/cli/dev). It lives on your machine, talks to the same CLI process over loopback, and goes away when you stop the dev server. There is no separate signup, no public URL.
 


### PR DESCRIPTION
## Summary

This branch combines two threads of docs work:

### Section first-page rename (sidebar deduplication)

Sidebar previously showed `CLI > CLI`, `Studio > Studio`, etc. because each section's first overview page used the group name as its frontmatter `title`. Each first page now reads as something distinct:

- `concepts/overview`: Concepts → **Mental model**
- `cli/overview`: CLI → **Command reference**
- `sdk/overview`: SDK → **API reference**
- `studio/overview`: Studio → **What Studio is**
- `cookbook/overview`: Cookbook → **Recipes**

Also dropped the redundant body `# Studio` and `# Cookbook` H1s (Mintlify auto-renders the frontmatter `title` as the page H1, so those were producing a double heading).

### Public Roadmap page

- New `docs/roadmap.mdx` with `In progress` / `Up next` / `Backlog` sections, each item a Card with an inline anchor target (`<div id="..." />`) so other pages can deep-link.
- New `Roadmap` group at the top of the **English** sidebar (`docs/docs.json`). The `ja` sidebar is intentionally not changed in this PR; a JA roadmap translation can land in a follow-up.
- Existing "on the roadmap" mentions in `docs/cli/overview.mdx`, `docs/cli/auth.mdx`, and `docs/sdk/create-arkor.mdx` are now linked into the matching roadmap anchors.

## Test plan

- [ ] `cd docs && mintlify dev` and confirm the sidebar shows: Roadmap, Get started, Concepts > Mental model, CLI > Command reference, SDK > API reference, Studio > What Studio is, Cookbook > Recipes
- [ ] Click each roadmap deep link from `cli/overview`, `cli/auth`, `sdk/create-arkor` and confirm it lands on the right card
- [ ] Open each renamed overview page directly and verify a single H1 (the new title) and matching browser tab title
- [ ] Switch to the JA sidebar and confirm it is unchanged (no Roadmap entry, no broken links)