### PR TITLE
feat(packaging): bundle README.ja.md alongside README.md in published tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 # Generated copies of root files (see packages/*/scripts/copy-root-files.mjs)
 packages/*/CONTRIBUTING.md
+packages/*/README.ja.md
 
 # Generated copy of docs/ (see packages/arkor/scripts/copy-docs.mjs)
 packages/arkor/docs/

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -35,7 +35,8 @@
   "files": [
     "dist",
     "docs",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "README.ja.md"
   ],
   "engines": {
     "node": ">=22.6"

--- a/packages/arkor/scripts/copy-root-files.mjs
+++ b/packages/arkor/scripts/copy-root-files.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Copy single-source root files (currently `CONTRIBUTING.md`) into the
- * package directory so they end up in the published tarball. Kept as Node
- * (not shell) to stay Windows-friendly.
+ * Copy single-source root files (`CONTRIBUTING.md`, `README.ja.md`) into
+ * the package directory so they end up in the published tarball. Kept as
+ * Node (not shell) to stay Windows-friendly.
  */
 import { copyFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -13,7 +13,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = join(__dirname, "..");
 const repoRoot = join(pkgRoot, "../..");
 
-const FILES = ["CONTRIBUTING.md"];
+const FILES = ["CONTRIBUTING.md", "README.ja.md"];
 
 for (const name of FILES) {
   const src = join(repoRoot, name);

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "dist",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "README.ja.md"
   ],
   "engines": {
     "node": ">=22.6"

--- a/packages/create-arkor/scripts/copy-root-files.mjs
+++ b/packages/create-arkor/scripts/copy-root-files.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Copy single-source root files (currently `CONTRIBUTING.md`) into the
- * package directory so they end up in the published tarball. Kept as Node
- * (not shell) to stay Windows-friendly.
+ * Copy single-source root files (`CONTRIBUTING.md`, `README.ja.md`) into
+ * the package directory so they end up in the published tarball. Kept as
+ * Node (not shell) to stay Windows-friendly.
  */
 import { copyFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -13,7 +13,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = join(__dirname, "..");
 const repoRoot = join(pkgRoot, "../..");
 
-const FILES = ["CONTRIBUTING.md"];
+const FILES = ["CONTRIBUTING.md", "README.ja.md"];
 
 for (const name of FILES) {
   const src = join(repoRoot, name);


### PR DESCRIPTION
## Summary
- Extend [`packages/arkor/scripts/copy-root-files.mjs`](packages/arkor/scripts/copy-root-files.mjs) and [`packages/create-arkor/scripts/copy-root-files.mjs`](packages/create-arkor/scripts/copy-root-files.mjs) — already used to mirror the repo-root `CONTRIBUTING.md` into each package — to also copy `README.ja.md`.
- Add `"README.ja.md"` to each package's `files` allowlist so the generated copy actually ships in the published npm tarball.
- Gitignore `packages/*/README.ja.md`. Single source of truth stays at the repo root.

### Why

Same delivery shape as `CONTRIBUTING.md` and the `docs/` tree: installed-only consumers can read the Japanese README locally (e.g. `node_modules/arkor/README.ja.md`) without bouncing to the repo. npmjs.com still renders the canonical English `README.md` on the package page.

### Tarball impact

Verified locally with `npm pack --dry-run` after `pnpm run build`:

| | Before | After |
|---|---|---|
| `arkor` package size | ~466 kB | ~477 kB (+~11 kB) |
| `create-arkor` package size | ~12 kB | ~14.8 kB (+~3 kB) |
| New entries | — | `README.ja.md` (13.2 kB raw) |

## Test plan
- [ ] `pnpm --filter arkor build` and `pnpm --filter create-arkor build` succeed and print `Copied .../README.ja.md -> packages/<pkg>/README.ja.md`
- [ ] `cd packages/arkor && npm pack --dry-run` lists `README.ja.md` (13.2 kB)
- [ ] `cd packages/create-arkor && npm pack --dry-run` lists `README.ja.md` (13.2 kB)
- [ ] `pnpm --filter @arkor/cli-internal test` passes
- [ ] After the next release, `npm pack arkor@<version>` extracts a tarball that contains `package/README.ja.md`