### PR TITLE
Update CI workflow for multi-OS support and enforce bash shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Pin pnpm to the version declared in root package.json's
+      # `packageManager`. action-setup@v6 added support for pnpm v11, and on
+      # some OSes (observed: windows-latest, macos-latest) it can resolve to
+      # v11.x instead of the packageManager-pinned 10.33.2 — pnpm 11 hard-
+      # errors on Node <22.13, which breaks every matrix entry below 22.13.
+      # An explicit version sidesteps the auto-detect path entirely.
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.2
 
       # rolldown-incompatible path: install + tsdown build run here, on a
       # known-compatible Node. The matrix Node below then exercises dist/.
@@ -173,7 +181,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Match the build job: pin pnpm explicitly so action-setup doesn't
+      # surprise us with v11 on a future runner image refresh.
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.2
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,24 @@ on:
 
 jobs:
   build:
-    name: typecheck · test · build · node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+    name: typecheck · test · build · ${{ matrix.os }} · node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
+    # Force bash on every OS so `run:` steps that use POSIX redirection (e.g.
+    # `>> "$GITHUB_STEP_SUMMARY"`) work uniformly. windows-latest defaults to
+    # pwsh otherwise. Git Bash ships on the GitHub-hosted Windows image.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
+        # Cross every Node entry below with all three GitHub-hosted OS images.
+        # The Node matrix exists to surface strip-types / transform-types /
+        # amaro behaviour shifts; running it on Linux + Windows + macOS also
+        # catches platform-specific regressions in path handling, child
+        # process spawning, and pnpm hardlink/symlink behaviour.
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
         # This matrix intentionally covers Node.js versions where built-in
         # TypeScript execution was experimental, so we can verify behavioral
         # differences across strip-types / transform-types / amaro changes.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,15 +82,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Pin pnpm to the version declared in root package.json's
-      # `packageManager`. action-setup@v6 added support for pnpm v11, and on
-      # some OSes (observed: windows-latest, macos-latest) it can resolve to
-      # v11.x instead of the packageManager-pinned 10.33.2 — pnpm 11 hard-
-      # errors on Node <22.13, which breaks every matrix entry below 22.13.
-      # An explicit version sidesteps the auto-detect path entirely.
+      # action-setup@v6 bootstrap-installs pnpm v11 (per its committed lockfile)
+      # and only honours `packageManager` via pnpm's own `manage-package-manager
+      # -versions`. Bootstrap pnpm v11 hard-errors on Node <22.13 unless it's
+      # the @pnpm/exe (Node-bundled) build. The action auto-picks @pnpm/exe
+      # when the *runner's preinstalled* Node is <22.13, which is true for
+      # ubuntu-24.04 (Node 20.x) but NOT windows-2025 / macos-15 (Node 22.22).
+      # Force @pnpm/exe everywhere so bootstrap pnpm runs on its bundled Node
+      # regardless of the matrix Node we switch to next.
+      #
+      # Pinning `version: 10.33.2` instead doesn't work: action-setup compares
+      # it against the full `pnpm@10.33.2+sha512.xxx` packageManager string
+      # and refuses on mismatch (ERR_PNPM_BAD_PM_VERSION-style error).
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.2
+          standalone: true
 
       # rolldown-incompatible path: install + tsdown build run here, on a
       # known-compatible Node. The matrix Node below then exercises dist/.
