### PR TITLE
Implement reusable build workflow and enhance release process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,103 @@
+name: Build (reusable)
+
+# SLSA Build L3 trusted builder.
+#
+# Scope (intentionally minimal): install → build → pack → attest → publish.
+# Everything that is not strictly required to produce and sign the
+# artifact lives in the caller — tests (which execute arbitrary
+# user-controlled code), tag-shape validation, version reconciliation
+# against package.json, the npm-not-yet-published guard, and the dry-run
+# verification path. Keeping those out of the reusable workflow shrinks
+# the trust boundary that downstream verifiers pin via the OIDC
+# `job_workflow_ref` claim, so a compromise of caller-side checks cannot
+# leak into the publish identity.
+#
+# The npm provenance attached by `npm publish --provenance` is signed via
+# Sigstore using this job's GitHub OIDC token, whose `job_workflow_ref`
+# claim resolves to this file's path + ref. Verifiers (e.g.
+# `npm audit signatures`, slsa-verifier) can therefore require provenance
+# signed by this exact reusable workflow as a separately-lockable trust
+# principal — branch-protect this file and the publish identity is safe
+# even if a caller workflow is compromised.
+
+on:
+  workflow_call:
+    inputs:
+      npm_tag:
+        description: "Resolved npm dist-tag."
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      attestations: write
+
+    environment: npm-publish
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        env:
+          ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
+          ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
+        run: pnpm run build
+
+      - name: Pack release tarballs
+        run: |
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          rm -rf "$PACK_DIR"
+          mkdir -p "$PACK_DIR"
+
+          for PKG_DIR in packages/arkor packages/create-arkor; do
+            (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
+          done
+
+      - name: Generate GitHub artifact attestations for release tarballs
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ runner.temp }}/npm-pack/*.tgz
+
+      # Publish from the package directory (not from the pre-packed tarball)
+      # so npm CLI reads README.md at publish time and embeds it in the
+      # registry packument's `readme` field. `npm publish <tarball>` does
+      # not perform that injection, which leaves the page on npmjs.com
+      # blank.
+      - name: Publish arkor to npm
+        working-directory: packages/arkor
+        run: |
+          npm publish \
+            --access public \
+            --tag "${{ inputs.npm_tag }}" \
+            --provenance
+
+      - name: Publish create-arkor to npm
+        working-directory: packages/create-arkor
+        run: |
+          npm publish \
+            --access public \
+            --tag "${{ inputs.npm_tag }}" \
+            --provenance
+
+      - name: Upload release tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-tarballs
+          path: ${{ runner.temp }}/npm-pack/*.tgz
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -23,9 +23,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dry-run:
+  # Same shape as release.yaml's preflight: all source-level validation
+  # lives here. Duplication is intentional — see the comment at the top
+  # of build.yaml.
+  preflight:
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      npm_tag: ${{ steps.meta.outputs.npm_tag }}
     steps:
       - name: Ensure workflow is running on a tag
         run: |
@@ -133,13 +138,34 @@ jobs:
             fi
           done
 
+  # Verifies the source on every tag push: packs, runs e2e against the
+  # packed tarball, and exercises `pnpm publish --dry-run` to surface
+  # `files:` / dist/ / package.json metadata regressions before the
+  # maintainer manually triggers release.yaml. Does NOT call
+  # build.yaml — the trusted builder is exercised only on real release.
+  test:
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
       - name: Install
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
 
-      - name: Pack and inspect tarballs
+      - name: Pack tarballs for e2e scaffold tests
         run: |
           PACK_DIR="$RUNNER_TEMP/npm-pack"
           rm -rf "$PACK_DIR"
@@ -149,10 +175,6 @@ jobs:
             (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
           done
 
-          # Resolve the freshly-packed `arkor` tarball without hard-coding
-          # the filename, then expose it to subsequent steps as a
-          # `file:` spec so the e2e scaffold install tests use *this*
-          # build instead of fetching `arkor` from the registry.
           shopt -s nullglob
           ARKOR_TARBALLS=("$PACK_DIR"/arkor-*.tgz)
           shopt -u nullglob
@@ -164,11 +186,6 @@ jobs:
           ARKOR_TARBALL="${ARKOR_TARBALLS[0]}"
           echo "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC=file:$ARKOR_TARBALL" >> "$GITHUB_ENV"
 
-          for TARBALL in "$PACK_DIR"/*.tgz; do
-            echo "## $(basename "$TARBALL")"
-            tar -tf "$TARBALL"
-          done
-
       - name: Test
         env:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
@@ -176,38 +193,28 @@ jobs:
           # Disable runtime telemetry: `pnpm run test` triggers the
           # e2e-cli pretest, which rebuilds `arkor` with the key baked
           # in. The tests then spawn that binary, so without this flag
-          # every release run would emit real PostHog events from CI.
+          # every dry-run would emit real PostHog events from CI.
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 
-      # Re-pack after Test so the dry-run publish exercises the same
-      # dist/ that the real release would upload. The pre-Test pack
-      # only existed to feed ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC; the
-      # e2e-cli pretest rebuilt dist/ since.
-      - name: Re-pack release tarballs
-        run: |
-          PACK_DIR="$RUNNER_TEMP/npm-pack"
-          rm -rf "$PACK_DIR"
-          mkdir -p "$PACK_DIR"
-
-          for PKG_DIR in packages/arkor packages/create-arkor; do
-            (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
-          done
-
+      # Publish from the package directory (not from the pre-Test pack)
+      # so the dry-run exercises the dist/ shape that the e2e pretest
+      # rebuilt — same dist/ that `npm publish` would upload during a
+      # real release.
       - name: Dry run publish (arkor)
+        working-directory: packages/arkor
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          pnpm publish "$RUNNER_TEMP/npm-pack/arkor-$VERSION.tgz" \
+          pnpm publish \
             --access public \
-            --tag "${{ steps.meta.outputs.npm_tag }}" \
+            --tag "${{ needs.preflight.outputs.npm_tag }}" \
             --no-git-checks \
             --dry-run
 
       - name: Dry run publish (create-arkor)
+        working-directory: packages/create-arkor
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          pnpm publish "$RUNNER_TEMP/npm-pack/create-arkor-$VERSION.tgz" \
+          pnpm publish \
             --access public \
-            --tag "${{ steps.meta.outputs.npm_tag }}" \
+            --tag "${{ needs.preflight.outputs.npm_tag }}" \
             --no-git-checks \
             --dry-run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,22 +14,20 @@ on:
           - beta
           - rc
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
-
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
+  # All source-level validation lives here so build.yaml stays minimal —
+  # see the comment at the top of build.yaml. preflight is the gate that
+  # decides whether the rest of the workflow may proceed; if any check
+  # fails nothing else runs.
+  preflight:
     runs-on: ubuntu-latest
-
-    # npm Trusted Publisher 側で environment を指定するなら一致させる
-    # environment: npm-publish
-
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      npm_tag: ${{ steps.meta.outputs.npm_tag }}
     steps:
       - name: Ensure workflow is running on a tag
         run: |
@@ -42,6 +40,15 @@ jobs:
 
           if [[ "${GITHUB_REF_NAME}" != v* ]]; then
             echo "Tag must start with v, e.g. v1.2.3"
+            exit 1
+          fi
+
+      - name: Check GitHub Release does not exist yet
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release already exists: $GITHUB_REF_NAME"
             exit 1
           fi
 
@@ -59,9 +66,10 @@ jobs:
 
       - name: Resolve release metadata
         id: meta
+        env:
+          INPUT_NPM_TAG: ${{ inputs.npm_tag }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          NPM_TAG="${{ inputs.npm_tag }}"
 
           ARKOR_VERSION="$(node -p "require('./packages/arkor/package.json').version")"
           CREATE_ARKOR_VERSION="$(node -p "require('./packages/create-arkor/package.json').version")"
@@ -100,6 +108,8 @@ jobs:
               ;;
           esac
 
+          NPM_TAG="$INPUT_NPM_TAG"
+
           if [[ "$NPM_TAG" != "$EXPECTED_NPM_TAG" ]]; then
             echo "npm_tag does not match version"
             echo "version:          $VERSION"
@@ -130,14 +140,26 @@ jobs:
             fi
           done
 
-      - name: Check GitHub Release does not exist yet
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "GitHub Release already exists: $GITHUB_REF_NAME"
-            exit 1
-          fi
+  # Tests live outside the SLSA L3 trusted builder (build.yaml) so the
+  # builder's trust boundary stays minimal. This job runs the
+  # published-shape verification: pack the tarballs and point the e2e
+  # scaffold tests at them via ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC, so any
+  # `files:` / dist/ regression that would only surface post-pack is
+  # caught before the build job signs and publishes.
+  test:
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -148,7 +170,7 @@ jobs:
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
         run: pnpm run build
 
-      - name: Pack and inspect tarballs
+      - name: Pack tarballs for e2e scaffold tests
         run: |
           PACK_DIR="$RUNNER_TEMP/npm-pack"
           rm -rf "$PACK_DIR"
@@ -158,10 +180,6 @@ jobs:
             (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
           done
 
-          # Resolve the freshly-packed `arkor` tarball without hard-coding
-          # the filename, then expose it to subsequent steps as a
-          # `file:` spec so the e2e scaffold install tests use *this*
-          # build instead of fetching `arkor` from the registry.
           shopt -s nullglob
           ARKOR_TARBALLS=("$PACK_DIR"/arkor-*.tgz)
           shopt -u nullglob
@@ -172,11 +190,6 @@ jobs:
           fi
           ARKOR_TARBALL="${ARKOR_TARBALLS[0]}"
           echo "ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC=file:$ARKOR_TARBALL" >> "$GITHUB_ENV"
-
-          for TARBALL in "$PACK_DIR"/*.tgz; do
-            echo "## $(basename "$TARBALL")"
-            tar -tf "$TARBALL"
-          done
 
       - name: Test
         env:
@@ -189,51 +202,30 @@ jobs:
           ARKOR_TELEMETRY_DISABLED: "1"
         run: pnpm run test
 
-      # Re-pack after Test so the attestation and the GitHub Release
-      # artifacts capture the same dist/ that `npm publish` (from the
-      # package directory, below) will upload — the e2e-cli pretest
-      # rebuilds dist/, so the pre-Test pack that fed
-      # ARKOR_INTERNAL_SCAFFOLD_ARKOR_SPEC is now stale for that
-      # purpose.
-      - name: Re-pack release tarballs
-        run: |
-          PACK_DIR="$RUNNER_TEMP/npm-pack"
-          rm -rf "$PACK_DIR"
-          mkdir -p "$PACK_DIR"
+  # The trusted builder. Because `npm publish --provenance` runs inside
+  # build.yaml, the OIDC token Sigstore signs has
+  # `job_workflow_ref = .../build.yaml@<ref>` rather than this caller's
+  # path — giving SLSA Build L3 verifiers a stable, separately-lockable
+  # identity to pin.
+  build:
+    needs: [preflight, test]
+    permissions:
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/build.yaml
+    with:
+      npm_tag: ${{ needs.preflight.outputs.npm_tag }}
+    secrets: inherit
 
-          for PKG_DIR in packages/arkor packages/create-arkor; do
-            (cd "$PKG_DIR" && pnpm pack --pack-destination "$PACK_DIR")
-          done
-
-      - name: Generate GitHub artifact attestations for release tarballs
-        uses: actions/attest@v4
-        with:
-          subject-path: ${{ runner.temp }}/npm-pack/*.tgz
-
-      # Publish from the package directory (not from the pre-packed tarball)
-      # so npm CLI reads README.md at publish time and embeds it in the
-      # registry packument's `readme` field. `npm publish <tarball>` does
-      # not perform that injection, which leaves the page on npmjs.com
-      # blank.
-      - name: Publish arkor to npm
-        working-directory: packages/arkor
-        run: |
-          npm publish \
-            --access public \
-            --tag "${{ steps.meta.outputs.npm_tag }}" \
-            --provenance
-
-      - name: Publish create-arkor to npm
-        working-directory: packages/create-arkor
-        run: |
-          npm publish \
-            --access public \
-            --tag "${{ steps.meta.outputs.npm_tag }}" \
-            --provenance
-
+  postflight:
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Verify published packages
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="${{ needs.preflight.outputs.version }}"
           MAX_ATTEMPTS=120
           SLEEP_SECONDS=5
           for PKG in arkor create-arkor; do
@@ -254,11 +246,17 @@ jobs:
             done
           done
 
+      - name: Download release tarballs
+        uses: actions/download-artifact@v6
+        with:
+          name: npm-tarballs
+          path: ${{ runner.temp }}/npm-pack
+
       - name: Create draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="${{ needs.preflight.outputs.version }}"
           PACK_DIR="$RUNNER_TEMP/npm-pack"
 
           ARGS=(
@@ -267,6 +265,7 @@ jobs:
             --draft
             --verify-tag
             --generate-notes
+            --repo "$GITHUB_REPOSITORY"
           )
 
           if [[ "$VERSION" == *"-"* ]]; then


### PR DESCRIPTION
This pull request restructures and improves the release automation workflows for the project, focusing on security, maintainability, and separation of concerns. The main changes include introducing a reusable, minimal SLSA Build L3 trusted builder workflow, splitting source validation and testing from artifact building and publishing, and enhancing checks and outputs for more robust releases. The workflows now better align with security best practices and reduce the trusted code boundary for artifact signing and publishing.

**Workflow restructuring and separation of concerns:**

* Introduced a new reusable workflow `.github/workflows/build.yaml` that handles only building, packing, attesting, and publishing npm packages with SLSA Build L3 provenance, minimizing the trusted code boundary for artifact signing and publishing.
* Refactored both `release.yaml` and `release-dry-run.yaml` to separate preflight/source validation, testing, and build/publish steps into distinct jobs. The trusted builder (`build.yaml`) is only called for actual releases, not for dry runs. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R30) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3L26-R33) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL192-R228) [[4]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R141-R168)
* Moved all source-level validation (version checks, tag checks, changelog checks, etc.) into a dedicated `preflight` job, which gates the rest of the workflow. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R30) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3L26-R33)

**Security and correctness improvements:**

* Added a check to ensure a GitHub Release does not already exist for the tag, preventing accidental overwrites.
* The release process now uploads and attests tarballs using the trusted builder, and only publishes from the package directory to ensure correct README embedding and provenance. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R1-R103) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL192-R228)

**Testing and verification enhancements:**

* Both release and dry-run workflows now run end-to-end tests against the packed tarballs before publishing, using the actual build artifacts that will be released, to catch regressions in `files:`, `dist/`, or `package.json` metadata. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL133-R162) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R141-R168) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL151-R173)
* Added a postflight job to verify that published packages are available on npm and to create a draft GitHub Release with attached tarballs. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL192-R228) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR249-R259)

**Other improvements:**

* Improved workflow outputs and variable passing between jobs for clarity and maintainability. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR69-L64) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR111-R112) [[3]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3L26-R33)
* Updated documentation and comments throughout the workflows to clarify the rationale behind the structure and security measures. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R1-R103) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R30)

These changes make the release process more secure, reliable, and maintainable, and align with modern supply chain security standards.…ith preflight checks