### PR TITLE
fix(ci): declare PostHog env on turbo build/test tasks so the key reaches tsdown

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["ARKOR_POSTHOG_KEY", "ARKOR_POSTHOG_HOST"],
       "outputs": ["dist/**"]
     },
     "dev": {
@@ -14,12 +15,24 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC", "SKIP_E2E_INSTALL"],
+      "env": [
+        "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC",
+        "ARKOR_POSTHOG_KEY",
+        "ARKOR_POSTHOG_HOST",
+        "ARKOR_TELEMETRY_DISABLED",
+        "SKIP_E2E_INSTALL"
+      ],
       "outputs": []
     },
     "test:coverage": {
       "dependsOn": ["^build"],
-      "env": ["ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC", "SKIP_E2E_INSTALL"],
+      "env": [
+        "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC",
+        "ARKOR_POSTHOG_KEY",
+        "ARKOR_POSTHOG_HOST",
+        "ARKOR_TELEMETRY_DISABLED",
+        "SKIP_E2E_INSTALL"
+      ],
       "cache": false
     },
     "typecheck": {


### PR DESCRIPTION
## Summary

Turbo 2.x's strict env mode filters environment variables that aren't declared on the task in [`turbo.json`](turbo.json), even when the calling shell sets them. The release workflow's `Build` step has been setting `ARKOR_POSTHOG_KEY` / `ARKOR_POSTHOG_HOST` since #44, but `turbo.json`'s `build` task didn't list them, so by the time `tsdown` ran inside the spawned `arkor` build the values were already gone. [`tsdown.config.ts`](packages/arkor/tsdown.config.ts) then fell back to its `?? ""` default and inlined an empty string into `__ARKOR_POSTHOG_KEY__`, leaving every published `dist/bin.mjs` with `new PostHog("", ...)`.

Telemetry is silently disabled at runtime by the `if (!POSTHOG_KEY) return false;` guard in [`telemetry.ts`](packages/arkor/src/core/telemetry.ts), so this never surfaced as a runtime error — but it also means no PostHog events have actually fired from any published alpha so far.

This PR adds the PostHog vars (and `ARKOR_TELEMETRY_DISABLED` for the test paths, since `e2e-cli`'s pretest rebuilds the bin and the tests then spawn it) to `build`, `test`, and `test:coverage` so the next release actually has the key embedded.

### Verification

To confirm the bug locally before the fix:

```bash
$ npm pack arkor@0.0.1-alpha.5 && tar -xzf arkor-0.0.1-alpha.5.tgz \
    && grep -oE 'new [a-z]+\(`[^`]{0,50}`,\{host:`[^`]+posthog[^`]+`' package/dist/bin.mjs
new be(``,{host:`https://us.i.posthog.com`
```

Empty first argument = empty key. After this PR (assuming `ARKOR_POSTHOG_KEY` is set when `pnpm run build` runs), the same grep should print `new be(\`phc_…\`, ...)`.

### Scope

- alpha.5 and earlier stay broken since npm forbids same-version republish.
- The fix lands in alpha.6.
- Telemetry was a no-op across all alphas, so this is a forward-only fix, not a regression.

## Test plan
- [ ] After tagging `v0.0.1-alpha.6` and running release.yaml: `npm pack arkor@0.0.1-alpha.6 && grep -oE 'phc_[A-Za-z0-9_-]+' package/dist/bin.mjs` returns the configured project key
- [ ] Local `ARKOR_POSTHOG_KEY=test-key-123 pnpm run build` produces `dist/bin.mjs` containing `test-key-123`
- [ ] CI's `Test` and coverage paths still pass (no env break from the new declarations)