### PR TITLE
docs: cover both OAuth login paths in credentials.json description

### DIFF
--- a/docs/concepts/project-structure.mdx
+++ b/docs/concepts/project-structure.mdx
@@ -74,7 +74,7 @@ You should not commit this directory.
 
 Lives in your home directory, shared across all Arkor projects on the machine.
 
-- **`~/.arkor/credentials.json`**. Auth state. Either an Arkor Cloud OAuth token (after `arkor login --oauth`) or an anonymous token (created on first use if you never logged in). The file is tagged with a `mode` field of `"auth0"` or `"anon"` so the CLI knows which path you are on. `arkor login` writes only this file; it does **not** create `.arkor/state.json`.
+- **`~/.arkor/credentials.json`**. Auth state. Either an Arkor Cloud OAuth token (written by `arkor login --oauth`, or by choosing `OAuth (browser)` in the interactive `arkor login` picker) or an anonymous token (created on first use if you never logged in). The file is tagged with a `mode` field of `"auth0"` or `"anon"` so the CLI knows which path you are on. `arkor login` writes only this file; it does **not** create `.arkor/state.json`.
 - **`~/.arkor/studio-token`** (transient). A per-launch CSRF token written by `arkor dev` (mode `0600`). Used by Studio to authorize calls back into the CLI's local server. Rotated on every `arkor dev` run.
 
 `arkor logout` deletes `credentials.json`. The studio token is removed on process exit on a best-effort basis (it may linger if `arkor dev` crashes) and is rotated on the next launch.

--- a/docs/ja/concepts/project-structure.mdx
+++ b/docs/ja/concepts/project-structure.mdx
@@ -74,7 +74,7 @@ export default {};
 
 ホームディレクトリにあり、マシン上のすべての Arkor プロジェクト間で共有されます。
 
-- **`~/.arkor/credentials.json`**。認証状態。`arkor login --oauth` 後の Arkor Cloud OAuth トークンか、未ログインで初使用時に作られる匿名トークンのいずれか。ファイルは `mode` フィールドが `"auth0"` か `"anon"` でタグ付けされており、CLI はどのパスにいるかを把握します。`arkor login` はこのファイルだけを書きます。`.arkor/state.json` は **作成しません**。
+- **`~/.arkor/credentials.json`**。認証状態。`arkor login --oauth` または対話的な `arkor login` のピッカーで `OAuth (browser)` を選んだ場合に書かれる Arkor Cloud OAuth トークンか、未ログインで初使用時に作られる匿名トークンのいずれか。ファイルは `mode` フィールドが `"auth0"` か `"anon"` でタグ付けされており、CLI はどのパスにいるかを把握します。`arkor login` はこのファイルだけを書きます。`.arkor/state.json` は **作成しません**。
 - **`~/.arkor/studio-token`**（一時的）。`arkor dev` が起動ごとに書く CSRF トークン（モード `0600`）。Studio が CLI のローカルサーバーへの呼び出しを認可するのに使います。`arkor dev` 起動のたびにローテートされます。
 
 `arkor logout` は `credentials.json` を削除します。Studio トークンはプロセス終了時にベストエフォートで削除され（`arkor dev` がクラッシュすると残る場合あり）、次回起動時にローテートされます。


### PR DESCRIPTION
## Summary
- Follow-up to a Copilot review on the now-merged #75 that landed just before merge.
- The `~/.arkor/credentials.json` bullet in [Project structure](docs/concepts/project-structure.mdx) read as if `arkor login --oauth` were the only way to obtain an OAuth (`mode: "auth0"`) credentials file. The CLI also writes the same credentials when the user picks `OAuth (browser)` in the interactive `arkor login` picker.
- Reword the bullet (EN + JA) so both entry points are documented and `--oauth` no longer reads as required.

## Test plan
- [ ] `cd docs && node_modules/.bin/mint broken-links` — no broken links.
- [ ] Spot-check the rendered Project structure pages in `mint dev` and confirm the credentials.json bullet reads naturally in both English and Japanese.
- [ ] Cross-check against [`packages/arkor/src/cli/commands/login.ts`](packages/arkor/src/cli/commands/login.ts) (`runAuth0Login` is reached either via `--oauth` or via the picker selecting `oauth`) to confirm the doc matches the CLI behavior.