### PR TITLE
refactor: drop deprecated chatml/minimal/alpaca starter templates

### DIFF
--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -25,7 +25,7 @@ arkor init [options]
 | --- | --- |
 | `-y, --yes` | Accept defaults instead of prompting (project name from the directory name, template `triage`). |
 | `--name <name>` | Project name. Defaults to the current directory's name (`arkor-project` if the path has no basename, e.g. `/`). The value is sanitised before it lands in `package.json`. |
-| `--template <id>` | Starter template. Visible options: `triage`, `translate`, `redaction`. The validator also accepts hidden ids (`minimal`, `alpaca`, `chatml`) when passed explicitly. Unknown ids throw before any filesystem work. |
+| `--template <id>` | Starter template. Options: `triage`, `translate`, `redaction`. Unknown ids throw before any filesystem work. |
 | `--skip-install` | Skip running the package manager's `install` step after scaffolding. |
 | `--use-npm` | Force npm as the package manager. |
 | `--use-pnpm` | Force pnpm as the package manager. |
@@ -45,8 +45,6 @@ arkor init [options]
 | `redaction` | PII redaction | `{ redactedText, redactedCount, tags }` |
 
 All three pair the same small open-weight base (`unsloth/gemma-4-E4B-it`) with a curated public dataset on HuggingFace.
-
-The hidden templates (`minimal`, `alpaca`, `chatml`) are intentionally bare and exist as references. They do not appear in the interactive picker.
 
 ## Package manager detection
 
@@ -83,7 +81,7 @@ If you forget `--yes` in a non-interactive shell, the command still completes (p
 | Message | What it means | Fix |
 | --- | --- | --- |
 | `Pick one of --git / --skip-git, not both.` | Both git flags were passed. | Pass at most one. |
-| `Unknown template "<id>". Available: triage, translate, redaction, minimal, alpaca, chatml` | `--template` value did not match any registered template id. | Use one of the listed ids. The hidden ids (`minimal`, `alpaca`, `chatml`) only work when passed explicitly. |
+| `Unknown template "<id>". Available: triage, translate, redaction` | `--template` value did not match any registered template id. | Use one of the listed ids. |
 | `Commit signing failed — created an unsigned commit.` | `git init` succeeded but the initial commit could not be GPG-signed. | Re-sign with `git commit --amend -S` once your signing setup is fixed. The repo is otherwise fine. |
 
 ## Examples

--- a/docs/ja/cli/init.mdx
+++ b/docs/ja/cli/init.mdx
@@ -25,7 +25,7 @@ arkor init [options]
 | --- | --- |
 | `-y, --yes` | プロンプトの代わりにデフォルトを採用（プロジェクト名はディレクトリー名、テンプレートは `triage`）。 |
 | `--name <name>` | プロジェクト名。デフォルトはカレントディレクトリー名（パスに basename がない場合 `arkor-project`、例えば `/`）。`package.json` に書く前にサニタイズされます。 |
-| `--template <id>` | スターターテンプレート。表示される選択肢: `triage`、`translate`、`redaction`。バリデータは明示的に渡したときに限り隠し ID（`minimal`、`alpaca`、`chatml`）も受け付けます。未知の ID はファイル操作前に例外が発生します。 |
+| `--template <id>` | スターターテンプレート。選択肢: `triage`、`translate`、`redaction`。未知の ID はファイル操作前に例外が発生します。 |
 | `--skip-install` | 生成後のパッケージマネージャの `install` をスキップ。 |
 | `--use-npm` | パッケージマネージャに npm を強制。 |
 | `--use-pnpm` | パッケージマネージャに pnpm を強制。 |
@@ -45,8 +45,6 @@ arkor init [options]
 | `redaction` | 個人情報のマスク | `{ redactedText, redactedCount, tags }` |
 
 3 つとも同じ小型のオープンウェイトベース（`unsloth/gemma-4-E4B-it`）と HuggingFace 上の厳選公開データセットを組み合わせています。
-
-隠しテンプレート（`minimal`、`alpaca`、`chatml`）は意図的にミニマルで、参照用として存在します。対話ピッカーには出てきません。
 
 ## パッケージマネージャ検出
 
@@ -83,7 +81,7 @@ pnpm exec arkor init --yes --template triage --use-pnpm --skip-git
 | メッセージ | 意味 | 対処 |
 | --- | --- | --- |
 | `Pick one of --git / --skip-git, not both.`（`--git` と `--skip-git` のどちらか一方だけ指定してください） | git 関連の両フラグを渡した。 | どちらか一方にする。 |
-| `Unknown template "<id>". Available: triage, translate, redaction, minimal, alpaca, chatml`（未知のテンプレート `<id>`。利用可能: triage, translate, redaction, minimal, alpaca, chatml） | `--template` の値がどの登録テンプレート ID にも一致しなかった。 | 一覧の ID を使う。隠し ID（`minimal`、`alpaca`、`chatml`）は明示指定時のみ有効。 |
+| `Unknown template "<id>". Available: triage, translate, redaction`（未知のテンプレート `<id>`。利用可能: triage, translate, redaction） | `--template` の値がどの登録テンプレート ID にも一致しなかった。 | 一覧の ID を使う。 |
 | `Commit signing failed — created an unsigned commit.`（コミット署名に失敗したため、署名なしコミットを作成しました） | `git init` は成功したが初回コミットを GPG 署名できなかった。 | 署名のセットアップを直したら `git commit --amend -S` で再署名。リポジトリ自体は問題なし。 |
 
 ## 例

--- a/e2e/cli/src/arkor-init.test.ts
+++ b/e2e/cli/src/arkor-init.test.ts
@@ -109,14 +109,14 @@ describe("arkor init (E2E)", () => {
         "--name",
         "no-prompt-app",
         "--template",
-        "chatml",
+        "redaction",
       ],
       cwd,
     );
     expect(result.code).toBe(0);
 
     const trainer = readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8");
-    expect(trainer).toContain('"chatml-run"');
+    expect(trainer).toContain('"redaction-run"');
 
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),

