### PR TITLE
chore: release arkor + create-arkor 0.0.1-alpha.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,6 +185,8 @@ jobs:
       # even when tests fail; the job's final outcome still reflects the
       # test result.
       - name: Test with coverage
+        env:
+          ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC: file:${{ github.workspace }}/packages/arkor
         run: pnpm exec turbo run test:coverage --continue
 
       - name: Upload arkor coverage

--- a/e2e/cli/src/arkor-whoami.test.ts
+++ b/e2e/cli/src/arkor-whoami.test.ts
@@ -230,7 +230,7 @@ describe("arkor whoami × SDK version gate (E2E)", () => {
       res.setHeader("Deprecation", "true");
       res.setHeader(
         "Warning",
-        '299 - "Arkor SDK 0.0.1-alpha.4 is deprecated; supported range: >=2.0.0"',
+        '299 - "Arkor SDK 0.0.1-alpha.5 is deprecated; supported range: >=2.0.0"',
       );
       res.end(
         JSON.stringify({

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -2,7 +2,7 @@
 
 The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 
-> Status: alpha (`0.0.1-alpha.4`). APIs may change without notice. No compat
+> Status: alpha (`0.0.1-alpha.5`). APIs may change without notice. No compat
 > shims are offered between alpha versions — pin and re-read the changelog
 > before bumping.
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkor",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "description": "Code-first TypeScript training SDK, CLI, and local Studio.",
   "private": false,
   "type": "module",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -128,7 +128,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.4");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.5");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");
@@ -150,7 +150,7 @@ describe("scaffold", () => {
     // The value is opaque to scaffold — only that it's faithfully
     // round-tripped into package.json matters, so use a relative
     // `file:` spec that is platform-neutral (no Unix-only `/tmp`).
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.4.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.5.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     const { files } = await scaffold({
       cwd,
@@ -185,7 +185,7 @@ describe("scaffold", () => {
         readFileSync(join(cwd, "package.json"), "utf8"),
       ) as Record<string, unknown>;
       const devDeps = pkg.devDependencies as Record<string, string>;
-      expect(devDeps.arkor).toBe("^0.0.1-alpha.4");
+      expect(devDeps.arkor).toBe("^0.0.1-alpha.5");
     },
   );
 
@@ -194,7 +194,7 @@ describe("scaffold", () => {
     // and the patch path that runs when `package.json` already exists
     // but has no `devDependencies.arkor`. Cover the patch path too so
     // the override doesn't silently regress to the default there.
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.4.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.5.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     writeFileSync(
       join(cwd, "package.json"),

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -30,7 +30,7 @@ const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
-const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.4";
+const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.5";
 
 function resolveArkorScaffoldSpec(): string {
   // Treat unset, empty, and whitespace-only values the same: fall back to

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -3,7 +3,7 @@
 Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
 `npm create` / `pnpm create` / `yarn create` / `bun create`.
 
-> Status: alpha (`0.0.1-alpha.4`).
+> Status: alpha (`0.0.1-alpha.5`).
 
 ## Usage
 

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-arkor",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "description": "Scaffolder for arkor training projects.",
   "private": false,
   "type": "module",

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,7 @@
     },
     "test:coverage": {
       "dependsOn": ["^build"],
+      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC", "SKIP_E2E_INSTALL"],
       "cache": false
     },
     "typecheck": {


### PR DESCRIPTION
## Summary
- Bump the two public packages (`arkor`, `create-arkor`) from `0.0.1-alpha.4` to `0.0.1-alpha.5`.
- Bump `DEFAULT_ARKOR_SPEC` in [packages/cli-internal/src/scaffold.ts](packages/cli-internal/src/scaffold.ts) (and the corresponding test expectations + override fixture filenames) to `^0.0.1-alpha.5`. Now that `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC` is wired into ci.yaml / release.yaml / release-dry-run.yaml (#73), the e2e install tests no longer fall back to the registry — so we can pre-pin the unreleased version without the chicken-and-egg failure that earlier bumps had to dodge by lagging one version behind.
- Update the alpha-version callouts in the per-package READMEs and the `arkor-whoami` deprecation-warning fixture.
- Two follow-ups to keep the override pre-pin working everywhere:
  - Pass the env to the `coverage · upload to Codecov` step in `ci.yaml` (the matrix Test steps already had it).
  - Declare `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC` (and `SKIP_E2E_INSTALL`) on the `test:coverage` task in `turbo.json`, mirroring `test`. Turbo 2.x's strict env mode otherwise filters the var out of the spawned task even when the workflow step sets it.

### What `file:` spec each workflow uses

CI and the release workflows point the env at slightly different things on purpose:

| Workflow | Spec | Why |
|---|---|---|
| `ci.yaml` (matrix Test + coverage) | `file:${{ github.workspace }}/packages/arkor` (directory) | Per-PR fast feedback — directory install is enough to validate the scaffold path against the workspace's current source. |
| `release.yaml`, `release-dry-run.yaml` | `file:$ARKOR_TARBALL` from a pre-Test `pnpm pack` (tarball) | Validates the exact bytes that `npm publish` will upload, including the build-time copies (`CONTRIBUTING.md`, `docs/`). |

### What's new in alpha.5 vs alpha.4

- First release where the npm publish runs through the corrected `Test`-step env wiring (#78) and the pre-Test re-pack flow (#73), so the published binary actually has the PostHog telemetry key embedded.
- Picks up `/api/jobs` deprecation parity (#71), `eng-557` CLI auth polish (#74), and contributing-guideline tweaks merged on `main` after alpha.4.

## Test plan
- [ ] `pnpm --filter @arkor/cli-internal test` passes (scaffold tests assert `^0.0.1-alpha.5`)
- [ ] CI's e2e install tests resolve `arkor` from the workspace `packages/arkor` directory via `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC`, not from the registry — both in the matrix Test steps and the coverage job
- [ ] After tagging `v0.0.1-alpha.5` and running release.yaml:
  - `npm view arkor@0.0.1-alpha.5 dist.attestations.provenance` returns SLSA v1 provenance
  - Tarball still includes `docs/`, `CONTRIBUTING.md`, `LICENSE.md`, `README.md`
  - PostHog key embedded in published `dist/bin.mjs` (`grep -oE 'phc_[A-Za-z0-9_-]+' dist/bin.mjs` returns the configured project key)
  - npmjs.com page renders the README
- [ ] Manually re-point `latest` after release: `npm dist-tag add arkor@0.0.1-alpha.5 latest && npm dist-tag add create-arkor@0.0.1-alpha.5 latest`