### PR TITLE
Standardize model identifier casing for `unsloth/gemma-4-e4b-it`

### DIFF
--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -64,7 +64,7 @@ arkor init [options]
 | `translate` | 9-language translation | `{ translation, detectedLanguage }` |
 | `redaction` | PII redaction | `{ redactedText, redactedCount, tags }` |
 
-All three pair the same small open-weight base (`unsloth/gemma-4-E4B-it`) with a curated public dataset on HuggingFace.
+All three pair the same small open-weight base (`unsloth/gemma-4-e4b-it`) with a curated public dataset on HuggingFace.
 
 ## Package manager detection
 

--- a/docs/ja/cli/init.mdx
+++ b/docs/ja/cli/init.mdx
@@ -64,7 +64,7 @@ arkor init [options]
 | `translate` | 9 言語の翻訳 | `{ translation, detectedLanguage }` |
 | `redaction` | 個人情報のマスク | `{ redactedText, redactedCount, tags }` |
 
-3 つとも同じ小型のオープンウェイトベース（`unsloth/gemma-4-E4B-it`）と HuggingFace 上の厳選公開データセットを組み合わせています。
+3 つとも同じ小型のオープンウェイトベース（`unsloth/gemma-4-e4b-it`）と HuggingFace 上の厳選公開データセットを組み合わせています。
 
 ## パッケージマネージャ検出
 

--- a/docs/ja/quickstart.mdx
+++ b/docs/ja/quickstart.mdx
@@ -47,7 +47,7 @@ cd my-arkor-app
 | `translate`  | 9 言語の翻訳            | `{ translation, detectedLanguage }`                   | 約 7 分      |
 | `redaction`  | 個人情報のマスク        | `{ redactedText, redactedCount, tags }`               | 約 12 分     |
 
-いずれも同じ小型のオープンウェイトベース（`unsloth/gemma-4-E4B-it`）と、HuggingFace 上の厳選された公開データセットを組み合わせたものです。学習は本物で、数分で終わるので、ループ全体をエンドツーエンドで体験できます。
+いずれも同じ小型のオープンウェイトベース（`unsloth/gemma-4-e4b-it`）と、HuggingFace 上の厳選された公開データセットを組み合わせたものです。学習は本物で、数分で終わるので、ループ全体をエンドツーエンドで体験できます。
 
 プロンプトをスキップしたいとき:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -47,7 +47,7 @@ The scaffolder asks which template you want. Pick the one closest to what you ev
 | `translate` | 9-language translation  | `{ translation, detectedLanguage }`                   | ~7 min             |
 | `redaction` | PII redaction           | `{ redactedText, redactedCount, tags }`               | ~12 min            |
 
-Each template pairs the same small open-weight base (`unsloth/gemma-4-E4B-it`) with a curated public dataset on HuggingFace. The training is real and finishes in minutes, so you get to see the whole loop end to end.
+Each template pairs the same small open-weight base (`unsloth/gemma-4-e4b-it`) with a curated public dataset on HuggingFace. The training is real and finishes in minutes, so you get to see the whole loop end to end.
 
 To skip the prompt:
 

--- a/packages/cli-internal/src/scaffold.test.ts
+++ b/packages/cli-internal/src/scaffold.test.ts
@@ -53,7 +53,7 @@ describe("scaffold", () => {
 
     const trainer = readFileSync(join(cwd, "src/arkor/trainer.ts"), "utf8");
     expect(trainer).toContain("createTrainer");
-    expect(trainer).toContain("unsloth/gemma-4-E4B-it");
+    expect(trainer).toContain("unsloth/gemma-4-e4b-it");
     expect(trainer).toContain('"triage-run"');
 
     const pkg = JSON.parse(

--- a/packages/cli-internal/src/templates.ts
+++ b/packages/cli-internal/src/templates.ts
@@ -18,24 +18,24 @@ export interface Template {
   trainer: string;
 }
 
-// The three demo templates below pair `unsloth/gemma-4-E4B-it` with curated
+// The three demo templates below pair `unsloth/gemma-4-e4b-it` with curated
 // HuggingFace datasets published under the `arkorlab` org. Each dataset is in
 // OpenAI messages format (chatml), one sample per JSONL line, with the system
-// prompt baked into the conversation — so `datasetFormat: { type: "chatml" }`
+// prompt baked into the conversation - so `datasetFormat: { type: "chatml" }`
 // hands the right shape to the trainer's apply_chat_template step.
 //
-// Use `dryRun: true` for a 2–3 minute smoke test (50 rows, max_steps=10) before
+// Use `dryRun: true` for a 2-3 minute smoke test (50 rows, max_steps=10) before
 // committing to a full run.
 
 const REDACTION_TRAINER = `import { createTrainer } from "arkor";
 
 export const trainer = createTrainer({
   name: "redaction-run",
-  model: "unsloth/gemma-4-E4B-it",
+  model: "unsloth/gemma-4-e4b-it",
   dataset: { type: "huggingface", name: "arkorlab/redaction-demo" },
   datasetFormat: { type: "chatml" },
   maxSteps: 100,
-  lora: { r: 16, alpha: 16 },
+  lora: { r: 16, alpha: 16, loadIn4bit: false },
   // Set dryRun: true for a fast end-to-end smoke test before a full run.
   // dryRun: true,
   callbacks: {
@@ -48,11 +48,11 @@ const TRANSLATE_TRAINER = `import { createTrainer } from "arkor";
 
 export const trainer = createTrainer({
   name: "translate-run",
-  model: "unsloth/gemma-4-E4B-it",
+  model: "unsloth/gemma-4-e4b-it",
   dataset: { type: "huggingface", name: "arkorlab/translate-demo" },
   datasetFormat: { type: "chatml" },
   maxSteps: 100,
-  lora: { r: 16, alpha: 16 },
+  lora: { r: 16, alpha: 16, loadIn4bit: false },
   // dryRun: true,
   callbacks: {
     onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
@@ -64,11 +64,11 @@ const TRIAGE_TRAINER = `import { createTrainer } from "arkor";
 
 export const trainer = createTrainer({
   name: "triage-run",
-  model: "unsloth/gemma-4-E4B-it",
+  model: "unsloth/gemma-4-e4b-it",
   dataset: { type: "huggingface", name: "arkorlab/triage-demo" },
   datasetFormat: { type: "chatml" },
   maxSteps: 100,
-  lora: { r: 16, alpha: 16 },
+  lora: { r: 16, alpha: 16, loadIn4bit: false },
   // dryRun: true,
   callbacks: {
     onLog: ({ step, loss }) => console.log(\`step=\${step} loss=\${loss}\`),
@@ -80,8 +80,8 @@ export const trainer = createTrainer({
 // CLI prompt lists demos first (sorted by estimated training time).
 //
 // Estimated training times assume A100 80GB on Runpod Serverless with the
-// template defaults (maxSteps: 100, batchSize: 4, LoRA r=16, 4-bit). Real
-// numbers depend on GPU availability + cold-start; treat them as ballparks.
+// template defaults (maxSteps: 100, batchSize: 4, LoRA r=16, full precision).
+// Real numbers depend on GPU availability + cold-start; treat them as ballparks.
 export const TEMPLATES: Record<TemplateId, Template> = {
   triage: {
     label: "Triage",


### PR DESCRIPTION
Standardize the casing of the model identifier `unsloth/gemma-4-e4b-it` across documentation and tests to ensure consistency.