### PR TITLE
Update Arkor SDK to 0.0.1-alpha.8 and adjust deprecations

### DIFF
--- a/e2e/cli/src/arkor-whoami.test.ts
+++ b/e2e/cli/src/arkor-whoami.test.ts
@@ -230,7 +230,7 @@ describe("arkor whoami × SDK version gate (E2E)", () => {
       res.setHeader("Deprecation", "true");
       res.setHeader(
         "Warning",
-        '299 - "Arkor SDK 0.0.1-alpha.7 is deprecated; supported range: >=2.0.0"',
+        '299 - "Arkor SDK 0.0.1-alpha.8 is deprecated; supported range: >=2.0.0"',
       );
       res.end(
         JSON.stringify({

--- a/packages/arkor/README.md
+++ b/packages/arkor/README.md
@@ -2,7 +2,7 @@
 
 The Arkor SDK + CLI + bundled local Studio. One package; three surfaces.
 
-> Status: alpha (`0.0.1-alpha.7`). APIs may change without notice. No compat
+> Status: alpha (`0.0.1-alpha.8`). APIs may change without notice. No compat
 > shims are offered between alpha versions — pin and re-read the changelog
 > before bumping.
 

--- a/packages/arkor/package.json
+++ b/packages/arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkor",
-  "version": "0.0.1-alpha.7",
+  "version": "0.0.1-alpha.8",
   "description": "Code-first TypeScript training SDK, CLI, and local Studio.",
   "private": false,
   "type": "module",

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -128,7 +128,7 @@ describe("scaffold", () => {
     expect(scripts.dev).toBe("arkor dev");
     expect(scripts.start).toBe("arkor start");
     const devDeps = patched.devDependencies as Record<string, string>;
-    expect(devDeps.arkor).toBe("^0.0.1-alpha.7");
+    expect(devDeps.arkor).toBe("^0.0.1-alpha.8");
 
     const pkgEntry = files.find((f) => f.path === "package.json");
     expect(pkgEntry?.action).toBe("patched");
@@ -161,7 +161,7 @@ describe("scaffold", () => {
     // The value is opaque to scaffold — only that it's faithfully
     // round-tripped into package.json matters, so use a relative
     // `file:` spec that is platform-neutral (no Unix-only `/tmp`).
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.7.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.8.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     const { files } = await scaffold({
       cwd,
@@ -196,7 +196,7 @@ describe("scaffold", () => {
         readFileSync(join(cwd, "package.json"), "utf8"),
       ) as Record<string, unknown>;
       const devDeps = pkg.devDependencies as Record<string, string>;
-      expect(devDeps.arkor).toBe("^0.0.1-alpha.7");
+      expect(devDeps.arkor).toBe("^0.0.1-alpha.8");
     },
   );
 
@@ -205,7 +205,7 @@ describe("scaffold", () => {
     // and the patch path that runs when `package.json` already exists
     // but has no `devDependencies.arkor`. Cover the patch path too so
     // the override doesn't silently regress to the default there.
-    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.7.tgz";
+    const overrideSpec = "file:./vendor/arkor-0.0.1-alpha.8.tgz";
     process.env.ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC = overrideSpec;
     writeFileSync(
       join(cwd, "package.json"),

--- a/packages/cli-internal/src/scaffold.ts
+++ b/packages/cli-internal/src/scaffold.ts
@@ -30,7 +30,7 @@ const CONFIG_PATH = "arkor.config.ts";
 const README_PATH = "README.md";
 const GITIGNORE_PATH = ".gitignore";
 const PACKAGE_JSON_PATH = "package.json";
-const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.7";
+const DEFAULT_ARKOR_SPEC = "^0.0.1-alpha.8";
 
 function resolveArkorScaffoldSpec(): string {
   // Treat unset, empty, and whitespace-only values the same: fall back to

--- a/packages/create-arkor/README.md
+++ b/packages/create-arkor/README.md
@@ -3,7 +3,7 @@
 Scaffolder for [Arkor](https://github.com/arkorlab/arkor) projects. Run via
 `npm create` / `pnpm create` / `yarn create` / `bun create`.
 
-> Status: alpha (`0.0.1-alpha.7`).
+> Status: alpha (`0.0.1-alpha.8`).
 
 ## Usage
 

--- a/packages/create-arkor/package.json
+++ b/packages/create-arkor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-arkor",
-  "version": "0.0.1-alpha.7",
+  "version": "0.0.1-alpha.8",
   "description": "Scaffolder for arkor training projects.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
This pull request updates the Arkor SDK and related packages from version `0.0.1-alpha.7` to `0.0.1-alpha.8`. The changes ensure that version references are consistent across the codebase, documentation, tests, and package scaffolding logic.

**Version bump and consistency updates:**

* Updated the SDK version in `package.json` files for both `arkor` and `create-arkor` to `0.0.1-alpha.8`. [[1]](diffhunk://#diff-65f8c0982731f958a2b47c8eae94ecac08b61d81a02ffad3f8c9995b492e4673L3-R3) [[2]](diffhunk://#diff-60de293e27c0a2440c228da2ab37d004a14dc45b248c7092ee1e0b44aafe8032L3-R3)
* Updated all documentation references to reflect the new version (`0.0.1-alpha.8`) in `README.md` files for `arkor` and `create-arkor`. [[1]](diffhunk://#diff-1b115c48ab72dac65f66f850fad4589f98d3c679cb9899f7db00d63551f552f8L5-R5) [[2]](diffhunk://#diff-b47e791ec316b0ae6283826d5226e70d3841da24c314ceee72213f40edd5f238L6-R6)
* Updated test assertions and scaffold logic to use the new version, including `devDependencies`, override specs, and default spec values in `scaffold.test.ts` and `scaffold.ts`. [[1]](diffhunk://#diff-1d566900a30166001d9214addca0a867154228c262a9367873aad829692e4709L131-R131) [[2]](diffhunk://#diff-1d566900a30166001d9214addca0a867154228c262a9367873aad829692e4709L164-R164) [[3]](diffhunk://#diff-1d566900a30166001d9214addca0a867154228c262a9367873aad829692e4709L199-R199) [[4]](diffhunk://#diff-1d566900a30166001d9214addca0a867154228c262a9367873aad829692e4709L208-R208) [[5]](diffhunk://#diff-3507f4ba1195891301434c611d71b6923fe199832dd7b43beb296da065ad9c7fL33-R33)
* Updated the SDK deprecation warning message in the E2E test to reference `0.0.1-alpha.8`.…including package.json, README.md, and test files. Adjust deprecation warnings and scaffold specifications accordingly.