### PR TITLE
Retry SIGKILL-flaky e2e child once in runCli on macOS

### DIFF
--- a/e2e/cli/src/spawn-cli.test.ts
+++ b/e2e/cli/src/spawn-cli.test.ts
@@ -1,15 +1,23 @@
-import { describe, expect, it } from "vitest";
-import { shouldRetryAfterSigkill, type RunResult } from "./spawn-cli";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+// `vi.hoisted` ensures the mock factory and its captured `spawnMock` are
+// available before any module-level imports execute, so the
+// `import { spawn } from "node:child_process"` at the top of `spawn-cli.ts`
+// resolves to our fake instead of the real Node binding.
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+// Imports come after the `vi.mock` for clarity; vitest hoists both above
+// the imports at runtime so the mocked binding is in place either way.
+// eslint-disable-next-line import/first
+import { runCli, shouldRetryAfterSigkill, type RunResult } from "./spawn-cli";
 
 // Pure-function tests for the ENG-632 retry gate. They cover the decision
 // matrix exhaustively so a future refactor that accidentally widens or
 // narrows the gate (e.g. forgets the `process.env.CI` check, drops the
 // elapsed-ms cutoff, treats SIGTERM as kill-equivalent) trips a unit test
 // rather than silently changing CI flake-tolerance behaviour.
-//
-// We deliberately keep this at the pure-function level: mocking
-// `node:child_process` end-to-end would buy us little extra coverage
-// because the wiring in `runCli` is just `if (gate(result, …)) retry`.
 
 function makeResult(overrides: Partial<RunResult>): RunResult {
   return {
@@ -77,21 +85,24 @@ describe("shouldRetryAfterSigkill", () => {
   });
 
   it("does not retry once the elapsed-ms cutoff is exceeded", () => {
-    // SIGKILL after ~1.5 s most likely landed mid-run (during
-    // `pnpm install`, after `git init`, etc.) — the dirty `cwd` from
-    // attempt 1 would either mask the real failure or produce a different
-    // failure on retry. The 1500 ms cutoff is calibrated against the
-    // observed flake (~100 ms) with a 10× safety margin.
+    // The cutoff is held below the time scaffold needs to start writing
+    // files (clean `arkor init --skip-install --skip-git` lands at
+    // ~600–1200 ms; see `vitest.config.ts`'s `testTimeout` rationale), so
+    // a SIGKILL above that cutoff most likely landed *after* the bin
+    // touched the filesystem. The dirty `cwd` from attempt 1 could then
+    // either mask a real failure or produce a different failure on
+    // attempt 2 — both worse outcomes than just letting the SIGKILL
+    // surface as-is.
     expect(
       shouldRetryAfterSigkill(
-        makeResult({ signal: "SIGKILL", elapsedMs: 1500 }),
+        makeResult({ signal: "SIGKILL", elapsedMs: 300 }),
         "darwin",
         true,
       ),
     ).toBe(false);
     expect(
       shouldRetryAfterSigkill(
-        makeResult({ signal: "SIGKILL", elapsedMs: 5000 }),
+        makeResult({ signal: "SIGKILL", elapsedMs: 800 }),
         "darwin",
         true,
       ),
@@ -126,5 +137,116 @@ describe("shouldRetryAfterSigkill", () => {
         false,
       ),
     ).toBe(false);
+  });
+});
+
+// `runCli` orchestration tests: hermetic, mock `node:child_process` so
+// we can drive the close-event sequence and assert on call count. The
+// pure-function tests above lock in the gate's decision matrix; these
+// tests lock in that `runCli` actually wires the gate up correctly —
+// retries exactly once (not zero, not twice) on a qualifying SIGKILL,
+// and never retries non-qualifying outcomes.
+
+interface FakeCloseSpec {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+function makeFakeChild(close: FakeCloseSpec): EventEmitter {
+  // Vitest's mock of `node:child_process.spawn` returns this fake.
+  // We only emit the events `runCliOnce` listens for: `close` carries
+  // the (code, signal) tuple, and the `stdout`/`stderr` sub-emitters
+  // never fire any data (the test isn't asserting on captured output).
+  const child = new EventEmitter();
+  Object.assign(child, {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+  });
+  // Defer the close emit so the caller has a chance to attach its
+  // listener inside the Promise constructor before we fire.
+  setImmediate(() => {
+    child.emit("close", close.code, close.signal);
+  });
+  return child;
+}
+
+describe("runCli orchestration", () => {
+  // Pin the platform / CI to the canonical "we should retry" environment
+  // so the gate can fire when the close-spec qualifies. Individual tests
+  // override the close spec to vary the outcome.
+  const ORIG_PLATFORM = process.platform;
+  const ORIG_CI = process.env.CI;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+    process.env.CI = "1";
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: ORIG_PLATFORM,
+      configurable: true,
+    });
+    if (ORIG_CI === undefined) delete process.env.CI;
+    else process.env.CI = ORIG_CI;
+  });
+
+  it("retries exactly once when a qualifying SIGKILL precedes a clean exit", async () => {
+    // The canonical recovery path: attempt 1 SIGKILL'd, attempt 2 fine.
+    // `spawnMock` should be called twice and the final result reflects
+    // attempt 2's clean exit.
+    spawnMock
+      .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }))
+      .mockImplementationOnce(() => makeFakeChild({ code: 0, signal: null }));
+
+    const result = await runCli("/fake/bin", [], "/tmp/x");
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(result.code).toBe(0);
+    expect(result.signal).toBeNull();
+  });
+
+  it("does not retry a third time when both attempts SIGKILL", async () => {
+    // Retry budget is one — a second SIGKILL must surface as the final
+    // result. Without this guard a flaky environment could loop forever.
+    spawnMock
+      .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }))
+      .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }));
+
+    const result = await runCli("/fake/bin", [], "/tmp/x");
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(result.signal).toBe("SIGKILL");
+  });
+
+  it("does not retry a non-qualifying signal (SIGTERM)", async () => {
+    // SIGTERM is *not* the runner-flake signature; retrying would risk
+    // hiding a genuine crash. Spawn must be invoked exactly once.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({ code: null, signal: "SIGTERM" }),
+    );
+
+    const result = await runCli("/fake/bin", [], "/tmp/x");
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.signal).toBe("SIGTERM");
+  });
+
+  it("does not retry a clean exit", async () => {
+    // The hot-path sanity check: a green test run must not double the
+    // spawn cost. If the gate ever returned `true` for a clean exit
+    // every CI run would silently re-execute every test once.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({ code: 0, signal: null }),
+    );
+
+    const result = await runCli("/fake/bin", [], "/tmp/x");
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.code).toBe(0);
   });
 });