@@ -181,11 +187,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Match the build job: pin pnpm explicitly so action-setup doesn't
-      # surprise us with v11 on a future runner image refresh.
+      # Same reason as the build job — see comment there.
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.2
+          standalone: true
 
       - uses: actions/setup-node@v6
         with:

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -47,14 +47,36 @@ export function runCli(
   // brand-new tree — most painfully, freshly-published `arkor` versions
   // get blocked by minimumReleaseAge. Strip them so the spawned CLI sees
   // a clean user shell.
+  //
+  // The match is case-insensitive on purpose: Windows env-var names are
+  // case-insensitive (CreateProcessW deduplicates by uppercased key), so
+  // the parent can hand us `NPM_CONFIG_USER_AGENT` while we expect
+  // `npm_config_user_agent`. A case-sensitive prefix check would let the
+  // upper-case variant leak through, which on Windows then collides with
+  // our explicit `npm_config_user_agent: ""` override below — Windows
+  // picks one of the duplicates non-deterministically and the spawned
+  // CLI has historically seen pnpm's UA, defeating the hermetic
+  // `detectPackageManager()` path.
   const cleanEnv: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (key.startsWith("npm_config_") || key.startsWith("pnpm_config_")) {
+    const lower = key.toLowerCase();
+    if (lower.startsWith("npm_config_") || lower.startsWith("pnpm_config_")) {
       continue;
     }
     cleanEnv[key] = value;
   }
   return new Promise((resolve, reject) => {
+    // Mirror an extraEnv-provided HOME onto USERPROFILE so the spawned
+    // CLI's `os.homedir()` resolves to the test temp dir on every OS:
+    // POSIX consults HOME, Windows consults USERPROFILE (with HOMEDRIVE
+    // + HOMEPATH as a tertiary fallback). Without this, tests that seed
+    // a fake `~/.arkor/credentials.json` under HOME are silently bypassed
+    // on Windows — the CLI keeps reading the real runner profile and
+    // reports "Not signed in", causing assertions to fail in confusing
+    // ways. Tests that genuinely need divergent HOME / USERPROFILE values
+    // can still set USERPROFILE explicitly: extraEnv is spread last.
+    const homeMirror: NodeJS.ProcessEnv =
+      extraEnv.HOME !== undefined ? { USERPROFILE: extraEnv.HOME } : {};
     const child = spawn(process.execPath, [binPath, ...argv], {
       cwd,
       env: {
@@ -65,6 +87,7 @@ export function runCli(
         GIT_AUTHOR_EMAIL: "e2e@arkor.test",
         GIT_COMMITTER_NAME: "Arkor E2E",
         GIT_COMMITTER_EMAIL: "e2e@arkor.test",
+        ...homeMirror,
         ...extraEnv,
       },
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/arkor/src/bin.ts
+++ b/packages/arkor/src/bin.ts
@@ -38,5 +38,23 @@ if (!hasStripTypesSupport()) {
     else process.exit(code ?? 0);
   });
 } else {
-  await main(process.argv.slice(2));
+  // Catch top-level await rejections explicitly instead of letting Node's
+  // default unhandled-rejection handler print them. Two reasons:
+  //   1. Node's default formatter prints a code-frame with the source line at
+  //      the throw site, and our bundled `dist/bin.mjs` is minified (a single
+  //      line per top-level statement), so the "code frame" is one giant
+  //      blob of JS that drowns the actual `Error: <message>` line.
+  //   2. On macOS Node <22.17 (libuv <1.51.0) the `Error: <message>` tail of
+  //      that output isn't reliably flushed to stderr before the process
+  //      exits — so spawned-CLI test assertions that `toContain` the message
+  //      fail with only the code-frame received. libuv 1.51.0 fixes this,
+  //      but we want CI green across the whole supported Node range.
+  // Setting `process.exitCode` (instead of `process.exit(1)`) lets the event
+  // loop drain naturally so stderr fully flushes before exit.
+  try {
+    await main(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+    process.exitCode = 1;
+  }
 }

--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -12,18 +12,25 @@ import {
 
 let fakeHome: string;
 const ORIG_HOME = process.env.HOME;
+// `os.homedir()` reads USERPROFILE on Windows; HOME-only redirection leaves
+// Windows runs reading/writing the real user profile and cross-contaminating
+// tests via `~/.arkor/credentials.json`.
+const ORIG_USERPROFILE = process.env.USERPROFILE;
 const ORIG_FETCH = globalThis.fetch;
 const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
 
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-dev-test-"));
   process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
   process.env.ARKOR_CLOUD_API_URL = "http://mock-cloud-api";
 });
 
 afterEach(() => {
   if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
   else delete process.env.HOME;
+  if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
+  else delete process.env.USERPROFILE;
   if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;
   else delete process.env.ARKOR_CLOUD_API_URL;
   globalThis.fetch = ORIG_FETCH;

--- a/packages/arkor/src/cli/commands/dev.test.ts
+++ b/packages/arkor/src/cli/commands/dev.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as clack from "@clack/prompts";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureCredentialsForStudio } from "./dev";
+// Re-import the credentials module as a namespace so individual tests can
+// `vi.spyOn` on `writeCredentials` to inject deterministic fs failures
+// regardless of host OS / filesystem semantics.
+import * as credentialsModule from "../../core/credentials";
 import {
   readCredentials,
   writeCredentials,
@@ -301,27 +305,24 @@ describe("ensureCredentialsForStudio", () => {
   // anon bootstrap, so fs errors from `writeCredentials` were also rewritten
   // as "deployment may require sign-in", hiding the actionable fs cause.
   //
-  // Setup: pre-create `~/.arkor` and chmod 0o555 (read+exec, no write) so
-  // `readCredentials()` cleanly returns null (credentials.json doesn't
-  // exist) but `writeCredentials()`'s `writeFile` raises EACCES on the
-  // locked-down parent dir. An earlier draft of this test pre-created
-  // `~/.arkor/credentials.json` *as a directory*, but that made
-  // `readCredentials()` blow up first with EISDIR before the bootstrap
-  // logic ever ran — so the assertion accidentally passed for the wrong
-  // reason (Copilot review on PR #65).
-  //
-  // Skipped under UID 0: root bypasses chmod permission checks on Linux,
-  // so `writeFile` would succeed and the assertion would never trigger
-  // (Codex review on PR #65). Most CI runners are non-root; container-
-  // based root CI just loses this one assertion, the wrap-narrowing
-  // logic itself is still covered by the schema-validation and 5xx
-  // tests above.
-  const isRoot =
-    typeof process.getuid === "function" && process.getuid() === 0;
-  it.skipIf(isRoot)("does not rewrite fs errors from writeCredentials as OAuth hints", async () => {
-    const arkorDir = join(fakeHome, ".arkor");
-    mkdirSync(arkorDir, { recursive: true });
-    chmodSync(arkorDir, 0o555);
+  // We inject EACCES at the `writeCredentials` boundary directly via
+  // `vi.spyOn` rather than fabricating it from filesystem state. The
+  // earlier approach (pre-create `~/.arkor` and `chmod 0o555` so
+  // `writeFile` would raise EACCES under the bootstrap) only works on
+  // POSIX as a non-root user: root bypasses chmod (Codex on PR #65), and
+  // on Windows POSIX permission bits don't durably block writes inside a
+  // directory at all — Node maps `chmod` to the legacy read-only
+  // attribute, which NTFS only enforces on files. Both edges silently
+  // turned the test green for the wrong reason. Mocking lifts the
+  // "produce an EACCES" half of the test out of the host filesystem
+  // entirely so every CI matrix entry exercises the wrap-narrowing
+  // branch.
+  it("does not rewrite fs errors from writeCredentials as OAuth hints", async () => {
+    const eacces = Object.assign(
+      new Error("EACCES: permission denied, open '~/.arkor/credentials.json'"),
+      { code: "EACCES" },
+    );
+    vi.spyOn(credentialsModule, "writeCredentials").mockRejectedValue(eacces);
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);
       if (url.endsWith("/v1/auth/cli/config")) {
@@ -349,15 +350,10 @@ describe("ensureCredentialsForStudio", () => {
       throw new Error(`unexpected fetch: ${url}`);
     }) as typeof fetch;
 
-    try {
-      await expect(ensureCredentialsForStudio()).rejects.toThrow(/EACCES/);
-      await expect(ensureCredentialsForStudio()).rejects.not.toThrow(
-        /arkor login --oauth/,
-      );
-    } finally {
-      // Restore writable so the afterEach `rmSync` can clean up.
-      chmodSync(arkorDir, 0o755);
-    }
+    await expect(ensureCredentialsForStudio()).rejects.toThrow(/EACCES/);
+    await expect(ensureCredentialsForStudio()).rejects.not.toThrow(
+      /arkor login --oauth/,
+    );
   });
 
   // Copilot review on PR #65 (round 3) flagged that the OAuth-only wrap

--- a/packages/arkor/src/cli/commands/login.test.ts
+++ b/packages/arkor/src/cli/commands/login.test.ts
@@ -8,6 +8,10 @@ import { readCredentials } from "../../core/credentials";
 
 let fakeHome: string;
 const ORIG_HOME = process.env.HOME;
+// `os.homedir()` reads USERPROFILE on Windows; HOME-only redirection leaves
+// Windows runs reading/writing the real user profile and cross-contaminating
+// tests via `~/.arkor/credentials.json`.
+const ORIG_USERPROFILE = process.env.USERPROFILE;
 const ORIG_CI = process.env.CI;
 const ORIG_FETCH = globalThis.fetch;
 const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
@@ -15,6 +19,7 @@ const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-login-test-"));
   process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
   process.env.ARKOR_CLOUD_API_URL = "http://mock-cloud-api";
   // Force isInteractive() → false so promptSelect returns its initialValue
   // instead of trying to open a real clack prompt.
@@ -24,6 +29,8 @@ beforeEach(() => {
 afterEach(() => {
   if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
   else delete process.env.HOME;
+  if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
+  else delete process.env.USERPROFILE;
   if (ORIG_CI !== undefined) process.env.CI = ORIG_CI;
   else delete process.env.CI;
   if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;

--- a/packages/arkor/src/core/credentials.test.ts
+++ b/packages/arkor/src/core/credentials.test.ts
@@ -16,16 +16,24 @@ import { SDK_VERSION } from "./version";
 
 let fakeHome: string;
 const ORIG_HOME = process.env.HOME;
+// `os.homedir()` reads HOME on POSIX but USERPROFILE on Windows. Setting only
+// HOME redirects fakeHome on Linux/macOS but leaves Windows pointed at the
+// real user profile, where tests would clobber a developer's actual
+// `~/.arkor/credentials.json` and bleed state into sibling tests.
+const ORIG_USERPROFILE = process.env.USERPROFILE;
 const ORIG_URL = process.env.ARKOR_CLOUD_API_URL;
 const ORIG_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-creds-test-"));
   process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
 });
 
 afterEach(() => {
   process.env.HOME = ORIG_HOME;
+  if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
+  else delete process.env.USERPROFILE;
   if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;
   else delete process.env.ARKOR_CLOUD_API_URL;
   globalThis.fetch = ORIG_FETCH;

--- a/packages/arkor/src/core/credentials.test.ts
+++ b/packages/arkor/src/core/credentials.test.ts
@@ -31,7 +31,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env.HOME = ORIG_HOME;
+  // `process.env.X = undefined` writes the literal string "undefined" rather
+  // than removing the entry, which then leaks into `os.homedir()` resolution
+  // for any test that runs later in the same vitest worker. Match the
+  // delete-when-originally-unset pattern used in cli/commands/*.test.ts.
+  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  else delete process.env.HOME;
   if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
   else delete process.env.USERPROFILE;
   if (ORIG_URL !== undefined) process.env.ARKOR_CLOUD_API_URL = ORIG_URL;

--- a/packages/arkor/src/core/telemetry.test.ts
+++ b/packages/arkor/src/core/telemetry.test.ts
@@ -67,7 +67,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env.HOME = ORIG_HOME;
+  // `process.env.X = undefined` writes the literal string "undefined" rather
+  // than removing the entry, which then leaks into `os.homedir()` resolution
+  // for any test that runs later in the same vitest worker. Match the
+  // delete-when-originally-unset pattern used in cli/commands/*.test.ts.
+  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  else delete process.env.HOME;
   if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
   else delete process.env.USERPROFILE;
   if (ORIG_DO_NOT_TRACK !== undefined) process.env.DO_NOT_TRACK = ORIG_DO_NOT_TRACK;

--- a/packages/arkor/src/core/telemetry.test.ts
+++ b/packages/arkor/src/core/telemetry.test.ts
@@ -20,6 +20,9 @@ vi.mock("posthog-node", () => ({
 }));
 
 const ORIG_HOME = process.env.HOME;
+// `os.homedir()` reads USERPROFILE on Windows; HOME-only redirection leaves
+// Windows runs writing the telemetry-id under the real user profile.
+const ORIG_USERPROFILE = process.env.USERPROFILE;
 const ORIG_DO_NOT_TRACK = process.env.DO_NOT_TRACK;
 const ORIG_DISABLED = process.env.ARKOR_TELEMETRY_DISABLED;
 
@@ -55,6 +58,7 @@ async function loadTelemetry(opts: {
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-telemetry-test-"));
   process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
   delete process.env.DO_NOT_TRACK;
   delete process.env.ARKOR_TELEMETRY_DISABLED;
   captureMock.mockClear();
@@ -64,6 +68,8 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env.HOME = ORIG_HOME;
+  if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
+  else delete process.env.USERPROFILE;
   if (ORIG_DO_NOT_TRACK !== undefined) process.env.DO_NOT_TRACK = ORIG_DO_NOT_TRACK;
   else delete process.env.DO_NOT_TRACK;
   if (ORIG_DISABLED !== undefined) process.env.ARKOR_TELEMETRY_DISABLED = ORIG_DISABLED;

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -32,10 +32,16 @@ let fakeHome: string;
 let assetsDir: string;
 let trainCwd: string;
 const ORIG_HOME = process.env.HOME;
+// `os.homedir()` reads USERPROFILE on Windows; HOME-only redirection leaves
+// Windows runs writing test creds to the real user profile and bleeding state
+// (e.g. `mode: "anon", token: "tok", orgSlug: "anon-org"`) into other tests
+// that read `~/.arkor/credentials.json` and expect it to be absent.
+const ORIG_USERPROFILE = process.env.USERPROFILE;
 
 beforeEach(() => {
   fakeHome = mkdtempSync(join(tmpdir(), "arkor-studio-test-"));
   process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
   assetsDir = mkdtempSync(join(tmpdir(), "arkor-studio-assets-"));
   mkdirSync(assetsDir, { recursive: true });
   writeFileSync(
@@ -47,6 +53,8 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env.HOME = ORIG_HOME;
+  if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
+  else delete process.env.USERPROFILE;
   rmSync(fakeHome, { recursive: true, force: true });
   rmSync(assetsDir, { recursive: true, force: true });
   rmSync(trainCwd, { recursive: true, force: true });

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -284,22 +284,41 @@ describe("Studio server", () => {
   // link inside the project directory pointing outside it would previously
   // pass the containment check and be handed to `arkor start` (which would
   // then dlopen the link's target).
+  //
+  // The link target must be a real existing file: the SDK does
+  // `realpath` first and rejects with "file does not exist" if the link
+  // dangles, which would short-circuit before the containment check can
+  // fire. Earlier this test pointed at `/etc/passwd` and worked on POSIX
+  // by coincidence, but Windows has no such path and the dangling-link
+  // branch took over. Pointing at a real outside-cwd file keeps both
+  // POSIX and Windows runners exercising the containment branch.
   it("rejects /api/train when body.file is a symlink to a path outside cwd", async () => {
     await writeCredentials(ANON_CREDS);
-    symlinkSync("/etc/passwd", join(trainCwd, "evil.ts"));
-    const app = build();
-    const res = await app.request("/api/train", {
-      method: "POST",
-      headers: {
-        host: "127.0.0.1:4000",
-        "x-arkor-studio-token": STUDIO_TOKEN,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ file: "evil.ts" }),
-    });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toMatch(/inside the project directory/);
+    // Note: GitHub-hosted Windows runners ship with Developer Mode on, so
+    // `symlinkSync` works for non-elevated users. If a future image
+    // regresses that, we'd rather see the test go red here than silently
+    // no-op.
+    const outsideDir = mkdtempSync(join(tmpdir(), "arkor-studio-outside-"));
+    try {
+      const outsideFile = join(outsideDir, "secret.txt");
+      writeFileSync(outsideFile, "secret");
+      symlinkSync(outsideFile, join(trainCwd, "evil.ts"));
+      const app = build();
+      const res = await app.request("/api/train", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:4000",
+          "x-arkor-studio-token": STUDIO_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ file: "evil.ts" }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toMatch(/inside the project directory/);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects /api/train when body.file does not exist", async () => {

--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -52,7 +52,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env.HOME = ORIG_HOME;
+  // `process.env.X = undefined` writes the literal string "undefined" rather
+  // than removing the entry, which then leaks into `os.homedir()` resolution
+  // for any test that runs later in the same vitest worker. Match the
+  // delete-when-originally-unset pattern used in cli/commands/*.test.ts.
+  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  else delete process.env.HOME;
   if (ORIG_USERPROFILE !== undefined) process.env.USERPROFILE = ORIG_USERPROFILE;
   else delete process.env.USERPROFILE;
   rmSync(fakeHome, { recursive: true, force: true });

--- a/packages/cli-internal/src/git.ts
+++ b/packages/cli-internal/src/git.ts
@@ -1,5 +1,18 @@
 import { spawn } from "node:child_process";
 
+// IMPORTANT: do NOT pass `shell: process.platform === "win32"` to these
+// `spawn("git", ...)` calls. `git` ships as `git.exe` on Windows so libuv
+// resolves it through PATHEXT without a shell, and routing through cmd.exe
+// instead corrupts the `git commit -m "<message>"` argument: the message
+// includes spaces and backticks (e.g. ``Initial commit from `arkor init` ``),
+// and Node's Windows shell-mode quoting wraps the whole arg in double quotes
+// while the surrounding cmd.exe `/c "<cmd>"` framing turns the resulting
+// nested quotes into a malformed command line. Git then sees a shorter or
+// empty message and either silently no-ops or commits unexpected content,
+// reporting exit 0 — leaving the scaffolded directory with a `.git/HEAD` but
+// no commit. Only `pnpm`/`yarn`/`bun`-style `.cmd` shims need shell:true
+// (see `install.ts`); plain `.exe` binaries do not.
+
 /**
  * Whether `cwd` is already inside a Git working tree. We check so we don't
  * clobber an existing repo by running `git init` on top of it.
@@ -9,7 +22,6 @@ export async function isInGitRepo(cwd: string): Promise<boolean> {
     const child = spawn("git", ["rev-parse", "--is-inside-work-tree"], {
       cwd,
       stdio: "ignore",
-      shell: process.platform === "win32",
     });
     child.on("error", () => resolve(false));
     child.on("close", (code) => resolve(code === 0));
@@ -73,7 +85,6 @@ function runGit(cwd: string, args: string[]): Promise<void> {
     const child = spawn("git", args, {
       cwd,
       stdio: "ignore",
-      shell: process.platform === "win32",
     });
     child.on("error", reject);
     child.on("close", (code) => {
@@ -94,7 +105,6 @@ function tryGit(
     const child = spawn("git", args, {
       cwd,
       stdio: ["ignore", "ignore", "pipe"],
-      shell: process.platform === "win32",
     });
     const chunks: Buffer[] = [];
     child.stderr?.on("data", (c: Buffer) => chunks.push(c));


### PR DESCRIPTION
This pull request updates the continuous integration workflow to improve cross-platform compatibility and test coverage. The main changes ensure that the build job runs on all major operating systems and that shell commands work consistently across environments.

Workflow enhancements:

* Modified the `build` job in `.github/workflows/ci.yaml` to run on a matrix of operating systems (`ubuntu-latest`, `windows-latest`, `macos-latest`) in addition to different Node.js versions, improving detection of OS-specific issues.
* Set the default shell to `bash` for all OSes to ensure POSIX shell compatibility for script steps, particularly on Windows where the default shell is PowerShell.…e bash shell

Modified the CI configuration to run tests across Ubuntu, Windows, and macOS. Updated the job name for clarity and set the default shell to bash for consistent behavior across platforms.