--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -141,7 +141,7 @@ describe("create-arkor (E2E)", () => {
       "--name",
       "no-prompt-app",
       "--template",
-      "chatml",
+      "redaction",
     ]);
     expect(result.code).toBe(0);
 
@@ -154,7 +154,7 @@ describe("create-arkor (E2E)", () => {
       join(targetDir, "src/arkor/trainer.ts"),
       "utf8",
     );
-    expect(trainer).toContain('"chatml-run"');
+    expect(trainer).toContain('"redaction-run"');
   });
 
   // Regression for ENG-357 — `--name "Foo Bar"` previously fell through to
@@ -194,30 +194,6 @@ describe("create-arkor (E2E)", () => {
     // Before the fix this would have been "arkor-project" (the sanitise
     // fallback for empty input).
     expect(pkg.name).toBe("trail");
-  });
-
-  it("honours --name --template alpaca", async () => {
-    const { result, targetDir } = await runCreateArkor([
-      "-y",
-      "--skip-install",
-      "--skip-git",
-      "--name",
-      "custom-app",
-      "--template",
-      "alpaca",
-    ]);
-    expect(result.code).toBe(0);
-
-    const pkg = JSON.parse(
-      readFileSync(join(targetDir, "package.json"), "utf8"),
-    ) as { name?: string };
-    expect(pkg.name).toBe("custom-app");
-
-    const trainer = readFileSync(
-      join(targetDir, "src/arkor/trainer.ts"),
-      "utf8",
-    );
-    expect(trainer).toContain('"alpaca-run"');
   });
 
   // Regression for ENG-426 — without an explicit `[dir]` the CLI used to

--- a/packages/arkor/src/cli/commands/init.test.ts
+++ b/packages/arkor/src/cli/commands/init.test.ts
@@ -37,10 +37,9 @@ vi.mock("@arkor/cli-internal", () => {
       files: [{ action: "created", path: "package.json" }],
     })),
     TEMPLATES: {
-      triage: { hidden: false },
-      translate: { hidden: false },
-      redaction: { hidden: false },
-      minimal: { hidden: true },
+      triage: {},
+      translate: {},
+      redaction: {},
     },
     templateChoices: () => [
       { value: "triage", label: "Triage", hint: "fast" },

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -116,9 +116,7 @@ export async function runInit(options: InitOptions): Promise<void> {
     initialValue: options.name ?? defaultName,
     skipWith: options.yes ? options.name ?? defaultName : undefined,
   });
