### PR TITLE
chore: release arkor + create-arkor 0.0.1-alpha.6

### DIFF
--- a/e2e/cli/src/arkor-whoami.test.ts
+++ b/e2e/cli/src/arkor-whoami.test.ts
@@ -230,7 +230,7 @@ describe("arkor whoami × SDK version gate (E2E)", () => {
       res.setHeader("Deprecation", "true");
       res.setHeader(
         "Warning",
-        '299 - "Arkor SDK 0.0.1-alpha.5 is deprecated; supported range: >=2.0.0"',
+        '299 - "Arkor SDK 0.0.1-alpha.6 is deprecated; supported range: >=2.0.0"',
       );
       res.end(
         JSON.stringify({

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -2,7 +2,7 @@
 
 The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 
-> Status: alpha (`0.0.1-alpha.5`). APIs may change without notice. No compat
+> Status: alpha (`0.0.1-alpha.6`). APIs may change without notice. No compat
 > shims are offered between alpha versions — pin and re-read the changelog
 > before bumping.
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkor",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "Code-first TypeScript training SDK, CLI, and local Studio.",
   "private": false,
   "type": "module",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -128,7 +128,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.5");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.6");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");
@@ -150,7 +150,7 @@ describe("scaffold", () => {
     // The value is opaque to scaffold — only that it's faithfully
     // round-tripped into package.json matters, so use a relative
     // `file:` spec that is platform-neutral (no Unix-only `/tmp`).
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.5.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.6.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     const { files } = await scaffold({
       cwd,
@@ -185,7 +185,7 @@ describe("scaffold", () => {
         readFileSync(join(cwd, "package.json"), "utf8"),
       ) as Record<string, unknown>;
       const devDeps = pkg.devDependencies as Record<string, string>;
-      expect(devDeps.arkor).toBe("^0.0.1-alpha.5");
+      expect(devDeps.arkor).toBe("^0.0.1-alpha.6");
     },
   );
 
@@ -194,7 +194,7 @@ describe("scaffold", () => {
     // and the patch path that runs when `package.json` already exists
     // but has no `devDependencies.arkor`. Cover the patch path too so
     // the override doesn't silently regress to the default there.
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.5.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.6.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     writeFileSync(
       join(cwd, "package.json"),

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -30,7 +30,7 @@ const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
-const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.5";
+const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.6";
 
 function resolveArkorScaffoldSpec(): string {
   // Treat unset, empty, and whitespace-only values the same: fall back to

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -3,7 +3,7 @@
 Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
 `npm create` / `pnpm create` / `yarn create` / `bun create`.
 
-> Status: alpha (`0.0.1-alpha.5`).
+> Status: alpha (`0.0.1-alpha.6`).
 
 ## Usage
 

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-arkor",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "Scaffolder for arkor training projects.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump the two public packages (`arkor`, `create-arkor`) from `0.0.1-alpha.5` to `0.0.1-alpha.6`.
- Bump `DEFAULT_ARKOR_SPEC` in [packages/cli-internal/src/scaffold.ts](packages/cli-internal/src/scaffold.ts) (and the corresponding test expectations + override fixture filenames) to `^0.0.1-alpha.6`. CI exercises the workspace via `ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC`, not the registry, so pre-pinning the unreleased version is safe.
- Update the alpha-version callouts in the per-package READMEs and the `arkor-whoami` deprecation-warning fixture.

### What's new in alpha.6 vs alpha.5

- First release where the embedded PostHog telemetry key actually reaches the published binary (#85). Earlier alphas all shipped `new PostHog("", ...)` because turbo 2.x's strict env mode was filtering `ARKOR_POSTHOG_KEY` out of the spawned `build` task; declaring it on the task fixed that.
- First release where the published tarball includes `README.ja.md` next to `README.md` (#94).

## Test plan
- [ ] `pnpm --filter @arkor/cli-internal test` passes (scaffold tests assert `^0.0.1-alpha.6`)
- [ ] CI's e2e install tests resolve `arkor` from the workspace `packages/arkor` directory
- [ ] After tagging `v0.0.1-alpha.6` and running release.yaml:
  - `npm view arkor@0.0.1-alpha.6 dist.attestations.provenance` returns SLSA v1 provenance
  - `npm pack arkor@0.0.1-alpha.6 && tar -xzf arkor-0.0.1-alpha.6.tgz && grep -oE 'phc_[A-Za-z0-9_-]+' package/dist/bin.mjs` returns the configured PostHog project key (NOT empty — fixes the regression that ran from alpha.0 through alpha.5)
  - Tarball contains `README.ja.md`, `CONTRIBUTING.md`, `LICENSE.md`, `README.md`, `docs/`
  - npmjs.com page renders the README
- [ ] Manually re-point `latest` after release: `npm dist-tag add arkor@0.0.1-alpha.6 latest && npm dist-tag add create-arkor@0.0.1-alpha.6 latest`