### PR TITLE
Improve documentation clarity and consistency across multiple files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ arkor/
 
 ## Development setup
 
-Please use **Node.js 24 (Preferably the latest) ** and **pnpm 10.21+**.
+Please use **Node.js 24 (preferably the latest)** and **pnpm 10.21+**.
 
 ```bash
 git clone https://github.com/arkorlab/arkor.git

--- a/docs/concepts/lifecycle.mdx
+++ b/docs/concepts/lifecycle.mdx
@@ -73,7 +73,7 @@ Common uses:
 
 - Forward to your own metrics pipeline (e.g. PostHog, Datadog).
 - Detect divergence early: if `loss` is climbing, abort `wait()` via `abortSignal` and call `trainer.cancel()` to stop the GPU on the backend.
-- Implement custom early stopping logic.
+- Implement custom early stopping (abort a run automatically when metrics regress — see the [Early stopping recipe](/cookbook/early-stopping)).
 
 ## `onCheckpoint({ step, adapter, job, infer, artifacts })`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,7 +92,7 @@
           ],
           "primary": {
             "type": "button",
-            "label": "Get started",
+            "label": "はじめに",
             "href": "/ja/quickstart"
           }
         },

--- a/docs/sdk/callbacks.mdx
+++ b/docs/sdk/callbacks.mdx
@@ -70,7 +70,7 @@ onLog: ({ step, loss, evalLoss }) => {
 }
 ```
 
-Common uses: forward metrics to your own pipeline (PostHog, Datadog), detect divergence early, and implement custom early-stopping. For early-stopping, remember that aborting the [`abortSignal`](/sdk/trainer-control#abortsignal) only stops your local `wait()`; call [`trainer.cancel()`](/sdk/trainer-control#cancel) afterwards to actually stop the GPU on the backend.
+Common uses: forward metrics to your own pipeline (PostHog, Datadog), detect divergence early, and implement custom early-stopping (see the [Early stopping recipe](/cookbook/early-stopping)). For early-stopping, remember that aborting the [`abortSignal`](/sdk/trainer-control#abortsignal) only stops your local `wait()`; call [`trainer.cancel()`](/sdk/trainer-control#cancel) afterwards to actually stop the GPU on the backend.
 
 ## `onCheckpoint({ step, adapter, job, infer, artifacts })`
 

--- a/docs/sdk/infer.mdx
+++ b/docs/sdk/infer.mdx
@@ -74,5 +74,5 @@ When `stream: true` (the default), the body is an SSE event stream in the same s
 ## When you would use it
 
 - **Sanity check during a run.** Compare a checkpoint at step 50 to one at step 100 against a fixed prompt. If the loss curve looks fine but outputs are degraded, you find out before the run finishes.
-- **Custom early-stopping.** Combine with a simple eval prompt: if outputs diverge, abort the run via `controller.abort()` (see [`abortSignal`](/sdk/trainer-control#abortsignal)) and call `trainer.cancel()` to stop the backend.
+- **Custom early-stopping.** Combine with a simple eval prompt: if outputs diverge, abort the run via `controller.abort()` (see [`abortSignal`](/sdk/trainer-control#abortsignal)) and call `trainer.cancel()` to stop the backend. See the [Early stopping recipe](/cookbook/early-stopping) for the full pattern.
 - **Live preview into your own UI.** Send the checkpoint output to Slack, an internal review queue, or your own app's preview channel.


### PR DESCRIPTION
This pull request updates documentation to provide clearer guidance and better references for implementing early stopping in training workflows. It also improves localization for the Japanese quickstart.

**Documentation improvements for early stopping:**

* Added explicit references to the [Early stopping recipe](/cookbook/early-stopping) in the following files to help users implement custom early stopping logic:
  - `docs/concepts/lifecycle.mdx`
  - `docs/sdk/callbacks.mdx`
  - `docs/sdk/infer.mdx`

**Localization:**

* Updated the primary button label in `docs/docs.json` from "Get started" to "はじめに" and set the link to the Japanese quickstart page.

**Minor formatting fix:**

* Fixed capitalization and spacing in the Node.js and pnpm version requirements in `arkor/CONTRIBUTING.md`.- Revised the development setup instructions in CONTRIBUTING.md for improved readability.
- Translated the "Get started" label to Japanese in docs/docs.json.
- Enhanced descriptions related to custom early stopping in lifecycle.mdx and callbacks.mdx, linking to the Early stopping recipe for better guidance.
- Added a reference to the Early stopping recipe in infer.mdx to provide users with a complete pattern for implementation.