### PR TITLE
docs: lead with "Get started" before "Roadmap" in nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,12 +21,12 @@
         "default": true,
         "groups": [
           {
-            "group": "Roadmap",
-            "pages": ["roadmap"]
-          },
-          {
             "group": "Get started",
             "pages": ["introduction", "quickstart"]
+          },
+          {
+            "group": "Roadmap",
+            "pages": ["roadmap"]
           },
           {
             "group": "Concepts",
@@ -98,12 +98,12 @@
         },
         "groups": [
           {
-            "group": "ロードマップ",
-            "pages": ["ja/roadmap"]
-          },
-          {
             "group": "はじめに",
             "pages": ["ja/introduction", "ja/quickstart"]
+          },
+          {
+            "group": "ロードマップ",
+            "pages": ["ja/roadmap"]
           },
           {
             "group": "コンセプト",


### PR DESCRIPTION
## Summary
- Reorder the top-level navigation groups in `docs/docs.json` so **Get started** is the first group in the sidebar, with **Roadmap** moved to second.
- Apply the same reorder to the Japanese mirror (はじめに → ロードマップ).
- The navbar primary button already routes to `/quickstart`; the sidebar now matches that landing target so first-time visitors see how to start before what's planned.

No page paths or group names are changed, so no link-rot risk.

## Test plan
- [ ] Mintlify preview deploy on this PR shows **Get started** above **Roadmap** in the EN sidebar.
- [ ] Same check on the JA sidebar (`/ja`): **はじめに** above **ロードマップ**.
- [ ] Navbar "Get started" button still navigates to `/quickstart` (and `/ja/quickstart` on the JA side).
- [ ] `docs/docs.json` parses as valid JSON (verified locally).