### PR TITLE
docs(sdk/create-trainer): show internal context arg in Signature

### DIFF
--- a/docs/ja/sdk/create-trainer.mdx
+++ b/docs/ja/sdk/create-trainer.mdx
@@ -22,10 +22,14 @@ export const trainer = createTrainer({
 ## シグネチャー
 
 ```ts
-function createTrainer(input: TrainerInput): Trainer;
+function createTrainer(
+  input: TrainerInput,
+  /** @internal */
+  context?: TrainerInternalContext,
+): Trainer;
 ```
 
-`TrainerInput` の全体は下記のパラメータで説明します。返ってくる `Trainer` は [トレーナー制御](/ja/sdk/trainer-control) ページにあります。
+`TrainerInput` の全体は下記のパラメータで説明します。返ってくる `Trainer` は [トレーナー制御](/ja/sdk/trainer-control) ページにあります。第 2 引数 `context` は `@internal` 注釈付きで、テストと高度なオーバーライド用に予約されています。`TrainerInternalContext` 自体は形状が安定していないため `arkor` から export されていません。設定可能な既知のフィールド (`reconnectDelayMs` / `maxReconnectDelayMs` / `maxReconnectAttempts`) は [ライフサイクルコールバック > 例外ハンドリング](/ja/sdk/callbacks#例外ハンドリング) を参照してください。
 
 ## 必須フィールド
 

--- a/docs/ja/sdk/create-trainer.mdx
+++ b/docs/ja/sdk/create-trainer.mdx
@@ -29,7 +29,7 @@ function createTrainer(
 ): Trainer;
 ```
 
-`TrainerInput` の全体は下記のパラメータで説明します。返ってくる `Trainer` は [トレーナー制御](/ja/sdk/trainer-control) ページにあります。第 2 引数 `context` は `@internal` 注釈付きで、テストと高度なオーバーライド用に予約されています。`TrainerInternalContext` 自体は形状が安定していないため `arkor` から export されていません。設定可能な既知のフィールド (`reconnectDelayMs` / `maxReconnectDelayMs` / `maxReconnectAttempts`) は [ライフサイクルコールバック > 例外ハンドリング](/ja/sdk/callbacks#例外ハンドリング) を参照してください。
+`TrainerInput` の全体は下記のパラメータで説明します。返ってくる `Trainer` は [トレーナー制御](/ja/sdk/trainer-control) ページにあります。第 2 引数 `context` は `@internal` 注釈付きで、テストと高度なオーバーライド用に予約されています。`TrainerInternalContext` 自体は形状が安定していないため `arkor` から export されていません。設定可能な既知のフィールド (`reconnectDelayMs` / `maxReconnectDelayMs` / `maxReconnectAttempts`) は [トレーナー制御 > 再接続](/ja/sdk/trainer-control#再接続) を参照してください。
 
 ## 必須フィールド
 

--- a/docs/sdk/create-trainer.mdx
+++ b/docs/sdk/create-trainer.mdx
@@ -29,7 +29,7 @@ function createTrainer(
 ): Trainer;
 ```
 
-The full `TrainerInput` shape is described under Parameters below; the returned `Trainer` is documented on the [Trainer control](/sdk/trainer-control) page. The second `context` argument is annotated `@internal` and is reserved for tests and advanced overrides. `TrainerInternalContext` is not exported from `arkor` because the shape is unstable; its known fields (`reconnectDelayMs`, `maxReconnectDelayMs`, `maxReconnectAttempts`) are documented under [Lifecycle callbacks > Exception handling](/sdk/callbacks#exception-handling).
+The full `TrainerInput` shape is described under Parameters below; the returned `Trainer` is documented on the [Trainer control](/sdk/trainer-control) page. The second `context` argument is annotated `@internal` and is reserved for tests and advanced overrides. `TrainerInternalContext` is not exported from `arkor` because the shape is unstable; its known fields (`reconnectDelayMs`, `maxReconnectDelayMs`, `maxReconnectAttempts`) are documented under [Trainer control > Reconnects](/sdk/trainer-control#reconnects).
 
 ## Required fields
 

--- a/docs/sdk/create-trainer.mdx
+++ b/docs/sdk/create-trainer.mdx
@@ -22,10 +22,14 @@ export const trainer = createTrainer({
 ## Signature
 
 ```ts
-function createTrainer(input: TrainerInput): Trainer;
+function createTrainer(
+  input: TrainerInput,
+  /** @internal */
+  context?: TrainerInternalContext,
+): Trainer;
 ```
 
-The full `TrainerInput` shape is described under Parameters below; the returned `Trainer` is documented on the [Trainer control](/sdk/trainer-control) page.
+The full `TrainerInput` shape is described under Parameters below; the returned `Trainer` is documented on the [Trainer control](/sdk/trainer-control) page. The second `context` argument is annotated `@internal` and is reserved for tests and advanced overrides. `TrainerInternalContext` is not exported from `arkor` because the shape is unstable; its known fields (`reconnectDelayMs`, `maxReconnectDelayMs`, `maxReconnectAttempts`) are documented under [Lifecycle callbacks > Exception handling](/sdk/callbacks#exception-handling).
 
 ## Required fields
 


### PR DESCRIPTION
## Summary
- The `createTrainer` API Reference Signature block was 1-arg even though the function actually takes an `@internal` second `context` argument, and sibling Reference pages (callbacks, trainer-control) already disclose it as the only path for `reconnectDelayMs` / `maxReconnectDelayMs` / `maxReconnectAttempts`. The Signature block was the only place that stayed silent, leaving the API Reference internally inconsistent.
- Update EN + JA Signature blocks to show the 2-arg form with the `@internal` marker and a one-paragraph note that `TrainerInternalContext` is intentionally not re-exported, with a cross-link to Trainer control > Reconnects for the field-level details (this is the only section that lists all three reconnect fields together).

Addresses post-merge review on PR #111: https://github.com/arkorlab/arkor/pull/111#discussion_r3202850358

## Test plan
- [ ] `cd docs && npx mintlify dev` and visually confirm `/sdk/create-trainer` and `/ja/sdk/create-trainer` render the 2-arg form with the `@internal` JSDoc comment intact
- [ ] `git grep -n "createTrainer(input: TrainerInput): Trainer"` in `docs/` returns 0 hits