### PR TITLE
feat(cli): align runtime hint and scaffolded READMEs with script-form convention

### DIFF
--- a/e2e/cli/src/arkor-init.test.ts
+++ b/e2e/cli/src/arkor-init.test.ts
@@ -85,10 +85,10 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("pnpm install");
-    expect(result.stdout).toContain("pnpm arkor dev");
+    expect(result.stdout).toContain("pnpm dev");
   });
 
-  it("renders the npm next-steps (npx for run) when --use-npm is set", async () => {
+  it("renders the npm next-steps (npm run for scripts) when --use-npm is set", async () => {
     const result = await runCli(
       ARKOR_BIN,
       ["init", "-y", "--skip-install", "--skip-git", "--use-npm"],
@@ -96,12 +96,12 @@ describe("arkor init (E2E)", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("npm install");
-    expect(result.stdout).toContain("npx arkor dev");
+    expect(result.stdout).toContain("npm run dev");
   });
 
   it.each([
-    { pm: "yarn", devCmd: "yarn arkor dev" },
-    { pm: "bun", devCmd: "bun arkor dev" },
+    { pm: "yarn", devCmd: "yarn dev" },
+    { pm: "bun", devCmd: "bun dev" },
   ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, devCmd }) => {
     const result = await runCli(
       ARKOR_BIN,

--- a/e2e/cli/src/arkor-init.test.ts
+++ b/e2e/cli/src/arkor-init.test.ts
@@ -71,9 +71,12 @@ describe("arkor init (E2E)", () => {
     expect(existsSync(join(cwd, "arkor.config.ts"))).toBe(true);
 
     expect(result.stdout).toContain("Next:");
-    // pm undefined → manual install hint surfaces in the outro.
+    // pm undefined → both manual install + manual dev hints surface in the outro.
     expect(result.stdout).toContain(
       "install dependencies (npm i / pnpm install / yarn / bun install)",
+    );
+    expect(result.stdout).toContain(
+      "run dev (npm run dev / pnpm dev / yarn dev / bun dev)",
     );
   });
 

--- a/e2e/cli/src/arkor-init.test.ts
+++ b/e2e/cli/src/arkor-init.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, join } from "node:path";
 import { ARKOR_BIN } from "./bins";
 import { cleanup, makeTempDir, runCli, runGit } from "./spawn-cli";
@@ -114,6 +121,29 @@ describe("arkor init (E2E)", () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toContain(`${pm} install`);
     expect(result.stdout).toContain(devCmd);
+  });
+
+  it("falls back to a runner-form dev hint when an existing `dev` script is preserved", async () => {
+    // Existing project with its own `dev` script (e.g. a Next.js app). The
+    // scaffolder must not clobber `scripts.dev`, so the runtime hint should
+    // point at `arkor dev` directly via the package manager runner instead
+    // of `pnpm dev` (which would re-run the user's pre-existing script).
+    writeFileSync(
+      join(cwd, "package.json"),
+      `${JSON.stringify(
+        { name: "host", private: true, scripts: { dev: "next dev" } },
+        null,
+        2,
+      )}\n`,
+    );
+    const result = await runCli(
+      ARKOR_BIN,
+      ["init", "-y", "--skip-install", "--skip-git", "--use-pnpm"],
+      cwd,
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("pnpm exec arkor dev");
+    expect(result.stdout).not.toMatch(/Next:.*`pnpm dev`/);
   });
 
   it("creates a real git repo and initial commit when --git is set", async () => {

--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -103,10 +103,12 @@ describe("create-arkor (E2E)", () => {
     );
     expect(trainer).toContain("createTrainer");
 
-    // No `--use-*` and CI=1 → pm undefined → manual install hint + `npm run dev` fallback.
-    expect(result.stdout).toContain("npm run dev");
+    // No `--use-*` and CI=1 → pm undefined → both manual install + manual dev hints fire.
     expect(result.stdout).toContain(
       "install dependencies (npm i / pnpm install / yarn / bun install)",
+    );
+    expect(result.stdout).toContain(
+      "run dev (npm run dev / pnpm dev / yarn dev / bun dev)",
     );
   });
 

--- a/e2e/cli/src/create-arkor.test.ts
+++ b/e2e/cli/src/create-arkor.test.ts
@@ -103,8 +103,8 @@ describe("create-arkor (E2E)", () => {
     );
     expect(trainer).toContain("createTrainer");
 
-    // No `--use-*` and CI=1 → pm undefined → manual install hint + npx dev.
-    expect(result.stdout).toContain("npx arkor dev");
+    // No `--use-*` and CI=1 → pm undefined → manual install hint + `npm run dev` fallback.
+    expect(result.stdout).toContain("npm run dev");
     expect(result.stdout).toContain(
       "install dependencies (npm i / pnpm install / yarn / bun install)",
     );
@@ -119,10 +119,10 @@ describe("create-arkor (E2E)", () => {
     ]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("pnpm install");
-    expect(result.stdout).toContain("pnpm arkor dev");
+    expect(result.stdout).toContain("pnpm dev");
   });
 
-  it("renders the npm next-steps (npx for run) when --use-npm is set", async () => {
+  it("renders the npm next-steps (npm run for scripts) when --use-npm is set", async () => {
     const { result } = await runCreateArkor([
       "-y",
       "--skip-install",
@@ -131,13 +131,13 @@ describe("create-arkor (E2E)", () => {
     ]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("npm install");
-    // npm forces `npx arkor` since `npm arkor` isn't a thing.
-    expect(result.stdout).toContain("npx arkor dev");
+    // npm needs `npm run <script>` since `npm <script>` isn't a thing.
+    expect(result.stdout).toContain("npm run dev");
   });
 
   it.each([
-    { pm: "yarn", devCmd: "yarn arkor dev" },
-    { pm: "bun", devCmd: "bun arkor dev" },
+    { pm: "yarn", devCmd: "yarn dev" },
+    { pm: "bun", devCmd: "bun dev" },
   ])("renders the $pm next-steps when --use-$pm is set", async ({ pm, devCmd }) => {
     const { result } = await runCreateArkor([
       "-y",

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -3,6 +3,10 @@ import {
   gitInitialCommit,
   install,
   isInGitRepo,
+  MANUAL_DEV_HINT,
+  MANUAL_INSTALL_HINT,
+  MANUAL_RUN_ARKOR_DEV_HINT,
+  runArkorDevViaPm,
   sanitise,
   scaffold,
   TEMPLATES,
@@ -29,32 +33,6 @@ export interface InitOptions {
   git?: boolean;
   /** `true` when the user explicitly passed `--skip-git` (no prompt, no init). */
   skipGit?: boolean;
-}
-
-const MANUAL_INSTALL_HINT =
-  "install dependencies (npm i / pnpm install / yarn / bun install)";
-
-const MANUAL_DEV_HINT =
-  "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
-
-// Used when the project's `dev` script was preserved by the scaffolder and
-// points at something other than `arkor dev` (e.g. an existing `next dev`).
-// Suggest invoking the local arkor binary directly via the package manager
-// runner so the user does not accidentally launch their pre-existing app.
-const MANUAL_RUN_ARKOR_DEV_HINT =
-  "run arkor dev (npx arkor dev / pnpm exec arkor dev / yarn run arkor dev / bunx arkor dev)";
-
-function runArkorDevViaPm(pm: PackageManager): string {
-  switch (pm) {
-    case "npm":
-      return "npx arkor dev";
-    case "pnpm":
-      return "pnpm exec arkor dev";
-    case "yarn":
-      return "yarn run arkor dev";
-    case "bun":
-      return "bunx arkor dev";
-  }
 }
 
 /**

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -34,6 +34,9 @@ export interface InitOptions {
 const MANUAL_INSTALL_HINT =
   "install dependencies (npm i / pnpm install / yarn / bun install)";
 
+const MANUAL_DEV_HINT =
+  "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
+
 /**
  * Decide whether to run `git init` + initial commit, surfacing the prompt
  * upfront so the user doesn't sit at an interactive question after the long
@@ -167,13 +170,16 @@ export async function runInit(options: InitOptions): Promise<void> {
 
   if (shouldInitGit) await runGitInit(cwd);
 
-  const devCmd =
-    pm && pm !== "npm" ? `${pm} dev` : "npm run dev";
+  const devHint = pm
+    ? pm === "npm"
+      ? "`npm run dev`"
+      : `\`${pm} dev\``
+    : MANUAL_DEV_HINT;
   ui.outro(
     installed
-      ? `Next: \`${devCmd}\``
+      ? `Next: ${devHint}`
       : pm
-        ? `Next: \`${pm} install\`, then \`${devCmd}\``
-        : `Next: ${MANUAL_INSTALL_HINT}, then \`${devCmd}\``,
+        ? `Next: \`${pm} install\`, then ${devHint}`
+        : `Next: ${MANUAL_INSTALL_HINT}, then ${devHint}`,
   );
 }

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -168,7 +168,7 @@ export async function runInit(options: InitOptions): Promise<void> {
   if (shouldInitGit) await runGitInit(cwd);
 
   const devCmd =
-    pm && pm !== "npm" ? `${pm} arkor dev` : "npx arkor dev";
+    pm && pm !== "npm" ? `${pm} dev` : "npm run dev";
   ui.outro(
     installed
       ? `Next: \`${devCmd}\``

--- a/packages/arkor/src/cli/commands/init.ts
+++ b/packages/arkor/src/cli/commands/init.ts
@@ -37,6 +37,26 @@ const MANUAL_INSTALL_HINT =
 const MANUAL_DEV_HINT =
   "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
 
+// Used when the project's `dev` script was preserved by the scaffolder and
+// points at something other than `arkor dev` (e.g. an existing `next dev`).
+// Suggest invoking the local arkor binary directly via the package manager
+// runner so the user does not accidentally launch their pre-existing app.
+const MANUAL_RUN_ARKOR_DEV_HINT =
+  "run arkor dev (npx arkor dev / pnpm exec arkor dev / yarn run arkor dev / bunx arkor dev)";
+
+function runArkorDevViaPm(pm: PackageManager): string {
+  switch (pm) {
+    case "npm":
+      return "npx arkor dev";
+    case "pnpm":
+      return "pnpm exec arkor dev";
+    case "yarn":
+      return "yarn run arkor dev";
+    case "bun":
+      return "bunx arkor dev";
+  }
+}
+
 /**
  * Decide whether to run `git init` + initial commit, surfacing the prompt
  * upfront so the user doesn't sit at an interactive question after the long
@@ -139,7 +159,11 @@ export async function runInit(options: InitOptions): Promise<void> {
 
   // Sanitise here so `--name "Foo Bar"` (which bypasses prompts under
   // `--yes` / non-interactive) doesn't end up in `package.json` as-is.
-  const { files } = await scaffold({ cwd, name: sanitise(projectName), template });
+  const { files, devScriptWiresArkor } = await scaffold({
+    cwd,
+    name: sanitise(projectName),
+    template,
+  });
 
   ui.note(
     files.map((f) => `${f.action.padEnd(8)} ${f.path}`).join("\n"),
@@ -170,11 +194,15 @@ export async function runInit(options: InitOptions): Promise<void> {
 
   if (shouldInitGit) await runGitInit(cwd);
 
-  const devHint = pm
-    ? pm === "npm"
-      ? "`npm run dev`"
-      : `\`${pm} dev\``
-    : MANUAL_DEV_HINT;
+  const devHint = devScriptWiresArkor
+    ? pm
+      ? pm === "npm"
+        ? "`npm run dev`"
+        : `\`${pm} dev\``
+      : MANUAL_DEV_HINT
+    : pm
+      ? `\`${runArkorDevViaPm(pm)}\``
+      : MANUAL_RUN_ARKOR_DEV_HINT;
   ui.outro(
     installed
       ? `Next: ${devHint}`

--- a/packages/cli-internal/src/index.ts
+++ b/packages/cli-internal/src/index.ts
@@ -19,6 +19,12 @@ export {
 } from "./package-manager";
 export { install } from "./install";
 export {
+  MANUAL_DEV_HINT,
+  MANUAL_INSTALL_HINT,
+  MANUAL_RUN_ARKOR_DEV_HINT,
+  runArkorDevViaPm,
+} from "./next-steps";
+export {
   gitInitialCommit,
   isInGitRepo,
   type InitialCommitResult,

--- a/packages/cli-internal/src/next-steps.test.ts
+++ b/packages/cli-internal/src/next-steps.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  MANUAL_DEV_HINT,
+  MANUAL_INSTALL_HINT,
+  MANUAL_RUN_ARKOR_DEV_HINT,
+  runArkorDevViaPm,
+} from "./next-steps";
+import type { PackageManager } from "./package-manager";
+
+describe("runArkorDevViaPm", () => {
+  it.each<{ pm: PackageManager; expected: string }>([
+    { pm: "npm", expected: "npx arkor dev" },
+    { pm: "pnpm", expected: "pnpm exec arkor dev" },
+    { pm: "yarn", expected: "yarn run arkor dev" },
+    { pm: "bun", expected: "bunx arkor dev" },
+  ])("returns the runner form for $pm", ({ pm, expected }) => {
+    expect(runArkorDevViaPm(pm)).toBe(expected);
+  });
+
+  it("throws on an unknown package manager (defends against PackageManager union drift)", () => {
+    // Cast through `unknown` so the test exercises the runtime `assertNever`
+    // path without TypeScript rejecting it at compile time.
+    expect(() =>
+      runArkorDevViaPm("rush" as unknown as PackageManager),
+    ).toThrow(/Unhandled package manager: rush/);
+  });
+});
+
+describe("manual hint constants", () => {
+  // Spot-check the exact wording so a typo here surfaces in CI rather than in
+  // a freshly scaffolded project's outro.
+  it("MANUAL_INSTALL_HINT lists every supported package manager", () => {
+    expect(MANUAL_INSTALL_HINT).toContain("npm i");
+    expect(MANUAL_INSTALL_HINT).toContain("pnpm install");
+    expect(MANUAL_INSTALL_HINT).toContain("yarn");
+    expect(MANUAL_INSTALL_HINT).toContain("bun install");
+  });
+
+  it("MANUAL_DEV_HINT lists every supported package manager's dev script", () => {
+    expect(MANUAL_DEV_HINT).toContain("npm run dev");
+    expect(MANUAL_DEV_HINT).toContain("pnpm dev");
+    expect(MANUAL_DEV_HINT).toContain("yarn dev");
+    expect(MANUAL_DEV_HINT).toContain("bun dev");
+  });
+
+  it("MANUAL_RUN_ARKOR_DEV_HINT lists every runner form `arkor dev`", () => {
+    expect(MANUAL_RUN_ARKOR_DEV_HINT).toContain("npx arkor dev");
+    expect(MANUAL_RUN_ARKOR_DEV_HINT).toContain("pnpm exec arkor dev");
+    expect(MANUAL_RUN_ARKOR_DEV_HINT).toContain("yarn run arkor dev");
+    expect(MANUAL_RUN_ARKOR_DEV_HINT).toContain("bunx arkor dev");
+  });
+});

--- a/packages/cli-internal/src/next-steps.ts
+++ b/packages/cli-internal/src/next-steps.ts
@@ -1,0 +1,41 @@
+import type { PackageManager } from "./package-manager";
+
+/**
+ * Manual hints printed in the "Next steps:" outro after `create-arkor` /
+ * `arkor init` when the package manager could not be auto-detected (no
+ * `--use-*` flag, no `npm_config_user_agent`). They list the form for
+ * every supported package manager so the reader can pick.
+ *
+ * Also: a single shared `runArkorDevViaPm` helper that maps a known PM to
+ * its runner-form equivalent of `arkor dev`, used when the project's
+ * `scripts.dev` was preserved by the scaffolder and points elsewhere.
+ *
+ * Centralising these in `@arkor/cli-internal` is what keeps the
+ * `create-arkor` and `arkor init` commands from drifting in their wording.
+ */
+
+export const MANUAL_INSTALL_HINT =
+  "install dependencies (npm i / pnpm install / yarn / bun install)";
+
+export const MANUAL_DEV_HINT =
+  "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
+
+export const MANUAL_RUN_ARKOR_DEV_HINT =
+  "run arkor dev (npx arkor dev / pnpm exec arkor dev / yarn run arkor dev / bunx arkor dev)";
+
+export function runArkorDevViaPm(pm: PackageManager): string {
+  switch (pm) {
+    case "npm":
+      return "npx arkor dev";
+    case "pnpm":
+      return "pnpm exec arkor dev";
+    case "yarn":
+      return "yarn run arkor dev";
+    case "bun":
+      return "bunx arkor dev";
+    default: {
+      const _exhaustive: never = pm;
+      throw new Error(`Unhandled package manager: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -134,6 +134,33 @@ describe("scaffold", () => {
     expect(pkgEntry?.action).toBe("patched");
   });
 
+  it("flags devScriptWiresArkor when scripts.dev is `arkor dev` (greenfield)", async () => {
+    const result = await scaffold({ cwd, name: "fresh", template: "triage" });
+    expect(result.devScriptWiresArkor).toBe(true);
+  });
+
+  it("flags devScriptWiresArkor when an existing package.json has no `dev` script (we patch it in)", async () => {
+    writeFileSync(
+      join(cwd, "package.json"),
+      JSON.stringify({ name: "n", scripts: { build: "tsc" } }, null, 2),
+    );
+    const result = await scaffold({ cwd, name: "n", template: "triage" });
+    expect(result.devScriptWiresArkor).toBe(true);
+  });
+
+  it("does NOT flag devScriptWiresArkor when an existing `dev` script is preserved", async () => {
+    writeFileSync(
+      join(cwd, "package.json"),
+      JSON.stringify(
+        { name: "n", scripts: { dev: "next dev", build: "tsc" } },
+        null,
+        2,
+      ),
+    );
+    const result = await scaffold({ cwd, name: "n", template: "triage" });
+    expect(result.devScriptWiresArkor).toBe(false);
+  });
+
   it("appends to an existing .gitignore only if the entry is missing", async () => {
     writeFileSync(join(cwd, ".gitignore"), "node_modules/\n");
     const first = await scaffold({ cwd, name: "n", template: "triage" });

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -22,6 +22,13 @@ export interface ScaffoldOptions {
 export interface ScaffoldResult {
   files: Array<{ path: string; action: FileAction }>;
   cwd: string;
+  /**
+   * True when the final package.json has `scripts.dev === "arkor dev"`.
+   * False when an existing project's `dev` script was preserved and points
+   * elsewhere (e.g. `next dev`); callers should suggest invoking `arkor dev`
+   * directly in that case rather than the package script.
+   */
+  devScriptWiresArkor: boolean;
 }
 
 const INDEX_PATH = "src/arkor/index.ts";
@@ -171,7 +178,19 @@ export async function scaffold(
     path: PACKAGE_JSON_PATH,
     action: await patchPackageJson(cwd, options.name),
   });
-  return { files, cwd };
+
+  let devScriptWiresArkor = false;
+  try {
+    const pkg = JSON.parse(
+      await readFile(join(cwd, PACKAGE_JSON_PATH), "utf8"),
+    ) as { scripts?: Record<string, string> };
+    devScriptWiresArkor = pkg.scripts?.dev === SCRIPT_DEFAULTS.dev;
+  } catch {
+    // package.json unreadable: treat as not wired so callers fall back to
+    // the explicit `arkor dev` invocation form.
+  }
+
+  return { files, cwd, devScriptWiresArkor };
 }
 
 export function templateChoices(): Array<{

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -136,10 +136,15 @@ npm install && npm run dev
 
 \`arkor dev\` opens the local Studio GUI (most workflows live there).
 
-Optional — log in to your own org instead of using anonymous tokens:
+Optional — log in to your own org instead of using anonymous tokens.
+\`arkor\` is a local devDependency, not a global, so invoke it through
+your package manager's runner:
 
 \`\`\`
-arkor login
+npx arkor login
+# or: pnpm exec arkor login
+# or: yarn run arkor login
+# or: bunx arkor login
 \`\`\`
 
 CLI-only flow (no GUI):

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -125,13 +125,12 @@ An arkor training project scaffolded by \`create-arkor\`.
 
 The \`dev\` / \`build\` / \`start\` package scripts forward to the matching
 \`arkor\` subcommands, so the script form works across every package
-manager (\`npm\` does not run package binaries via \`npm <bin>\` — use
-\`npm run <script>\` or \`npx arkor <subcommand>\`).
+manager.
 
 \`\`\`
 npm install && npm run dev
 # or: pnpm install && pnpm dev
-# or: yarn && yarn dev
+# or: yarn install && yarn dev
 # or: bun install && bun dev
 \`\`\`
 
@@ -140,7 +139,7 @@ npm install && npm run dev
 Optional — log in to your own org instead of using anonymous tokens:
 
 \`\`\`
-npx arkor login
+arkor login
 \`\`\`
 
 CLI-only flow (no GUI):

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -87,9 +87,7 @@ cd my-app
 
 The `dev` / `build` / `start` package scripts forward to the corresponding
 `arkor` subcommands, so the script form works the same across npm, pnpm,
-yarn, and bun. (npm in particular does *not* run package binaries via
-`npm <bin>` — use `npm run <script>`, or `npx arkor <subcommand>` for
-one-off invocations.)
+yarn, and bun.
 
 `arkor dev` opens the local Studio. See the
 [`arkor` package README](../arkor/README.md) for the full SDK + CLI

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -38,6 +38,26 @@ const MANUAL_INSTALL_HINT =
 const MANUAL_DEV_HINT =
   "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
 
+// Used when the project's `dev` script was preserved by the scaffolder and
+// points at something other than `arkor dev` (e.g. an existing `next dev`).
+// Suggest invoking the local arkor binary directly via the package manager
+// runner so the user does not accidentally launch their pre-existing app.
+const MANUAL_RUN_ARKOR_DEV_HINT =
+  "run arkor dev (npx arkor dev / pnpm exec arkor dev / yarn run arkor dev / bunx arkor dev)";
+
+function runArkorDevViaPm(pm: PackageManager): string {
+  switch (pm) {
+    case "npm":
+      return "npx arkor dev";
+    case "pnpm":
+      return "pnpm exec arkor dev";
+    case "yarn":
+      return "yarn run arkor dev";
+    case "bun":
+      return "bunx arkor dev";
+  }
+}
+
 function isInteractive(): boolean {
   return Boolean(process.stdout.isTTY) && !process.env.CI;
 }
@@ -227,7 +247,11 @@ async function run(options: RunOptions): Promise<void> {
 
   const spin = clack.spinner();
   spin.start(`Scaffolding in ${cwd}`);
-  const { files } = await scaffold({ cwd, name, template });
+  const { files, devScriptWiresArkor } = await scaffold({
+    cwd,
+    name,
+    template,
+  });
   spin.stop("Done");
 
   clack.note(
@@ -268,11 +292,15 @@ async function run(options: RunOptions): Promise<void> {
     : pm
       ? `  ${pm} install`
       : `  ${MANUAL_INSTALL_HINT}`;
-  const devLine = pm
-    ? pm === "npm"
-      ? `  npm run dev`
-      : `  ${pm} dev`
-    : `  ${MANUAL_DEV_HINT}`;
+  const devLine = devScriptWiresArkor
+    ? pm
+      ? pm === "npm"
+        ? `  npm run dev`
+        : `  ${pm} dev`
+      : `  ${MANUAL_DEV_HINT}`
+    : pm
+      ? `  ${runArkorDevViaPm(pm)}`
+      : `  ${MANUAL_RUN_ARKOR_DEV_HINT}`;
 
   clack.outro(
     [

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -9,7 +9,11 @@ import {
   gitInitialCommit,
   install,
   isInGitRepo,
+  MANUAL_DEV_HINT,
+  MANUAL_INSTALL_HINT,
+  MANUAL_RUN_ARKOR_DEV_HINT,
   resolvePackageManager,
+  runArkorDevViaPm,
   sanitise,
   scaffold,
   TEMPLATES,
@@ -30,32 +34,6 @@ interface RunOptions {
   git?: boolean;
   /** `true` when the user explicitly passed `--skip-git` (no prompt, no init). */
   skipGit?: boolean;
-}
-
-const MANUAL_INSTALL_HINT =
-  "install dependencies (npm i / pnpm install / yarn / bun install)";
-
-const MANUAL_DEV_HINT =
-  "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
-
-// Used when the project's `dev` script was preserved by the scaffolder and
-// points at something other than `arkor dev` (e.g. an existing `next dev`).
-// Suggest invoking the local arkor binary directly via the package manager
-// runner so the user does not accidentally launch their pre-existing app.
-const MANUAL_RUN_ARKOR_DEV_HINT =
-  "run arkor dev (npx arkor dev / pnpm exec arkor dev / yarn run arkor dev / bunx arkor dev)";
-
-function runArkorDevViaPm(pm: PackageManager): string {
-  switch (pm) {
-    case "npm":
-      return "npx arkor dev";
-    case "pnpm":
-      return "pnpm exec arkor dev";
-    case "yarn":
-      return "yarn run arkor dev";
-    case "bun":
-      return "bunx arkor dev";
-  }
 }
 
 function isInteractive(): boolean {

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -266,7 +266,7 @@ async function run(options: RunOptions): Promise<void> {
       ? `  ${pm} install`
       : `  ${MANUAL_INSTALL_HINT}`;
   const devLine =
-    pm && pm !== "npm" ? `  ${pm} arkor dev` : `  npx arkor dev`;
+    pm && pm !== "npm" ? `  ${pm} dev` : `  npm run dev`;
 
   clack.outro(
     [

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -35,6 +35,9 @@ interface RunOptions {
 const MANUAL_INSTALL_HINT =
   "install dependencies (npm i / pnpm install / yarn / bun install)";
 
+const MANUAL_DEV_HINT =
+  "run dev (npm run dev / pnpm dev / yarn dev / bun dev)";
+
 function isInteractive(): boolean {
   return Boolean(process.stdout.isTTY) && !process.env.CI;
 }
@@ -265,8 +268,11 @@ async function run(options: RunOptions): Promise<void> {
     : pm
       ? `  ${pm} install`
       : `  ${MANUAL_INSTALL_HINT}`;
-  const devLine =
-    pm && pm !== "npm" ? `  ${pm} dev` : `  npm run dev`;
+  const devLine = pm
+    ? pm === "npm"
+      ? `  npm run dev`
+      : `  ${pm} dev`
+    : `  ${MANUAL_DEV_HINT}`;
 
   clack.outro(
     [


### PR DESCRIPTION
## Summary

After PR #103 settled the docs convention (script form for `dev`/`build`/`start`, local-install assumption), the CLI's own runtime output and the scaffolded project README were still pointing at the old runner form. This PR closes the gap so what the CLI prints, what the scaffolded README shows, and what the published docs recommend are all the same.

## Changes

- **CLI runtime \"next steps\" hint** (`packages/create-arkor/src/bin.ts`, `packages/arkor/src/cli/commands/init.ts`)
  - Was: `Next: ${pm} arkor dev` (or `npx arkor dev` for npm).
  - Now: `Next: ${pm} dev` (or `npm run dev` for npm) when the freshly scaffolded `scripts.dev` actually wraps `arkor dev`.
  - When the scaffolder lands in an existing repo and **preserves** a custom `scripts.dev` (e.g. an app already wired to `next dev`), the hint instead falls back to the runner form (`pnpm exec arkor dev` / `npx arkor dev` / `yarn run arkor dev` / `bunx arkor dev`) so the suggestion still launches Arkor, not the user's other app.
  - When the package manager is unknown (no `--use-*` flag, UA detection failed), we print PM-agnostic hints (`MANUAL_DEV_HINT` / `MANUAL_RUN_ARKOR_DEV_HINT`) listing all four options instead of silently choosing npm.
- **Scaffolder result** (`packages/cli-internal/src/scaffold.ts`)
  - `ScaffoldResult` gains a `devScriptWiresArkor: boolean` flag so callers can branch their next-step hint without re-reading `package.json`.
- **Hint helpers consolidated** (`packages/cli-internal/src/next-steps.ts`)
  - `MANUAL_INSTALL_HINT`, `MANUAL_DEV_HINT`, `MANUAL_RUN_ARKOR_DEV_HINT`, and `runArkorDevViaPm()` now live in one shared module with an explicit `assertNever` for the `PackageManager` union. `create-arkor` and `arkor init` import them instead of redefining them.
- **Scaffolded project README** (`STARTER_README` in `packages/cli-internal/src/templates.ts`)
  - Drops the npm-vs-binary parenthetical (now we assume local install + scripts).
  - Replaces the single-PM `npx arkor login` example with the full four-form runner list (`npx arkor login` / `pnpm exec arkor login` / `yarn run arkor login` / `bunx arkor login`) so the snippet is copy-pasteable on any package manager. Plain markdown can't render Mintlify CodeGroups, so the multi-line listing matches the `install && dev` block already on the page.
- **`packages/create-arkor/README.md`** drops the matching `npm run <script>` / `npx arkor <subcommand>` parenthetical for consistency.
- **e2e + unit assertions** (`e2e/cli/src/{arkor-init,create-arkor}.test.ts`, `packages/cli-internal/src/scaffold.test.ts`, `packages/cli-internal/src/next-steps.test.ts`) updated/added to lock in the new hint shapes and the runner-form fallback.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @arkor/cli-internal test` passes (one pre-existing GPG-signing test in `git.test.ts` was already failing on `main`, unrelated)
- [x] `SKIP_E2E_INSTALL=1 pnpm --filter @arkor/e2e-cli test` passes (39 tests)
- [x] `mint broken-links` clean
- [ ] Smoke: `node packages/create-arkor/dist/bin.mjs ./tmp-app --use-pnpm --skip-install --skip-git -y` prints `Next: pnpm dev`
- [ ] Smoke: same with `--use-npm` prints `npm run dev`
- [ ] Smoke: `arkor init` in a directory with `scripts.dev = "next dev"` prints `Next: pnpm exec arkor dev`