-  // An explicit `--template <id>` is treated as authoritative — skip the
-  // prompt entirely so a hidden-but-valid template (e.g. `minimal`) can't be
-  // overwritten by the visible-only options list.
+  // An explicit `--template <id>` is authoritative: skip the prompt and use it as-is.
   const template = await promptSelect<TemplateId>({
     message: "Starter template?",
     initialValue: options.template ?? "triage",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 
 describe("scaffold", () => {
   it("writes all starter files in an empty directory", async () => {
-    const result = await scaffold({ cwd, name: "my-app", template: "minimal" });
+    const result = await scaffold({ cwd, name: "my-app", template: "triage" });
     // index.ts, trainer.ts, arkor.config.ts, README.md, .gitignore, package.json
     expect(result.files.map((f) => f.action)).toEqual([
       "created",
@@ -54,7 +54,7 @@ describe("scaffold", () => {
     const trainer = readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8");
     expect(trainer).toContain("createTrainer");
     expect(trainer).toContain("unsloth/gemma-4-E4B-it");
-    expect(trainer).toContain('"my-first-run"');
+    expect(trainer).toContain('"triage-run"');
 
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),
@@ -80,7 +80,7 @@ describe("scaffold", () => {
     writeFileSync(join(cwd, "src/arkor/index.ts"), existingIndex);
     writeFileSync(join(cwd, "src/arkor/trainer.ts"), existingTrainer);
 
-    const result = await scaffold({ cwd, name: "foo", template: "minimal" });
+    const result = await scaffold({ cwd, name: "foo", template: "triage" });
     const indexEntry = result.files.find(
       (f) => f.path === "src/arkor/index.ts",
     );
@@ -115,7 +115,7 @@ describe("scaffold", () => {
     const { files } = await scaffold({
       cwd,
       name: "ignored",
-      template: "minimal",
+      template: "triage",
     });
     const patched = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),
@@ -136,12 +136,12 @@ describe("scaffold", () => {
 
   it("appends to an existing .gitignore only if the entry is missing", async () => {
     writeFileSync(join(cwd, ".gitignore"), "node_modules/\n");
-    const first = await scaffold({ cwd, name: "n", template: "minimal" });
+    const first = await scaffold({ cwd, name: "n", template: "triage" });
     const firstEntry = first.files.find((f) => f.path === ".gitignore");
     expect(firstEntry?.action).toBe("patched");
     expect(readFileSync(join(cwd, ".gitignore"), "utf8")).toContain(".arkor/");
 
-    const second = await scaffold({ cwd, name: "n", template: "minimal" });
+    const second = await scaffold({ cwd, name: "n", template: "triage" });
     const secondEntry = second.files.find((f) => f.path === ".gitignore");
     expect(secondEntry?.action).toBe("ok");
   });
@@ -152,7 +152,7 @@ describe("scaffold", () => {
     // e.g. `node_modules/.arkor/`, which git would interpret as a single
     // path pattern.
     writeFileSync(join(cwd, ".gitignore"), "node_modules/");
-    await scaffold({ cwd, name: "n", template: "minimal" });
+    await scaffold({ cwd, name: "n", template: "triage" });
     const contents = readFileSync(join(cwd, ".gitignore"), "utf8");
     expect(contents).toBe("node_modules/\n.arkor/\n");
   });
@@ -166,7 +166,7 @@ describe("scaffold", () => {
     const { files } = await scaffold({
       cwd,
       name: "override-app",
-      template: "minimal",
+      template: "triage",
     });
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),
@@ -190,7 +190,7 @@ describe("scaffold", () => {
       await scaffold({
         cwd,
         name: "blank-override",
-        template: "minimal",
+        template: "triage",
       });
       const pkg = JSON.parse(
         readFileSync(join(cwd, "package.json"), "utf8"),
@@ -223,7 +223,7 @@ describe("scaffold", () => {
     const { files } = await scaffold({
       cwd,
       name: "existing-app",
-      template: "minimal",
+      template: "triage",
     });
     const pkg = JSON.parse(
       readFileSync(join(cwd, "package.json"), "utf8"),
@@ -242,7 +242,7 @@ describe("scaffold", () => {
     const parent = mkdtempSync(join(tmpdir(), "scaffold-fresh-"));
     const fresh = join(parent, "brand-new");
     try {
-      await scaffold({ cwd: fresh, name: "brand-new", template: "minimal" });
+      await scaffold({ cwd: fresh, name: "brand-new", template: "triage" });
       expect(readFileSync(join(fresh, "package.json"), "utf8")).toContain(
         '"brand-new"',
       );
@@ -252,12 +252,12 @@ describe("scaffold", () => {
   });
 
   it("renders each template with a distinct trainer body", async () => {
-    const expectations: Record<"minimal" | "alpaca" | "chatml", string> = {
-      minimal: `"my-first-run"`,
-      alpaca: `"alpaca-run"`,
-      chatml: `"chatml-run"`,
+    const expectations: Record<"triage" | "translate" | "redaction", string> = {
+      triage: `"triage-run"`,
+      translate: `"translate-run"`,
+      redaction: `"redaction-run"`,
     };
-    for (const template of ["minimal", "alpaca", "chatml"] as const) {
+    for (const template of ["triage", "translate", "redaction"] as const) {
       const dir = mkdtempSync(join(tmpdir(), `scaffold-${template}-`));
       await scaffold({ cwd: dir, name: template, template });
       const trainer = readFileSync(join(dir, "src/arkor/trainer.ts"), "utf8");
@@ -324,7 +324,7 @@ describe("resolvePackageManager", () => {
 });
 
 describe("templateChoices", () => {
-  it("exposes only the non-hidden templates with a hint", () => {
+  it("exposes every registered template with a hint", () => {
     const list = templateChoices();
     expect(list.map((t) => t.value).sort()).toEqual([
       "redaction",

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -179,11 +179,9 @@ export function templateChoices(): Array<{
   label: string;
   hint: string;
 }> {
-  return (Object.keys(TEMPLATES) as TemplateId[])
-    .filter((key) => !TEMPLATES[key].hidden)
-    .map((key) => ({
-      value: key,
-      label: TEMPLATES[key].label,
-      hint: TEMPLATES[key].hint,
-    }));
+  return (Object.keys(TEMPLATES) as TemplateId[]).map((key) => ({
+    value: key,
+    label: TEMPLATES[key].label,
+    hint: TEMPLATES[key].hint,
+  }));
 }

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -9,90 +9,14 @@
  *
  * `index.ts` is identical across templates — only the trainer body differs.
  */
-export type TemplateId =
-  | "minimal"
-  | "alpaca"
-  | "chatml"
-  | "redaction"
-  | "translate"
-  | "triage";
+export type TemplateId = "redaction" | "translate" | "triage";
 
 export interface Template {
   label: string;
   hint: string;
   /** Body of `src/arkor/trainer.ts` for this template. */
   trainer: string;
-  /**
-   * When true, the template is excluded from the CLI's interactive prompt and
-   * `templateChoices()` listing. The entry stays in `TEMPLATES` so direct
-   * `scaffold({ template })` calls (e.g. tests) still work, and re-enabling
-   * is a one-line change.
-   */
-  hidden?: boolean;
 }
-
-const MINIMAL_TRAINER = `import { createTrainer } from "arkor";
-
-export const trainer = createTrainer({
-  name: "my-first-run",
-  model: "unsloth/gemma-4-E4B-it",
-  dataset: {
-    type: "huggingface",
-    name: "yahma/alpaca-cleaned",
-    split: "train[:500]",
-  },
-  maxSteps: 50,
-  lora: { r: 16, alpha: 16 },
-  callbacks: {
-    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
-  },
-});
-`;
-
-const ALPACA_TRAINER = `import { createTrainer } from "arkor";
-
-export const trainer = createTrainer({
-  name: "alpaca-run",
-  model: "unsloth/gemma-4-E4B-it",
-  dataset: {
-    type: "huggingface",
-    name: "yahma/alpaca-cleaned",
-    split: "train[:1000]",
-  },
-  datasetFormat: { type: "alpaca" },
-  maxSteps: 100,
-  lora: { r: 16, alpha: 16 },
-  callbacks: {
-    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
-    onCheckpoint: async ({ step, infer }) => {
-      const res = await infer({
-        messages: [{ role: "user", content: "Hello!" }],
-        stream: false,
-      });
-      console.log(\`ckpt @ \${step}:\`, await res.text());
-    },
-  },
-});
-`;
-
-const CHATML_TRAINER = `import { createTrainer } from "arkor";
-
-export const trainer = createTrainer({
-  name: "chatml-run",
-  model: "unsloth/gemma-4-E4B-it",
-  dataset: {
-    type: "huggingface",
-    name: "stingning/ultrachat",
-    split: "train[:500]",
-  },
-  datasetFormat: { type: "chatml" },
-  maxSteps: 100,
-  lora: { r: 16, alpha: 16 },
-  callbacks: {
-    onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
-  },
-});
-`;
 
 // The three demo templates below pair `unsloth/gemma-4-E4B-it` with curated
 // HuggingFace datasets published under the `arkorlab` org. Each dataset is in
@@ -173,26 +97,6 @@ export const TEMPLATES: Record<TemplateId, Template> = {
     label: "Redaction",
     hint: "PII redaction → structured JSON (estimated training: ~12 min)",
     trainer: REDACTION_TRAINER,
-  },
-  // The starter templates below are kept in source for reference but excluded
-  // from the CLI prompt for now. To re-enable, drop the `hidden: true` flag.
-  minimal: {
-    label: "Minimal",
-    hint: "bare createTrainer call",
-    trainer: MINIMAL_TRAINER,
-    hidden: true,
-  },
-  alpaca: {
-    label: "Alpaca",
-    hint: "instruction-tuning + mid-training eval",
-    trainer: ALPACA_TRAINER,
-    hidden: true,
-  },
-  chatml: {
-    label: "ChatML",
-    hint: "multi-turn chat fine-tuning",
-    trainer: CHATML_TRAINER,
-    hidden: true,
   },
 };
 

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -177,9 +177,7 @@ async function run(options: RunOptions): Promise<void> {
       break;
     }
 
-    // An explicit `--template <id>` is treated as authoritative — skip the
-    // prompt so a hidden-but-valid template (e.g. `minimal`) can't be
-    // overwritten by the visible-only options list.
+    // An explicit `--template <id>` is authoritative: skip the prompt and use it as-is.
     if (options.template === undefined) {
       const chosenTemplate = await clack.select<TemplateId>({
         message: "Starter template?",
@@ -313,12 +311,10 @@ program
       if (opts.git && opts.skipGit) {
         throw new Error("Pick one of --git / --skip-git, not both.");
       }
-      // Accept any TEMPLATES key — including hidden ones — so passing
-      // `--template minimal` still scaffolds correctly (per the Template.hidden
-      // JSDoc). Use `Object.hasOwn` (not `in`) so prototype keys like
-      // `toString` / `__proto__` can't pass validation and crash later inside
-      // scaffold(). Reject typos / removed names with an explicit error rather
-      // than silently coercing them to the default.
+      // Use `Object.hasOwn` (not `in`) so prototype keys like `toString` /
+      // `__proto__` can't pass validation and crash later inside scaffold().
+      // Reject typos with an explicit error rather than silently coercing them
+      // to the default.
       let template: TemplateId | undefined;
       if (opts.template !== undefined) {
         if (!Object.hasOwn(TEMPLATES, opts.template)) {


### PR DESCRIPTION
## Summary
- Remove the three deprecated starter templates (`chatml`, `minimal`, `alpaca`) from `@arkor/cli-internal`. They were already excluded from the interactive picker via `Template.hidden` but remained accessible through `--template <id>`; now they are gone entirely.
- Drop the `Template.hidden` field, the `templateChoices()` filter, and CLI comments that referenced the hidden mechanism, since no consumer remains.
- Sync EN + JA `arkor init` docs (option table, dedicated paragraph, Common errors row) and switch unit / e2e tests to the surviving `triage` / `translate` / `redaction` templates.

`datasetFormat: { type: "chatml" }` (used by the surviving demo trainers) and `datasetFormat: "alpaca"` (in SDK trainer tests) are unrelated to the starter-template ids and untouched.

## Test plan
- [x] `pnpm typecheck` (all 6 packages)
- [x] `pnpm --filter arkor test` (327/327)
- [x] `pnpm --filter @arkor/cli-internal test` (scaffold + 4 others green; pre-existing `git.test.ts` signing-fallback failure on `main` is unrelated)
- [x] `pnpm build`
- [x] `SKIP_E2E_INSTALL=1 pnpm --filter @arkor/e2e-cli test` (38/38)
- [x] Manual smoke: `node packages/create-arkor/dist/bin.mjs <name> --template {alpaca,chatml,minimal}` rejects with ``Unknown template "<id>". Available: triage, translate, redaction``; `--template triage` succeeds.