### PR TITLE
Skip Playwright browser download in release and dry-run workflows

### DIFF
--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -160,10 +160,30 @@ jobs:
           cache: pnpm
 
       - name: Install
+        # Belt-and-suspenders: pnpm-workspace.yaml's `allowBuilds`
+        # already gates which packages may run postinstall, and
+        # `playwright` is not in that list — so `pnpm install` won't
+        # invoke Playwright's browser-download script today. Setting
+        # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
+        # explicit so a future `allowBuilds` change can't silently
+        # re-enable a 150 MB postinstall download that the following
+        # cache + `playwright install` steps are meant to satisfy.
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
+
+      # The Test step below transitively runs `@arkor/e2e-studio#test`
+      # (Playwright/Chromium), so we need the browser binaries on disk
+      # before that. Dry-run mirrors release.yaml's no-cache stance:
+      # this job pre-flights the same shape build.yaml would publish,
+      # so we avoid a `~/.cache/ms-playwright` poisoning vector even
+      # though dry-run never actually uploads. The dry-run `test` job
+      # is Linux-only, so we always pass `--with-deps`.
+      - name: Install Playwright (Linux)
+        run: pnpm --filter @arkor/e2e-studio exec playwright install --with-deps chromium
 
       - name: Pack tarballs for e2e scaffold tests
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,16 @@ jobs:
           cache: pnpm
 
       - name: Install
+        # Belt-and-suspenders: pnpm-workspace.yaml's `allowBuilds`
+        # already gates which packages may run postinstall, and
+        # `playwright` is not in that list — so `pnpm install` won't
+        # invoke Playwright's browser-download script today. Setting
+        # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
+        # explicit so a future `allowBuilds` change can't silently
+        # re-enable a 150 MB postinstall download that the following
+        # cache + `playwright install` steps are meant to satisfy.
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Build
@@ -169,6 +179,17 @@ jobs:
           ARKOR_POSTHOG_KEY: ${{ secrets.ARKOR_POSTHOG_KEY }}
           ARKOR_POSTHOG_HOST: ${{ secrets.ARKOR_POSTHOG_HOST }}
         run: pnpm run build
+
+      # The Test step below transitively runs `@arkor/e2e-studio#test`
+      # (Playwright/Chromium), so we need the browser binaries on disk
+      # before that. Unlike ci.yaml, the release path intentionally
+      # *does not* cache: a poisoned `~/.cache/ms-playwright` entry
+      # would run inside the same job that pre-flights what build.yaml
+      # is about to publish. The ~150 MB download per release is
+      # cheaper than that supply-chain risk. The release `test` job is
+      # Linux-only, so we always pass `--with-deps`.
+      - name: Install Playwright (Linux)
+        run: pnpm --filter @arkor/e2e-studio exec playwright install --with-deps chromium
 
       - name: Pack tarballs for e2e scaffold tests
         run: |


### PR DESCRIPTION
This pull request updates the release and dry-run GitHub Actions workflows to improve the handling of Playwright browser binaries. The changes make the installation of Playwright more explicit and resilient against accidental or unwanted downloads, while also documenting the rationale for these steps.

**Playwright installation and workflow improvements:**

* Explicitly set the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` environment variable during the `pnpm install` step to prevent Playwright from downloading browser binaries during postinstall, ensuring future changes do not inadvertently trigger large downloads. (.github/workflows/release.yaml, .github/workflows/release-dry-run.yaml) [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR165-R174) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R163-R187)
* Add a dedicated step to manually install Playwright Chromium binaries with dependencies after install, ensuring the required browsers are available for end-to-end tests and preventing cache poisoning risks. (.github/workflows/release.yaml, .github/workflows/release-dry-run.yaml) [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR183-R193) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R163-R187)
* Add detailed comments explaining the reasoning behind these changes, particularly around security, cache management, and workflow consistency. (.github/workflows/release.yaml, .github/workflows/release-dry-run.yaml) [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR165-R174) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR183-R193) [[3]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R163-R187)… dry-run workflows