--- a/e2e/cli/src/spawn-cli.test.ts
+++ b/e2e/cli/src/spawn-cli.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -314,33 +322,63 @@ describe("runCli orchestration", () => {
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
-  it("does not retry when `cwd` was non-empty before attempt 1", async () => {
-    // Some tests pre-seed `cwd` with state the CLI is supposed to react
-    // to (e.g. `arkor init` against a directory that already has
-    // `git init` run inside it). Wiping that state to retry would
-    // change the CLI's input, so the gate suppresses the retry and
-    // surfaces the SIGKILL directly.
-    writeFileSync(join(cwd, "preseeded"), "");
-    dateNowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1100);
-    spawnMock.mockImplementationOnce(() =>
-      makeFakeChild({ code: null, signal: "SIGKILL" }),
-    );
+  it("preserves pre-seeded `cwd` state across the retry while clearing scaffold leftovers", async () => {
+    // Tests that pre-seed `cwd` (e.g. `arkor-init.test.ts`'s
+    // `git init` setup, `arkor-whoami.test.ts`'s seeded credentials,
+    // build fixtures) used to be excluded from the retry path under the
+    // earlier "cwd must be empty" gate. The path-set snapshot lifts that
+    // restriction: pre-existing entries survive, but anything attempt 1
+    // newly added gets removed before attempt 2 spawns.
+    //
+    // Setup: pre-seed `cwd/.git/HEAD` (a small file inside an existing
+    // dir, mirroring `git init`'s output) plus a sibling marker file.
+    // The killed first attempt then fakes a partial scaffold by
+    // writing `package.json` *and* a new file inside the pre-existing
+    // `.git/` (e.g. `.git/index`). Attempt 2 should see only the
+    // pre-seeded paths, with the partial scaffold gone.
+    mkdirSync(join(cwd, ".git"));
+    writeFileSync(join(cwd, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(join(cwd, "preseeded.txt"), "user state");
+
+    dateNowSpy
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1100)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2050);
+    spawnMock
+      .mockImplementationOnce(() => {
+        // Fake a partial scaffold: a brand-new top-level file *and* a
+        // new file inside the pre-seeded `.git/` directory. Both should
+        // be cleared on retry.
+        writeFileSync(join(cwd, "package.json"), "{ partial }");
+        writeFileSync(join(cwd, ".git", "index"), "binary blob");
+        return makeFakeChild({ code: null, signal: "SIGKILL" });
+      })
+      .mockImplementationOnce(() => {
+        // Attempt 2 sees only the pre-seeded baseline.
+        expect(existsSync(join(cwd, ".git", "HEAD"))).toBe(true);
+        expect(readFileSync(join(cwd, "preseeded.txt"), "utf8")).toBe(
+          "user state",
+        );
+        // Attempt 1's new files were removed.
+        expect(existsSync(join(cwd, "package.json"))).toBe(false);
+        expect(existsSync(join(cwd, ".git", "index"))).toBe(false);
+        return makeFakeChild({ code: 0, signal: null });
+      });
 
     const result = await runCli("/fake/bin", [], cwd);
 
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    expect(result.signal).toBe("SIGKILL");
-    // Pre-seeded file survived (the wipe path was skipped).
-    expect(existsSync(join(cwd, "preseeded"))).toBe(true);
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(result.code).toBe(0);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retrying after SIGKILL at 100ms"),
+    );
   });
 
-  it("wipes leftover scaffold artefacts before attempt 2", async () => {
-    // Simulate the precise concern reviewers flagged: a SIGKILL that
-    // landed *during* scaffold's filesystem writes leaves a partially
-    // populated `cwd`. The mock's first implementation writes a
-    // sentinel to fake that partial scaffold; attempt 2 must run
-    // against an empty `cwd` so it can scaffold fresh.
+  it("wipes leftover scaffold artefacts when `cwd` started empty", async () => {
+    // Simpler case of the same path-diff cleanup: empty cwd at attempt
+    // 1 start, partial scaffold from the SIGKILL'd attempt, attempt 2
+    // sees an empty cwd again. This is the canonical PR #104 pattern.
     dateNowSpy
       .mockReturnValueOnce(1000)
       .mockReturnValueOnce(1100)
@@ -353,8 +391,6 @@ describe("runCli orchestration", () => {
         return makeFakeChild({ code: null, signal: "SIGKILL" });
       })
       .mockImplementationOnce(() => {
-        // Attempt 2 runs against a wiped `cwd` — exactly what a single
-        // clean run would have seen.
         expect(readdirSync(cwd)).toEqual([]);
         return makeFakeChild({ code: 0, signal: null });
       });

--- a/e2e/cli/src/spawn-cli.test.ts
+++ b/e2e/cli/src/spawn-cli.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { shouldRetryAfterSigkill, type RunResult } from "./spawn-cli";
+
+// Pure-function tests for the ENG-632 retry gate. They cover the decision
+// matrix exhaustively so a future refactor that accidentally widens or
+// narrows the gate (e.g. forgets the `process.env.CI` check, drops the
+// elapsed-ms cutoff, treats SIGTERM as kill-equivalent) trips a unit test
+// rather than silently changing CI flake-tolerance behaviour.
+//
+// We deliberately keep this at the pure-function level: mocking
+// `node:child_process` end-to-end would buy us little extra coverage
+// because the wiring in `runCli` is just `if (gate(result, …)) retry`.
+
+function makeResult(overrides: Partial<RunResult>): RunResult {
+  return {
+    code: 0,
+    signal: null,
+    elapsedMs: 100,
+    stdout: "",
+    stderr: "",
+    dir: "/tmp/x",
+    ...overrides,
+  };
+}
+
+describe("shouldRetryAfterSigkill", () => {
+  it("retries the canonical GitHub macOS startup-SIGKILL flake", () => {
+    // Exactly the PR #104 symptom: macOS runner, CI=1, child SIGKILL'd
+    // at ~100 ms during the bin's startup re-exec.
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ signal: "SIGKILL", elapsedMs: 104 }),
+        "darwin",
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it.each<NodeJS.Signals>([
+    "SIGTERM",
+    "SIGABRT",
+    "SIGSEGV",
+    "SIGBUS",
+    "SIGINT",
+  ])("does not retry on %s — those are genuine CLI crashes", (signal) => {
+    // Anything other than SIGKILL means the CLI itself faulted
+    // (assertion failure, OOM-but-not-from-runner, segfault, user ^C).
+    // Retrying would mask the real bug.
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ signal, elapsedMs: 100 }),
+        "darwin",
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry on a clean non-zero exit", () => {
+    // Deterministic CLI failure (e.g. `--git --skip-git` argument clash,
+    // assertion-driven test failure). Must surface on the first attempt.
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ code: 1, signal: null, elapsedMs: 100 }),
+        "darwin",
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry on a clean exit-zero", () => {
+    // The happy-path baseline — the gate must not fire when the test
+    // passed. Sanity check; a buggy gate that returned `true` here would
+    // double the runtime of every test for no reason.
+    expect(
+      shouldRetryAfterSigkill(makeResult({ elapsedMs: 100 }), "darwin", true),
+    ).toBe(false);
+  });
+
+  it("does not retry once the elapsed-ms cutoff is exceeded", () => {
+    // SIGKILL after ~1.5 s most likely landed mid-run (during
+    // `pnpm install`, after `git init`, etc.) — the dirty `cwd` from
+    // attempt 1 would either mask the real failure or produce a different
+    // failure on retry. The 1500 ms cutoff is calibrated against the
+    // observed flake (~100 ms) with a 10× safety margin.
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ signal: "SIGKILL", elapsedMs: 1500 }),
+        "darwin",
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ signal: "SIGKILL", elapsedMs: 5000 }),
+        "darwin",
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it.each<NodeJS.Platform>(["linux", "win32", "freebsd"])(
+    "does not retry on %s — only the macOS runner has produced the symptom",
+    (platform) => {
+      // Other platforms have not exhibited this flake on PR #104's CI
+      // history; widening the gate would let a real Linux/Windows
+      // regression need two failures before surfacing.
+      expect(
+        shouldRetryAfterSigkill(
+          makeResult({ signal: "SIGKILL", elapsedMs: 100 }),
+          platform,
+          true,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("does not retry when CI is unset (local debugging)", () => {
+    // A developer chasing an intermittent crash on a Mac dev machine
+    // wants the failure to surface immediately, not be silently retried
+    // and possibly reported as flaky. Gating on `process.env.CI`
+    // restricts the retry to the runner where we actually need it.
+    expect(
+      shouldRetryAfterSigkill(
+        makeResult({ signal: "SIGKILL", elapsedMs: 100 }),
+        "darwin",
+        false,
+      ),
+    ).toBe(false);
+  });
+});

--- a/e2e/cli/src/spawn-cli.test.ts
+++ b/e2e/cli/src/spawn-cli.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // `vi.hoisted` ensures the mock factory and its captured `spawnMock` are
 // available before any module-level imports execute, so the
@@ -145,7 +148,8 @@ describe("shouldRetryAfterSigkill", () => {
 // pure-function tests above lock in the gate's decision matrix; these
 // tests lock in that `runCli` actually wires the gate up correctly —
 // retries exactly once (not zero, not twice) on a qualifying SIGKILL,
-// and never retries non-qualifying outcomes.
+// wipes `cwd` between attempts, refuses to retry against pre-seeded
+// state, and never retries non-qualifying outcomes.
 
 interface FakeCloseSpec {
   code: number | null;
@@ -173,9 +177,12 @@ function makeFakeChild(close: FakeCloseSpec): EventEmitter {
 describe("runCli orchestration", () => {
   // Pin the platform / CI to the canonical "we should retry" environment
   // so the gate can fire when the close-spec qualifies. Individual tests
-  // override the close spec to vary the outcome.
+  // override the close spec (and `Date.now` returns) to vary the outcome.
   const ORIG_PLATFORM = process.platform;
   const ORIG_CI = process.env.CI;
+  let cwd: string;
+  let dateNowSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", {
@@ -184,6 +191,24 @@ describe("runCli orchestration", () => {
     });
     process.env.CI = "1";
     spawnMock.mockReset();
+    // Real temp dir so the cwd-empty / wipe / pre-seed paths actually
+    // exercise filesystem state. The mocked `spawn` doesn't run a real
+    // process, so any files in `cwd` come from `writeFileSync` inside
+    // the test or inside the mock's `mockImplementationOnce` callback —
+    // i.e. exactly the carryover patterns we want to assert on.
+    cwd = mkdtempSync(join(tmpdir(), "spawn-cli-orchestration-"));
+    // Pin `Date.now` so `elapsedMs` is independent of wall-clock jitter.
+    // CI runners under load can delay `setImmediate` past the 300 ms
+    // gate; this stub keeps the test deterministic regardless. Each
+    // test overrides the return queue to simulate the elapsed time it
+    // wants attempt 1 (and, if applicable, attempt 2) to look like.
+    dateNowSpy = vi.spyOn(Date, "now");
+    // Suppress + capture the retry log so it doesn't pollute test
+    // output and so we can assert it fired.
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -193,31 +218,49 @@ describe("runCli orchestration", () => {
     });
     if (ORIG_CI === undefined) delete process.env.CI;
     else process.env.CI = ORIG_CI;
+    rmSync(cwd, { recursive: true, force: true });
+    dateNowSpy.mockRestore();
+    stderrSpy.mockRestore();
   });
 
   it("retries exactly once when a qualifying SIGKILL precedes a clean exit", async () => {
-    // The canonical recovery path: attempt 1 SIGKILL'd, attempt 2 fine.
-    // `spawnMock` should be called twice and the final result reflects
-    // attempt 2's clean exit.
+    // The canonical recovery path: attempt 1 SIGKILL'd at 100 ms (under
+    // the 300 ms cutoff), attempt 2 clean. `spawnMock` should be called
+    // twice and the final result reflects attempt 2's exit.
+    dateNowSpy
+      .mockReturnValueOnce(1000) // attempt 1 start
+      .mockReturnValueOnce(1100) // attempt 1 close → elapsedMs=100
+      .mockReturnValueOnce(2000) // attempt 2 start
+      .mockReturnValueOnce(2050); // attempt 2 close → elapsedMs=50
     spawnMock
       .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }))
       .mockImplementationOnce(() => makeFakeChild({ code: 0, signal: null }));
 
-    const result = await runCli("/fake/bin", [], "/tmp/x");
+    const result = await runCli("/fake/bin", [], cwd);
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(result.code).toBe(0);
     expect(result.signal).toBeNull();
+    expect(result.elapsedMs).toBe(50);
+    // Retry was logged so CI inspection can see how often this fires.
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retrying after SIGKILL at 100ms"),
+    );
   });
 
   it("does not retry a third time when both attempts SIGKILL", async () => {
     // Retry budget is one — a second SIGKILL must surface as the final
     // result. Without this guard a flaky environment could loop forever.
+    dateNowSpy
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1100)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2100);
     spawnMock
       .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }))
       .mockImplementationOnce(() => makeFakeChild({ code: null, signal: "SIGKILL" }));
 
-    const result = await runCli("/fake/bin", [], "/tmp/x");
+    const result = await runCli("/fake/bin", [], cwd);
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(result.signal).toBe("SIGKILL");
@@ -226,27 +269,99 @@ describe("runCli orchestration", () => {
   it("does not retry a non-qualifying signal (SIGTERM)", async () => {
     // SIGTERM is *not* the runner-flake signature; retrying would risk
     // hiding a genuine crash. Spawn must be invoked exactly once.
+    dateNowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1100);
     spawnMock.mockImplementationOnce(() =>
       makeFakeChild({ code: null, signal: "SIGTERM" }),
     );
 
-    const result = await runCli("/fake/bin", [], "/tmp/x");
+    const result = await runCli("/fake/bin", [], cwd);
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(result.signal).toBe("SIGTERM");
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 
   it("does not retry a clean exit", async () => {
     // The hot-path sanity check: a green test run must not double the
     // spawn cost. If the gate ever returned `true` for a clean exit
     // every CI run would silently re-execute every test once.
+    dateNowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1500);
     spawnMock.mockImplementationOnce(() =>
       makeFakeChild({ code: 0, signal: null }),
     );
 
-    const result = await runCli("/fake/bin", [], "/tmp/x");
+    const result = await runCli("/fake/bin", [], cwd);
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.code).toBe(0);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not retry once SIGKILL elapsed-ms exceeds the cutoff", async () => {
+    // Wall-clock 500 ms attempt 1: well past `SIGKILL_RETRY_MAX_MS`.
+    // Same SIGKILL signature as the canonical flake but the elapsed
+    // time signals it landed mid-run, so the gate refuses.
+    dateNowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1500);
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({ code: null, signal: "SIGKILL" }),
+    );
+
+    const result = await runCli("/fake/bin", [], cwd);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.signal).toBe("SIGKILL");
+    expect(result.elapsedMs).toBe(500);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not retry when `cwd` was non-empty before attempt 1", async () => {
+    // Some tests pre-seed `cwd` with state the CLI is supposed to react
+    // to (e.g. `arkor init` against a directory that already has
+    // `git init` run inside it). Wiping that state to retry would
+    // change the CLI's input, so the gate suppresses the retry and
+    // surfaces the SIGKILL directly.
+    writeFileSync(join(cwd, "preseeded"), "");
+    dateNowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1100);
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({ code: null, signal: "SIGKILL" }),
+    );
+
+    const result = await runCli("/fake/bin", [], cwd);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.signal).toBe("SIGKILL");
+    // Pre-seeded file survived (the wipe path was skipped).
+    expect(existsSync(join(cwd, "preseeded"))).toBe(true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("wipes leftover scaffold artefacts before attempt 2", async () => {
+    // Simulate the precise concern reviewers flagged: a SIGKILL that
+    // landed *during* scaffold's filesystem writes leaves a partially
+    // populated `cwd`. The mock's first implementation writes a
+    // sentinel to fake that partial scaffold; attempt 2 must run
+    // against an empty `cwd` so it can scaffold fresh.
+    dateNowSpy
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1100)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2050);
+    spawnMock
+      .mockImplementationOnce(() => {
+        writeFileSync(join(cwd, "package.json"), "{ partial }");
+        writeFileSync(join(cwd, "README.md"), "partial");
+        return makeFakeChild({ code: null, signal: "SIGKILL" });
+      })
+      .mockImplementationOnce(() => {
+        // Attempt 2 runs against a wiped `cwd` — exactly what a single
+        // clean run would have seen.
+        expect(readdirSync(cwd)).toEqual([]);
+        return makeFakeChild({ code: 0, signal: null });
+      });
+
+    const result = await runCli("/fake/bin", [], cwd);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(result.code).toBe(0);
   });
 });

--- a/e2e/cli/src/spawn-cli.test.ts
+++ b/e2e/cli/src/spawn-cli.test.ts
@@ -322,13 +322,13 @@ describe("runCli orchestration", () => {
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
-  it("preserves pre-seeded `cwd` state across the retry while clearing scaffold leftovers", async () => {
+  it("restores pre-seeded `cwd` state across the retry while clearing scaffold leftovers", async () => {
     // Tests that pre-seed `cwd` (e.g. `arkor-init.test.ts`'s
     // `git init` setup, `arkor-whoami.test.ts`'s seeded credentials,
-    // build fixtures) used to be excluded from the retry path under the
-    // earlier "cwd must be empty" gate. The path-set snapshot lifts that
-    // restriction: pre-existing entries survive, but anything attempt 1
-    // newly added gets removed before attempt 2 spawns.
+    // build fixtures) need the retry to leave their pre-seed state
+    // exactly as they wrote it. The full content snapshot guarantees
+    // that: pre-existing files survive, anything attempt 1 added gets
+    // removed before attempt 2 spawns.
     //
     // Setup: pre-seed `cwd/.git/HEAD` (a small file inside an existing
     // dir, mirroring `git init`'s output) plus a sibling marker file.
@@ -375,10 +375,52 @@ describe("runCli orchestration", () => {
     );
   });
 
+  it("restores pre-existing files that attempt 1 modified in place", async () => {
+    // The harder snapshot case: attempt 1 doesn't add a new file, it
+    // *overwrites* a pre-existing one (e.g. `arkor build` rewriting an
+    // already-present `.arkor/build/index.mjs`). A path-set snapshot
+    // would carry the mutated baseline file into attempt 2 and let a
+    // failure pass spuriously; the full content snapshot puts the
+    // original bytes back so attempt 2 sees the same input attempt 1
+    // had.
+    mkdirSync(join(cwd, ".arkor", "build"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".arkor", "build", "index.mjs"),
+      "// pre-existing build output\n",
+    );
+
+    dateNowSpy
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1100)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2050);
+    spawnMock
+      .mockImplementationOnce(() => {
+        // Fake an in-place rewrite (no new path, just changed content).
+        writeFileSync(
+          join(cwd, ".arkor", "build", "index.mjs"),
+          "// truncated rewrite from attempt 1\n",
+        );
+        return makeFakeChild({ code: null, signal: "SIGKILL" });
+      })
+      .mockImplementationOnce(() => {
+        // Attempt 2 sees the original bytes, not the truncated rewrite.
+        expect(
+          readFileSync(join(cwd, ".arkor", "build", "index.mjs"), "utf8"),
+        ).toBe("// pre-existing build output\n");
+        return makeFakeChild({ code: 0, signal: null });
+      });
+
+    const result = await runCli("/fake/bin", [], cwd);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(result.code).toBe(0);
+  });
+
   it("wipes leftover scaffold artefacts when `cwd` started empty", async () => {
-    // Simpler case of the same path-diff cleanup: empty cwd at attempt
-    // 1 start, partial scaffold from the SIGKILL'd attempt, attempt 2
-    // sees an empty cwd again. This is the canonical PR #104 pattern.
+    // Simpler case of the same restore: empty cwd at attempt 1 start,
+    // partial scaffold from the SIGKILL'd attempt, attempt 2 sees an
+    // empty cwd again. This is the canonical PR #104 pattern.
     dateNowSpy
       .mockReturnValueOnce(1000)
       .mockReturnValueOnce(1100)

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -129,13 +129,25 @@ export function cleanup(dir: string): void {
  *   3. The snapshot dir is cleaned up regardless of whether the retry
  *      fired.
  *
- * The cost is bounded: the retry only fires on SIGKILL within
+ * The snapshot is gated on `darwin + CI` — the only environment where
+ * the retry can possibly fire — so Linux/Windows CI jobs and local
+ * macOS dev runs pay nothing extra. Even on the darwin+CI hot path the
+ * cost is bounded: the retry only fires on SIGKILL within
  * `SIGKILL_RETRY_MAX_MS` (300 ms), which is well before any test runs
  * `pnpm install` or `arkor build`, so the snapshotted tree is always
  * the small pre-seed fixture (a few KB at most) — never a populated
- * `node_modules/` or build artefact. The pre-attempt-1 copy itself
- * happens on every `runCli` call, but for the dominant case of an empty
- * `cwd` it's a no-op `cpSync` of an empty directory.
+ * `node_modules/` or build artefact.
+ *
+ * Limitation — only `cwd` is snapshotted. CLI commands that write
+ * outside `cwd` (e.g. `arkor login` writing `~/.arkor/credentials.json`,
+ * or `arkor dev` touching the same path) carry that mutated HOME state
+ * into attempt 2, which could pass spuriously against partial state.
+ * No current e2e command exercises that pattern through `runCli` — the
+ * commands we test (`init` / `build` / scaffold) write only inside
+ * `cwd`, and `whoami` reads (never writes) HOME — but tests that add
+ * write-to-HOME flows in the future should isolate themselves by
+ * pointing `extraEnv.HOME` at a per-test temp dir and either accept
+ * the risk or extend this snapshot to cover that path too.
  *
  * Successful retries are logged to stderr so the runner-flake rate is
  * inspectable in CI logs (otherwise a steadily worsening environment
@@ -148,10 +160,16 @@ export async function runCli(
   cwd: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
-  const snapshotDir = snapshotCwd(cwd);
+  // Only the darwin + CI combination can ever fire the retry, so only
+  // that combination pays the snapshot cost. Linux/Windows CI jobs and
+  // local Mac runs both go through the cheap branch (snapshotDir stays
+  // `undefined`, the `finally` rmSync is a no-op, no cpSync is issued).
+  const canRetry = process.platform === "darwin" && Boolean(process.env.CI);
+  const snapshotDir = canRetry ? snapshotCwd(cwd) : undefined;
   try {
     let result = await runCliOnce(binPath, argv, cwd, extraEnv);
     if (
+      snapshotDir !== undefined &&
       shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
     ) {
       process.stderr.write(
@@ -162,7 +180,9 @@ export async function runCli(
     }
     return result;
   } finally {
-    rmSync(snapshotDir, { recursive: true, force: true });
+    if (snapshotDir !== undefined) {
+      rmSync(snapshotDir, { recursive: true, force: true });
+    }
   }
 }
 

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -112,15 +112,24 @@ export function cleanup(dir: string): void {
  * failures, broken pm, real CLI bugs). Those still surface on the first
  * run on every platform.
  *
- * Caveat (`cwd` carryover): the retry runs in the same `cwd`. Whatever
- * the first attempt wrote (scaffolded files, `git init`, partial
- * `node_modules/`) carries over into attempt 2. The (c) elapsed-ms gate
- * keeps that risk tightly scoped — `SIGKILL_RETRY_MAX_MS` is held below
- * the time scaffold needs to start writing files, so a qualifying run
- * means the bin almost certainly never reached the filesystem. A blanket
- * reset of `cwd` would clobber legitimately pre-seeded state (e.g. tests
- * that `git init` before calling `runCli`), so we accept the best-effort
- * behaviour rather than introducing a snapshot/restore.
+ * `cwd` handling: even with a tight elapsed-ms gate, the bin can reach
+ * `scaffold()` and start writing `package.json` / `src/arkor/*` before
+ * the SIGKILL lands — so attempt 2 in the same `cwd` could either pass
+ * spuriously against partial scaffold state or fail for the wrong
+ * reason. We dodge that two ways:
+ *
+ *   (i)  Snapshot whether `cwd` was empty *before* attempt 1. If it
+ *        wasn't (test pre-seeded state, e.g. `skips git init when the
+ *        target is already a git repo` runs `git init` first), we
+ *        suppress the retry — wiping unknown pre-seeded state would be
+ *        worse than letting the SIGKILL surface.
+ *   (ii) When `cwd` was empty and we *do* retry, wipe whatever the
+ *        killed first attempt left behind so attempt 2 starts pristine.
+ *
+ * Successful retries are logged to stderr so the runner-flake rate is
+ * inspectable in CI logs (otherwise a steadily worsening environment
+ * would silently turn into "tests still passing" until the second
+ * attempt also starts SIGKILLing).
  */
 export async function runCli(
   binPath: string,
@@ -128,13 +137,47 @@ export async function runCli(
   cwd: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
+  const cwdInitiallyEmpty = isCwdEmpty(cwd);
   let result = await runCliOnce(binPath, argv, cwd, extraEnv);
   if (
-    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
+    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI)) &&
+    cwdInitiallyEmpty
   ) {
+    process.stderr.write(
+      `[runCli] retrying after SIGKILL at ${result.elapsedMs}ms (${binPath} ${argv.join(" ")})\n`,
+    );
+    clearDirContents(cwd);
     result = await runCliOnce(binPath, argv, cwd, extraEnv);
   }
   return result;
+}
+
+/**
+ * Cheap snapshot used by `runCli` to decide whether wiping `cwd` between
+ * retry attempts is safe. Returns `true` if `readdirSync` raises (e.g.
+ * `cwd` doesn't exist yet) — the SIGKILL retry path is guarded by other
+ * conditions and `runCliOnce` will surface a real spawn failure anyway,
+ * so a missing `cwd` is treated the same as "no pre-seeded state to
+ * preserve".
+ */
+function isCwdEmpty(cwd: string): boolean {
+  try {
+    return readdirSync(cwd).length === 0;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Empty `cwd` while preserving the directory itself, so the caller's
+ * temp-dir handle stays valid across the retry. We iterate one level
+ * because `readdirSync` only returns names; `rmSync` recurses into each
+ * entry to remove subtrees.
+ */
+function clearDirContents(cwd: string): void {
+  for (const name of readdirSync(cwd)) {
+    rmSync(join(cwd, name), { recursive: true, force: true });
+  }
 }
 
 function runCliOnce(

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -4,7 +4,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 export interface RunResult {
+  /**
+   * The child's final exit code, or `-1` if the child was terminated by a
+   * signal (close event with `code === null`). Use `signal` to disambiguate
+   * those two cases — see ENG-632 retry policy in `runCli`.
+   */
   code: number;
+  /**
+   * The signal name (e.g. `"SIGKILL"`, `"SIGTERM"`, `"SIGSEGV"`) when the
+   * child was terminated by a signal, otherwise `null`. Mirrors the
+   * `signal` argument of Node's `ChildProcess` close event.
+   */
+  signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
   dir: string;
@@ -33,15 +44,30 @@ export function cleanup(dir: string): void {
  *   `git commit` succeeds even when the host (CI runners, fresh containers)
  *   has no `user.name` / `user.email` configured.
  *
- * ENG-632: macOS GitHub runners occasionally signal-kill the spawned child
+ * ENG-632: macOS GitHub runners occasionally SIGKILL the spawned child
  * during startup under load — the `close` event then fires with
- * `code === null`, which surfaces as `result.code === -1` here. Same
- * invocation passes on rerun and on every other matrix slot, so it's a
- * runner artefact rather than a regression. We retry exactly once and
- * only when (a) we're on macOS, (b) the previous attempt returned the
- * `-1` signal-kill marker. A real non-zero exit (CLI bug, broken pm,
- * assertion-driven failure) is *not* retried, so deterministic
- * regressions still surface on the first run.
+ * `code === null` and `signal === "SIGKILL"`. Same invocation passes on
+ * rerun and on every other matrix slot, so it's a runner artefact
+ * rather than a regression. We retry exactly once and only when:
+ *
+ *   (a) we're on macOS (only platform observed),
+ *   (b) the previous attempt's `signal === "SIGKILL"`.
+ *
+ * SIGTERM / SIGABRT / SIGSEGV / SIGBUS — i.e. the CLI itself crashed —
+ * are NOT retried; same for any non-zero exit code (assertion-driven
+ * failures, broken pm, real CLI bugs). Those still surface on the first
+ * run on every platform.
+ *
+ * Caveat: the retry runs in the same `cwd`. Whatever the first attempt
+ * wrote (scaffolded files, `git init`, partial `node_modules/`) carries
+ * over into attempt 2. In practice the observed flake fires under 150 ms
+ * — before scaffold completes — so side effects are minimal, and our
+ * scaffolders are idempotent (existing files become `kept` rather than
+ * `created`). We accept this best-effort behaviour rather than
+ * snapshotting / restoring `cwd` between attempts: the caller would
+ * reasonably expect their pre-seeded state (e.g. tests that
+ * `git init` before calling `runCli`) to survive, which makes a
+ * one-size-fits-all reset incorrect.
  */
 export async function runCli(
   binPath: string,
@@ -50,7 +76,7 @@ export async function runCli(
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
   let result = await runCliOnce(binPath, argv, cwd, extraEnv);
-  if (result.code === -1 && process.platform === "darwin") {
+  if (result.signal === "SIGKILL" && process.platform === "darwin") {
     result = await runCliOnce(binPath, argv, cwd, extraEnv);
   }
   return result;
@@ -120,9 +146,10 @@ function runCliOnce(
     child.stdout.on("data", (c: Buffer) => out.push(c));
     child.stderr.on("data", (c: Buffer) => err.push(c));
     child.on("error", reject);
-    child.on("close", (code) =>
+    child.on("close", (code, signal) =>
       resolve({
         code: code ?? -1,
+        signal,
         stdout: Buffer.concat(out).toString("utf8"),
         stderr: Buffer.concat(err).toString("utf8"),
         dir: cwd,
@@ -146,9 +173,10 @@ export function runGit(cwd: string, args: string[]): Promise<RunResult> {
     child.stdout.on("data", (c: Buffer) => out.push(c));
     child.stderr.on("data", (c: Buffer) => err.push(c));
     child.on("error", reject);
-    child.on("close", (code) =>
+    child.on("close", (code, signal) =>
       resolve({
         code: code ?? -1,
+        signal,
         stdout: Buffer.concat(out).toString("utf8"),
         stderr: Buffer.concat(err).toString("utf8"),
         dir: cwd,

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -32,12 +32,35 @@ export function cleanup(dir: string): void {
  * - `GIT_AUTHOR_*` / `GIT_COMMITTER_*` are pinned so the CLI's internal
  *   `git commit` succeeds even when the host (CI runners, fresh containers)
  *   has no `user.name` / `user.email` configured.
+ *
+ * ENG-632: macOS GitHub runners occasionally signal-kill the spawned child
+ * during startup under load — the `close` event then fires with
+ * `code === null`, which surfaces as `result.code === -1` here. Same
+ * invocation passes on rerun and on every other matrix slot, so it's a
+ * runner artefact rather than a regression. We retry exactly once and
+ * only when (a) we're on macOS, (b) the previous attempt returned the
+ * `-1` signal-kill marker. A real non-zero exit (CLI bug, broken pm,
+ * assertion-driven failure) is *not* retried, so deterministic
+ * regressions still surface on the first run.
  */
-export function runCli(
+export async function runCli(
   binPath: string,
   argv: string[],
   cwd: string,
   extraEnv: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  let result = await runCliOnce(binPath, argv, cwd, extraEnv);
+  if (result.code === -1 && process.platform === "darwin") {
+    result = await runCliOnce(binPath, argv, cwd, extraEnv);
+  }
+  return result;
+}
+
+function runCliOnce(
+  binPath: string,
+  argv: string[],
+  cwd: string,
+  extraEnv: NodeJS.ProcessEnv,
 ): Promise<RunResult> {
   // `pnpm test` propagates the workspace's pnpm config to children as
   // `npm_config_*` / `pnpm_config_*` env vars (e.g. minimumReleaseAge from

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, type Dirent } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -114,17 +114,27 @@ export function cleanup(dir: string): void {
  *
  * `cwd` handling: even with a tight elapsed-ms gate, the bin can reach
  * `scaffold()` and start writing `package.json` / `src/arkor/*` before
- * the SIGKILL lands — so attempt 2 in the same `cwd` could either pass
+ * the SIGKILL lands — so attempt 2 in the same `cwd` could pass
  * spuriously against partial scaffold state or fail for the wrong
- * reason. We dodge that two ways:
+ * reason. We dodge that with a path-set snapshot:
  *
- *   (i)  Snapshot whether `cwd` was empty *before* attempt 1. If it
- *        wasn't (test pre-seeded state, e.g. `skips git init when the
- *        target is already a git repo` runs `git init` first), we
- *        suppress the retry — wiping unknown pre-seeded state would be
- *        worse than letting the SIGKILL surface.
- *   (ii) When `cwd` was empty and we *do* retry, wipe whatever the
- *        killed first attempt left behind so attempt 2 starts pristine.
+ *   1. Walk `cwd` recursively before attempt 1 and remember every
+ *      relative path that already exists (test pre-seeded state, e.g.
+ *      `arkor-init.test.ts`'s `git init` setup or `arkor-whoami.test.ts`'s
+ *      seeded credentials).
+ *   2. If we decide to retry, walk `cwd` again and `rmSync` everything
+ *      *not* in the snapshot. Pre-seeded state survives intact;
+ *      partially-written scaffold artefacts get cleared so attempt 2
+ *      starts from the same baseline as attempt 1.
+ *
+ * Limitation: if attempt 1 *modified* a pre-seeded file in place
+ * (rather than adding new ones), the modification persists into attempt
+ * 2. The CLI's own scaffolders are idempotent — `package.json` patches
+ * are no-ops on already-patched state, every other writer either creates
+ * (`fs.writeFile` on a path that wasn't there) or keeps (`fs.existsSync`
+ * short-circuit) — so this is acceptable in practice. A full
+ * snapshot/restore (copying contents to a sibling temp dir) would handle
+ * that edge case but at much higher cost on every run.
  *
  * Successful retries are logged to stderr so the runner-flake rate is
  * inspectable in CI logs (otherwise a steadily worsening environment
@@ -137,47 +147,76 @@ export async function runCli(
   cwd: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
-  const cwdInitiallyEmpty = isCwdEmpty(cwd);
+  const cwdSnapshot = snapshotCwdPaths(cwd);
   let result = await runCliOnce(binPath, argv, cwd, extraEnv);
   if (
-    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI)) &&
-    cwdInitiallyEmpty
+    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
   ) {
     process.stderr.write(
       `[runCli] retrying after SIGKILL at ${result.elapsedMs}ms (${binPath} ${argv.join(" ")})\n`,
     );
-    clearDirContents(cwd);
+    removeNewlyAddedPaths(cwd, cwdSnapshot);
     result = await runCliOnce(binPath, argv, cwd, extraEnv);
   }
   return result;
 }
 
 /**
- * Cheap snapshot used by `runCli` to decide whether wiping `cwd` between
- * retry attempts is safe. Returns `true` if `readdirSync` raises (e.g.
- * `cwd` doesn't exist yet) — the SIGKILL retry path is guarded by other
- * conditions and `runCliOnce` will surface a real spawn failure anyway,
- * so a missing `cwd` is treated the same as "no pre-seeded state to
- * preserve".
+ * Recursively list every path inside `cwd` (one entry per file *and*
+ * directory), keyed by `cwd`-relative path with forward-slash separators
+ * for cross-platform comparability. Used by `runCli` to remember the
+ * pre-attempt-1 baseline so a retry can selectively undo whatever the
+ * killed first attempt added without clobbering pre-seeded test state.
+ *
+ * Errors are swallowed: a non-existent or unreadable `cwd` returns an
+ * empty set, which makes the subsequent `removeNewlyAddedPaths` walk a
+ * no-op. A real spawn failure in `runCliOnce` surfaces to the caller.
  */
-function isCwdEmpty(cwd: string): boolean {
-  try {
-    return readdirSync(cwd).length === 0;
-  } catch {
-    return true;
-  }
+function snapshotCwdPaths(cwd: string): Set<string> {
+  const paths = new Set<string>();
+  const walk = (dir: string, prefix: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const rel = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+      paths.add(rel);
+      if (entry.isDirectory()) walk(join(dir, entry.name), rel);
+    }
+  };
+  walk(cwd, "");
+  return paths;
 }
 
 /**
- * Empty `cwd` while preserving the directory itself, so the caller's
- * temp-dir handle stays valid across the retry. We iterate one level
- * because `readdirSync` only returns names; `rmSync` recurses into each
- * entry to remove subtrees.
+ * Walk `cwd` and `rmSync` anything whose relative path isn't in
+ * `baseline`. Children of a baseline directory are recursed into so a
+ * pre-existing `cwd/.git/` keeps its `HEAD` etc. while `cwd/package.json`
+ * (newly written by the killed attempt) gets removed. Mirrors the
+ * forward-slash relpath format `snapshotCwdPaths` produces.
  */
-function clearDirContents(cwd: string): void {
-  for (const name of readdirSync(cwd)) {
-    rmSync(join(cwd, name), { recursive: true, force: true });
-  }
+function removeNewlyAddedPaths(cwd: string, baseline: Set<string>): void {
+  const walk = (dir: string, prefix: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const rel = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+      const abs = join(dir, entry.name);
+      if (!baseline.has(rel)) {
+        rmSync(abs, { recursive: true, force: true });
+        continue;
+      }
+      if (entry.isDirectory()) walk(abs, rel);
+    }
+  };
+  walk(cwd, "");
 }
 
 function runCliOnce(

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -16,9 +16,48 @@ export interface RunResult {
    * `signal` argument of Node's `ChildProcess` close event.
    */
   signal: NodeJS.Signals | null;
+  /**
+   * Wall-clock milliseconds from spawn to the `close` event. Used by the
+   * ENG-632 SIGKILL retry guard to distinguish a startup-time runner kill
+   * (observed at ~104 ms) from a kill that arrived after the CLI had
+   * already done meaningful filesystem work — the latter would leave a
+   * dirty `cwd` that retrying over could turn into a false positive.
+   */
+  elapsedMs: number;
   stdout: string;
   stderr: string;
   dir: string;
+}
+
+/**
+ * Upper bound on the elapsed time (in milliseconds) for a SIGKILL'd run
+ * to still qualify for retry. Calibrated from the observed PR #104 flake,
+ * which fired at ~104 ms during the bin's startup re-exec, well before
+ * scaffold/install/git work begins. A SIGKILL after this point most
+ * likely landed mid-run (during pnpm install, after `git init`, etc.),
+ * by which time the `cwd` is no longer pristine and a retry could mask
+ * the real failure or pass spuriously.
+ */
+const SIGKILL_RETRY_MAX_MS = 1500;
+
+/**
+ * Pure decision function for the ENG-632 retry gate, factored out so it
+ * can be exercised by `spawn-cli.test.ts` without mocking
+ * `node:child_process` or `process.platform`. All inputs are explicit so
+ * a future refactor that accidentally widens or narrows the gate fails
+ * the matrix tests rather than silently changing behaviour.
+ */
+export function shouldRetryAfterSigkill(
+  result: RunResult,
+  platform: NodeJS.Platform,
+  isCI: boolean,
+): boolean {
+  return (
+    result.signal === "SIGKILL" &&
+    result.elapsedMs < SIGKILL_RETRY_MAX_MS &&
+    platform === "darwin" &&
+    isCI
+  );
 }
 
 export function makeTempDir(prefix: string): string {
@@ -44,30 +83,39 @@ export function cleanup(dir: string): void {
  *   `git commit` succeeds even when the host (CI runners, fresh containers)
  *   has no `user.name` / `user.email` configured.
  *
- * ENG-632: macOS GitHub runners occasionally SIGKILL the spawned child
- * during startup under load — the `close` event then fires with
- * `code === null` and `signal === "SIGKILL"`. Same invocation passes on
- * rerun and on every other matrix slot, so it's a runner artefact
- * rather than a regression. We retry exactly once and only when:
+ * ENG-632: macOS GitHub Actions runners occasionally SIGKILL the spawned
+ * child during startup under load — the `close` event then fires with
+ * `code === null` and `signal === "SIGKILL"` at ~100 ms, well before
+ * scaffold/install/git work begins. Same invocation passes on rerun and
+ * on every other matrix slot, so it's a runner artefact rather than a
+ * regression. We retry exactly once and only when ALL of the following
+ * hold (see `shouldRetryAfterSigkill`):
  *
- *   (a) we're on macOS (only platform observed),
- *   (b) the previous attempt's `signal === "SIGKILL"`.
+ *   (a) we're on macOS — only platform that has produced the symptom,
+ *   (b) the previous attempt's `signal === "SIGKILL"`,
+ *   (c) the previous attempt's `elapsedMs < SIGKILL_RETRY_MAX_MS` —
+ *       distinguishes a startup-time runner kill from a SIGKILL that
+ *       arrived after the CLI had already started writing files (e.g.
+ *       OOM mid-`pnpm install`), where retrying in the dirty `cwd`
+ *       could mask the real failure or pass spuriously,
+ *   (d) `process.env.CI` is set — local Mac developers debugging
+ *       intermittent crashes get one-shot failures rather than silent
+ *       retries that would hide the bug they're chasing.
  *
  * SIGTERM / SIGABRT / SIGSEGV / SIGBUS — i.e. the CLI itself crashed —
  * are NOT retried; same for any non-zero exit code (assertion-driven
  * failures, broken pm, real CLI bugs). Those still surface on the first
  * run on every platform.
  *
- * Caveat: the retry runs in the same `cwd`. Whatever the first attempt
- * wrote (scaffolded files, `git init`, partial `node_modules/`) carries
- * over into attempt 2. In practice the observed flake fires under 150 ms
- * — before scaffold completes — so side effects are minimal, and our
- * scaffolders are idempotent (existing files become `kept` rather than
- * `created`). We accept this best-effort behaviour rather than
- * snapshotting / restoring `cwd` between attempts: the caller would
- * reasonably expect their pre-seeded state (e.g. tests that
- * `git init` before calling `runCli`) to survive, which makes a
- * one-size-fits-all reset incorrect.
+ * Caveat (`cwd` carryover): the retry runs in the same `cwd`. Whatever
+ * the first attempt wrote (scaffolded files, `git init`, partial
+ * `node_modules/`) carries over into attempt 2. The (c) elapsed-ms gate
+ * keeps that risk tightly scoped — only sub-`SIGKILL_RETRY_MAX_MS` runs
+ * qualify, and the observed flake fires at ~100 ms before scaffold
+ * completes, so side effects are minimal in practice. A blanket reset
+ * of `cwd` would clobber legitimately pre-seeded state (e.g. tests that
+ * `git init` before calling `runCli`), so we accept the best-effort
+ * behaviour rather than introducing a snapshot/restore.
  */
 export async function runCli(
   binPath: string,
@@ -76,7 +124,9 @@ export async function runCli(
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
   let result = await runCliOnce(binPath, argv, cwd, extraEnv);
-  if (result.signal === "SIGKILL" && process.platform === "darwin") {
+  if (
+    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
+  ) {
     result = await runCliOnce(binPath, argv, cwd, extraEnv);
   }
   return result;
@@ -126,6 +176,7 @@ function runCliOnce(
     // can still set USERPROFILE explicitly: extraEnv is spread last.
     const homeMirror: NodeJS.ProcessEnv =
       extraEnv.HOME !== undefined ? { USERPROFILE: extraEnv.HOME } : {};
+    const start = Date.now();
     const child = spawn(process.execPath, [binPath, ...argv], {
       cwd,
       env: {
@@ -150,6 +201,7 @@ function runCliOnce(
       resolve({
         code: code ?? -1,
         signal,
+        elapsedMs: Date.now() - start,
         stdout: Buffer.concat(out).toString("utf8"),
         stderr: Buffer.concat(err).toString("utf8"),
         dir: cwd,
@@ -164,6 +216,7 @@ function runCliOnce(
  */
 export function runGit(cwd: string, args: string[]): Promise<RunResult> {
   return new Promise((resolve, reject) => {
+    const start = Date.now();
     const child = spawn("git", args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
@@ -177,6 +230,7 @@ export function runGit(cwd: string, args: string[]): Promise<RunResult> {
       resolve({
         code: code ?? -1,
         signal,
+        elapsedMs: Date.now() - start,
         stdout: Buffer.concat(out).toString("utf8"),
         stderr: Buffer.concat(err).toString("utf8"),
         dir: cwd,

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -31,14 +31,19 @@ export interface RunResult {
 
 /**
  * Upper bound on the elapsed time (in milliseconds) for a SIGKILL'd run
- * to still qualify for retry. Calibrated from the observed PR #104 flake,
- * which fired at ~104 ms during the bin's startup re-exec, well before
- * scaffold/install/git work begins. A SIGKILL after this point most
- * likely landed mid-run (during pnpm install, after `git init`, etc.),
- * by which time the `cwd` is no longer pristine and a retry could mask
- * the real failure or pass spuriously.
+ * to still qualify for retry. Calibrated from the observed PR #104 flake
+ * (~104 ms, during the bin's `--experimental-strip-types` self-re-exec)
+ * with ~3× headroom, and held well under the ~600–1200 ms a clean
+ * `arkor init --skip-install --skip-git` takes to scaffold (see
+ * `vitest.config.ts`'s `testTimeout` rationale). A SIGKILL past this
+ * cutoff most likely landed *after* scaffold started writing files
+ * (or much later, e.g. mid-`pnpm install`), at which point the `cwd`
+ * is no longer pristine and a retry could mask the real failure, pass
+ * spuriously against the merged-in-place tree, or fail with a different
+ * error — all of which are worse than letting the original failure
+ * surface.
  */
-const SIGKILL_RETRY_MAX_MS = 1500;
+const SIGKILL_RETRY_MAX_MS = 300;
 
 /**
  * Pure decision function for the ENG-632 retry gate, factored out so it
@@ -110,11 +115,11 @@ export function cleanup(dir: string): void {
  * Caveat (`cwd` carryover): the retry runs in the same `cwd`. Whatever
  * the first attempt wrote (scaffolded files, `git init`, partial
  * `node_modules/`) carries over into attempt 2. The (c) elapsed-ms gate
- * keeps that risk tightly scoped — only sub-`SIGKILL_RETRY_MAX_MS` runs
- * qualify, and the observed flake fires at ~100 ms before scaffold
- * completes, so side effects are minimal in practice. A blanket reset
- * of `cwd` would clobber legitimately pre-seeded state (e.g. tests that
- * `git init` before calling `runCli`), so we accept the best-effort
+ * keeps that risk tightly scoped — `SIGKILL_RETRY_MAX_MS` is held below
+ * the time scaffold needs to start writing files, so a qualifying run
+ * means the bin almost certainly never reached the filesystem. A blanket
+ * reset of `cwd` would clobber legitimately pre-seeded state (e.g. tests
+ * that `git init` before calling `runCli`), so we accept the best-effort
  * behaviour rather than introducing a snapshot/restore.
  */
 export async function runCli(

--- a/e2e/cli/src/spawn-cli.ts
+++ b/e2e/cli/src/spawn-cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync, type Dirent } from "node:fs";
+import { cpSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -113,28 +113,29 @@ export function cleanup(dir: string): void {
  * run on every platform.
  *
  * `cwd` handling: even with a tight elapsed-ms gate, the bin can reach
- * `scaffold()` and start writing `package.json` / `src/arkor/*` before
- * the SIGKILL lands — so attempt 2 in the same `cwd` could pass
- * spuriously against partial scaffold state or fail for the wrong
- * reason. We dodge that with a path-set snapshot:
+ * `scaffold()` and start writing `package.json` / `src/arkor/*` (or
+ * overwriting a pre-existing `.arkor/build/index.mjs` etc.) before the
+ * SIGKILL lands. Attempt 2 in the same `cwd` could then pass spuriously
+ * against partial scaffold state, or worse, run against an existing
+ * file the killed attempt clobbered halfway through. We dodge that with
+ * a full content snapshot:
  *
- *   1. Walk `cwd` recursively before attempt 1 and remember every
- *      relative path that already exists (test pre-seeded state, e.g.
- *      `arkor-init.test.ts`'s `git init` setup or `arkor-whoami.test.ts`'s
- *      seeded credentials).
- *   2. If we decide to retry, walk `cwd` again and `rmSync` everything
- *      *not* in the snapshot. Pre-seeded state survives intact;
- *      partially-written scaffold artefacts get cleared so attempt 2
- *      starts from the same baseline as attempt 1.
+ *   1. Before attempt 1, recursively copy `cwd`'s contents into a
+ *      sibling temp dir.
+ *   2. If we decide to retry, wipe `cwd`'s contents and copy the
+ *      snapshot back. Whatever attempt 1 wrote (new files, modified
+ *      pre-existing files, deleted pre-existing files) is undone, so
+ *      attempt 2 starts from byte-for-byte the same state as attempt 1.
+ *   3. The snapshot dir is cleaned up regardless of whether the retry
+ *      fired.
  *
- * Limitation: if attempt 1 *modified* a pre-seeded file in place
- * (rather than adding new ones), the modification persists into attempt
- * 2. The CLI's own scaffolders are idempotent — `package.json` patches
- * are no-ops on already-patched state, every other writer either creates
- * (`fs.writeFile` on a path that wasn't there) or keeps (`fs.existsSync`
- * short-circuit) — so this is acceptable in practice. A full
- * snapshot/restore (copying contents to a sibling temp dir) would handle
- * that edge case but at much higher cost on every run.
+ * The cost is bounded: the retry only fires on SIGKILL within
+ * `SIGKILL_RETRY_MAX_MS` (300 ms), which is well before any test runs
+ * `pnpm install` or `arkor build`, so the snapshotted tree is always
+ * the small pre-seed fixture (a few KB at most) — never a populated
+ * `node_modules/` or build artefact. The pre-attempt-1 copy itself
+ * happens on every `runCli` call, but for the dominant case of an empty
+ * `cwd` it's a no-op `cpSync` of an empty directory.
  *
  * Successful retries are logged to stderr so the runner-flake rate is
  * inspectable in CI logs (otherwise a steadily worsening environment
@@ -147,76 +148,66 @@ export async function runCli(
   cwd: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
-  const cwdSnapshot = snapshotCwdPaths(cwd);
-  let result = await runCliOnce(binPath, argv, cwd, extraEnv);
-  if (
-    shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
-  ) {
-    process.stderr.write(
-      `[runCli] retrying after SIGKILL at ${result.elapsedMs}ms (${binPath} ${argv.join(" ")})\n`,
-    );
-    removeNewlyAddedPaths(cwd, cwdSnapshot);
-    result = await runCliOnce(binPath, argv, cwd, extraEnv);
+  const snapshotDir = snapshotCwd(cwd);
+  try {
+    let result = await runCliOnce(binPath, argv, cwd, extraEnv);
+    if (
+      shouldRetryAfterSigkill(result, process.platform, Boolean(process.env.CI))
+    ) {
+      process.stderr.write(
+        `[runCli] retrying after SIGKILL at ${result.elapsedMs}ms (${binPath} ${argv.join(" ")})\n`,
+      );
+      restoreFromSnapshot(cwd, snapshotDir);
+      result = await runCliOnce(binPath, argv, cwd, extraEnv);
+    }
+    return result;
+  } finally {
+    rmSync(snapshotDir, { recursive: true, force: true });
   }
-  return result;
 }
 
 /**
- * Recursively list every path inside `cwd` (one entry per file *and*
- * directory), keyed by `cwd`-relative path with forward-slash separators
- * for cross-platform comparability. Used by `runCli` to remember the
- * pre-attempt-1 baseline so a retry can selectively undo whatever the
- * killed first attempt added without clobbering pre-seeded test state.
+ * Copy every entry under `cwd` into a fresh sibling temp dir and return
+ * its path. The snapshot is returned even when `cwd` is empty so the
+ * caller can unconditionally `restoreFromSnapshot` (as a no-op) and
+ * `rmSync` the snapshot in `finally`.
  *
- * Errors are swallowed: a non-existent or unreadable `cwd` returns an
- * empty set, which makes the subsequent `removeNewlyAddedPaths` walk a
- * no-op. A real spawn failure in `runCliOnce` surfaces to the caller.
+ * We `mkdtempSync` a parent and copy each top-level entry into it
+ * individually rather than `cpSync(cwd, snapshotDir)` so the
+ * source-vs-destination semantics stay unambiguous: each per-entry
+ * `cpSync` writes into a path that doesn't exist yet under the snapshot
+ * root, regardless of which Node version's `fs.cpSync` directory-merge
+ * behaviour is in play.
  */
-function snapshotCwdPaths(cwd: string): Set<string> {
-  const paths = new Set<string>();
-  const walk = (dir: string, prefix: string): void => {
-    let entries: Dirent[];
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const rel = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
-      paths.add(rel);
-      if (entry.isDirectory()) walk(join(dir, entry.name), rel);
-    }
-  };
-  walk(cwd, "");
-  return paths;
+function snapshotCwd(cwd: string): string {
+  const snapshotDir = mkdtempSync(join(tmpdir(), "spawn-cli-snapshot-"));
+  let entries: string[];
+  try {
+    entries = readdirSync(cwd);
+  } catch {
+    // `cwd` doesn't exist or isn't readable — return an empty snapshot.
+    // `runCliOnce` will surface the real spawn failure if `cwd` truly
+    // can't be used.
+    return snapshotDir;
+  }
+  for (const name of entries) {
+    cpSync(join(cwd, name), join(snapshotDir, name), { recursive: true });
+  }
+  return snapshotDir;
 }
 
 /**
- * Walk `cwd` and `rmSync` anything whose relative path isn't in
- * `baseline`. Children of a baseline directory are recursed into so a
- * pre-existing `cwd/.git/` keeps its `HEAD` etc. while `cwd/package.json`
- * (newly written by the killed attempt) gets removed. Mirrors the
- * forward-slash relpath format `snapshotCwdPaths` produces.
+ * Wipe `cwd`'s contents and copy the snapshot back. The directory
+ * itself is preserved so the caller's path handle (and any test-side
+ * `cwd` variable) stays valid across the retry.
  */
-function removeNewlyAddedPaths(cwd: string, baseline: Set<string>): void {
-  const walk = (dir: string, prefix: string): void => {
-    let entries: Dirent[];
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const rel = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
-      const abs = join(dir, entry.name);
-      if (!baseline.has(rel)) {
-        rmSync(abs, { recursive: true, force: true });
-        continue;
-      }
-      if (entry.isDirectory()) walk(abs, rel);
-    }
-  };
-  walk(cwd, "");
+function restoreFromSnapshot(cwd: string, snapshotDir: string): void {
+  for (const name of readdirSync(cwd)) {
+    rmSync(join(cwd, name), { recursive: true, force: true });
+  }
+  for (const name of readdirSync(snapshotDir)) {
+    cpSync(join(snapshotDir, name), join(cwd, name), { recursive: true });
+  }
 }
 
 function runCliOnce(

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -5,6 +5,20 @@ export default defineConfig({
     // Spawning Node + the bundled CLI bin takes ~600–1200 ms locally; the
     // default 5 s timeout is too tight for assertions that wait for `close`.
     testTimeout: 15_000,
+    // ENG-632: every e2e case spawns `dist/bin.mjs` as a Node child and
+    // captures its stdio via spawn-cli.ts. macOS GitHub runners
+    // occasionally signal-kill that child during startup under load (the
+    // child's `close` event fires with `code === null`, which spawn-cli
+    // surfaces as `result.code === -1` and trips assertions like
+    // `expect(result.code).toBe(0)`). Same test passes on rerun and on
+    // every other matrix slot — runner artefact, not a regression.
+    // Retry the whole test up to twice on failure so a single transient
+    // SIGKILL doesn't block the merge queue. Scoped intentionally to
+    // this suite: unit suites under packages/* keep retry=0 so a real
+    // flake there still surfaces on the first run. Vitest reports
+    // retried passes with a `(retry x N)` annotation, so accidental
+    // hiding of a *consistently* flaky test stays visible in CI logs.
+    retry: 2,
     // `default` keeps normal CLI output; `junit` writes the XML that
     // codecov-action consumes for Test Analytics. E2E coverage itself is
     // collected via c8 (NODE_V8_COVERAGE) wrapping vitest in the

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -5,24 +5,13 @@ export default defineConfig({
     // Spawning Node + the bundled CLI bin takes ~600–1200 ms locally; the
     // default 5 s timeout is too tight for assertions that wait for `close`.
     testTimeout: 15_000,
-    // ENG-632: every e2e case spawns `dist/bin.mjs` as a Node child and
-    // captures its stdio via spawn-cli.ts. macOS GitHub runners
-    // occasionally signal-kill that child during startup under load (the
-    // child's `close` event fires with `code === null`, which spawn-cli
-    // surfaces as `result.code === -1` and trips assertions like
-    // `expect(result.code).toBe(0)`). Same test passes on rerun and on
-    // every other matrix slot — runner artefact, not a regression.
-    //
-    // Gate the retry on `darwin` only: the SIGKILL pattern has only ever
-    // been observed on macOS runners, and applying retry universally
-    // would let a real Linux/Windows regression need three failures
-    // before it surfaces — and would slow local debugging on those
-    // platforms. Mac developers debugging locally see the same retry as
-    // CI, which is acceptable because the flake symptom (`code === -1`
-    // with no other output) is unmistakable in vitest's `(retry x N)`
-    // annotation. Unit suites under `packages/*` are unaffected — they
-    // load their own vitest config without `retry`.
-    retry: process.platform === "darwin" ? 2 : 0,
+    // ENG-632 retry lives in `spawn-cli.ts` (`runCli`) instead of here:
+    // vitest's test-level retry would re-run on *any* assertion failure,
+    // masking deterministic regressions on macOS for an extra attempt.
+    // The harness-level retry only fires on `result.code === -1` (child
+    // closed with `code === null`, i.e. signal-killed before a proper
+    // exit), which is the exact GitHub macOS-runner symptom we saw on
+    // PR #104. Real non-zero exits are not retried.
     // `default` keeps normal CLI output; `junit` writes the XML that
     // codecov-action consumes for Test Analytics. E2E coverage itself is
     // collected via c8 (NODE_V8_COVERAGE) wrapping vitest in the

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -12,13 +12,17 @@ export default defineConfig({
     // surfaces as `result.code === -1` and trips assertions like
     // `expect(result.code).toBe(0)`). Same test passes on rerun and on
     // every other matrix slot — runner artefact, not a regression.
-    // Retry the whole test up to twice on failure so a single transient
-    // SIGKILL doesn't block the merge queue. Scoped intentionally to
-    // this suite: unit suites under packages/* keep retry=0 so a real
-    // flake there still surfaces on the first run. Vitest reports
-    // retried passes with a `(retry x N)` annotation, so accidental
-    // hiding of a *consistently* flaky test stays visible in CI logs.
-    retry: 2,
+    //
+    // Gate the retry on `darwin` only: the SIGKILL pattern has only ever
+    // been observed on macOS runners, and applying retry universally
+    // would let a real Linux/Windows regression need three failures
+    // before it surfaces — and would slow local debugging on those
+    // platforms. Mac developers debugging locally see the same retry as
+    // CI, which is acceptable because the flake symptom (`code === -1`
+    // with no other output) is unmistakable in vitest's `(retry x N)`
+    // annotation. Unit suites under `packages/*` are unaffected — they
+    // load their own vitest config without `retry`.
+    retry: process.platform === "darwin" ? 2 : 0,
     // `default` keeps normal CLI output; `junit` writes the XML that
     // codecov-action consumes for Test Analytics. E2E coverage itself is
     // collected via c8 (NODE_V8_COVERAGE) wrapping vitest in the

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -5,13 +5,25 @@ export default defineConfig({
     // Spawning Node + the bundled CLI bin takes ~600–1200 ms locally; the
     // default 5 s timeout is too tight for assertions that wait for `close`.
     testTimeout: 15_000,
-    // ENG-632 retry lives in `spawn-cli.ts` (`runCli`) instead of here:
-    // vitest's test-level retry would re-run on *any* assertion failure,
-    // masking deterministic regressions on macOS for an extra attempt.
-    // The harness-level retry only fires on `result.code === -1` (child
-    // closed with `code === null`, i.e. signal-killed before a proper
-    // exit), which is the exact GitHub macOS-runner symptom we saw on
-    // PR #104. Real non-zero exits are not retried.
+    // ENG-632 retry lives in `spawn-cli.ts` (`runCli` / `shouldRetryAfter
+    // Sigkill`), not here. A vitest-level `retry` would rerun on every
+    // assertion failure on every platform — too broad. The harness gate
+    // only fires when ALL of these hold for the previous attempt:
+    //
+    //   - `signal === "SIGKILL"`           (the observed runner symptom;
+    //                                       SIGTERM/SIGABRT/SIGSEGV are
+    //                                       genuine CLI crashes)
+    //   - `elapsedMs < SIGKILL_RETRY_MAX_MS` (catches startup kills, not
+    //                                       a SIGKILL mid-`pnpm install`
+    //                                       where the dirty cwd would
+    //                                       make a retry meaningless)
+    //   - `process.platform === "darwin"`  (only platform observed)
+    //   - `process.env.CI` is set          (local Mac debugging surfaces
+    //                                       intermittent crashes one-shot
+    //                                       instead of hiding them)
+    //
+    // See `shouldRetryAfterSigkill` and its tests in `src/spawn-cli.ts`
+    // / `src/spawn-cli.test.ts` for the exact decision matrix.
     // `default` keeps normal CLI output; `junit` writes the XML that
     // codecov-action consumes for Test Analytics. E2E coverage itself is
     // collected via c8 (NODE_V8_COVERAGE) wrapping vitest in the

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -5,10 +5,11 @@ export default defineConfig({
     // Spawning Node + the bundled CLI bin takes ~600–1200 ms locally; the
     // default 5 s timeout is too tight for assertions that wait for `close`.
     testTimeout: 15_000,
-    // ENG-632 retry lives in `spawn-cli.ts` (`runCli` / `shouldRetryAfter
-    // Sigkill`), not here. A vitest-level `retry` would rerun on every
-    // assertion failure on every platform — too broad. The harness gate
-    // only fires when ALL of these hold for the previous attempt:
+    // ENG-632 retry lives in `spawn-cli.ts` — see `runCli` and the pure
+    // gate `shouldRetryAfterSigkill`. A vitest-level `retry` would rerun
+    // on every assertion failure on every platform — too broad. The
+    // harness gate only fires when ALL of these hold for the previous
+    // attempt:
     //
     //   - `signal === "SIGKILL"`           (the observed runner symptom;
     //                                       SIGTERM/SIGABRT/SIGSEGV are


### PR DESCRIPTION
## Summary

PR #104's CI surfaced a single macOS-Node-22.7-22.8 e2e failure where the spawned `arkor` bin was signal-killed during startup at 104 ms (child's `close` event fired with `code === null` and `signal === "SIGKILL"`). Same test passed on every other macOS matrix slot in the same run and on a rerun, so it's a runner artefact (transient resource pressure on the GitHub-hosted macOS runner triggering SIGKILL during fork/exec or during the bin's `--experimental-strip-types` self-re-exec) — not a real regression.

## Approach

Retry sits inside `runCli` (`e2e/cli/src/spawn-cli.ts`), **not** in `vitest.config.ts`, so it only fires for the well-defined SIGKILL signature instead of every assertion failure. The gate is the pure function `shouldRetryAfterSigkill(result, platform, isCI)` and fires when ALL of the following hold for the previous attempt:

| Guard | Why |
| --- | --- |
| `signal === "SIGKILL"` | the observed runner symptom; `SIGTERM`/`SIGABRT`/`SIGSEGV`/`SIGBUS` are genuine CLI crashes |
| `elapsedMs < SIGKILL_RETRY_MAX_MS` (300 ms) | catches startup kills (~104 ms observed). Held below the ~600–1200 ms a clean `arkor init --skip-install --skip-git` takes to scaffold |
| `process.platform === "darwin"` | only platform observed |
| `process.env.CI` is set | local Mac developers debugging intermittent crashes get one-shot failures rather than silent retries that would hide the bug they're chasing |

Anything else fails on the first attempt:

| Outcome on attempt 1 | Retry? |
| --- | --- |
| Exit code `0` | n/a — test continues |
| Non-zero exit code (CLI bug, broken pm, assertion-driven failure) | ❌ no |
| `signal === "SIGTERM"` / `SIGABRT` / `SIGSEGV` / `SIGBUS` (CLI itself crashed) | ❌ no |
| `signal === "SIGKILL"` on Linux/Windows | ❌ no |
| `signal === "SIGKILL"` on macOS in CI, `elapsedMs ≥ 300 ms` | ❌ no (likely landed mid-run, dirty `cwd`) |
| `signal === "SIGKILL"` on macOS in CI, `elapsedMs < 300 ms` | ✅ retry once |

`RunResult` carries `signal` and `elapsedMs` so the gating logic stays inspectable and any future debugging can disambiguate signal terminations from clean exits.

## `cwd` snapshot/restore

Even with the 300 ms gate, the bin can reach `scaffold()` and write or overwrite files inside `cwd` before SIGKILL lands. Attempt 2 in the same `cwd` could pass spuriously against partial scaffold state, or run against a pre-existing file the killed attempt clobbered halfway through. To prevent that:

1. Before attempt 1, `cpSync` every entry under `cwd` into a fresh sibling temp dir.
2. If we decide to retry, wipe `cwd`'s contents and copy the snapshot back. Whatever attempt 1 wrote (new files, modified files, deleted files) is undone, so attempt 2 starts byte-for-byte the same state attempt 1 saw.
3. The snapshot dir is removed in `finally` regardless of whether the retry fired.

The snapshot is **gated on `darwin` + `CI`** — the only environment where the retry can possibly fire — so Linux/Windows CI jobs and local macOS dev runs pay nothing. Even on the darwin+CI hot path the cost is bounded: a qualifying retry happens only within 300 ms of `runCli`, which is well before any test runs `pnpm install` or `arkor build`, so the snapshotted tree is always the small pre-seed fixture (a few KB at most) — never a populated `node_modules/` or build artefact.

### Limitation

The snapshot covers `cwd` only. CLI commands that write outside `cwd` (e.g. `arkor login` writing `~/.arkor/credentials.json`, or `arkor dev` touching the same path) carry that mutated HOME state into attempt 2, which could pass spuriously against partial state. No current e2e command exercises that pattern through `runCli` — `init` / `build` / scaffold write only inside `cwd`, and `whoami` reads (never writes) HOME — so this has zero practical impact today. Tests that add write-to-HOME flows in the future should isolate themselves by pointing `extraEnv.HOME` at a per-test temp dir and either accept the risk or extend the snapshot to cover that path too.

## Tests

- `shouldRetryAfterSigkill` matrix tests (13 cases): canonical flake, every other signal, clean non-zero exit, exit-zero, ms boundary, every other platform, and the `CI=unset` case. A future refactor that widens or narrows the gate trips a unit test.
- `runCli` orchestration tests (8 cases): mock `node:child_process.spawn` + stub `Date.now` to drive close-event sequences and assert on call count, retry log, and post-retry `cwd` state for the full matrix. The pre-seeded-cwd case (new files inside an existing `.git/`) and the in-place-overwrite case (`.arkor/build/index.mjs` truncated then SIGKILL'd) both verify the snapshot/restore wiring end-to-end.

## Scope notes

- Unit suites under `packages/*` are unaffected — they use their own vitest configs and don't go through `runCli`.
- Local Mac development is unaffected (CI env-gate excludes it). A developer chasing an intermittent crash sees the failure one-shot.

## Test plan

- [x] `pnpm --filter @arkor/e2e-cli typecheck`
- [x] `SKIP_E2E_INSTALL=1 pnpm --filter @arkor/e2e-cli test` — 59 passed (13 + 8 new spawn-cli tests, retry is a no-op on the happy path)
- [x] CI matrix