### PR TITLE
Enhance PowerShell path handling for leading-dash paths

### DIFF
--- a/packages/create-arkor/src/bin.test.ts
+++ b/packages/create-arkor/src/bin.test.ts
@@ -736,6 +736,25 @@ describe("buildCdLine", () => {
       expect(buildCdLine("My%FOO%App")).toBe("cd 'My%FOO%App'");
     });
   });
+
+  // Round 40 follow-up (Copilot, PR #99): the `%`-path PS
+  // fallback used to bypass `shellQuoteIfNeeded`'s leading-dash
+  // disambiguation, so a directory named `-foo%bar%` emitted
+  // `cd '-foo%bar%'` and PowerShell parsed `-foo` as an option
+  // to `Set-Location` (PS strips quotes before option parsing).
+  // The fallback now prefixes leading-dash paths with `.\` so
+  // the path is unambiguous to `Set-Location`.
+  it("prefixes leading-dash paths with .\\ in the `%`/PS fallback (Windows)", () => {
+    withPlatform("win32", () => {
+      expect(buildCdLine("-foo%bar%")).toBe("cd '.\\-foo%bar%'");
+    });
+  });
+
+  it("leaves non-leading-dash `%`-paths unchanged in the PS fallback", () => {
+    withPlatform("win32", () => {
+      expect(buildCdLine("My-%FOO%-App")).toBe("cd 'My-%FOO%-App'");
+    });
+  });
 });
 
 // `buildCdAndRun` was removed in round-40 follow-up #4 (Codex

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -145,25 +145,43 @@ function collisionMessage(name: string): string {
  *     cmd / PS lines would more than double the closing summary
  *     length for a hazard most users will never hit.
  */
+/**
+ * Disambiguate a relative path that starts with `-` so it doesn't
+ * look like an option/switch to `cd` (POSIX shells, PowerShell)
+ * or any other CLI the path is forwarded to.
+ *
+ * Round 40 follow-up (Copilot, PR #99): a leading dash makes
+ * POSIX shells, PowerShell, AND `cmd.exe` treat the argument as
+ * an option/switch even when QUOTED. `cd '-foo'` and
+ * `cd "-foo"` both still fail with "invalid option" in bash,
+ * because the shell strips the quotes before `cd` sees the
+ * argument. The portable fix is path-disambiguation: prefix a
+ * relative `-`-starting path with `./` (or `.\\` on Windows).
+ * `./-foo` and `.\-foo` are unambiguous filesystem paths the
+ * shell hands to `cd` verbatim, sidestepping the option parser
+ * entirely. Absolute paths never start with `-`, so this is a
+ * no-op for them.
+ *
+ * Round 40 follow-up #5 (Copilot, PR #149): factored out of
+ * `shellQuoteIfNeeded` so `buildCdLine`'s `%`-on-Windows PS
+ * fallback path can share the exact same disambiguation rule
+ * instead of re-implementing it (where the two could drift).
+ * Platform is passed in (not read from `process.platform`)
+ * because the `%`-fallback call site is already gated on
+ * `isWindowsPercentPath` and the test suite drives the helper
+ * across both platforms via `withPlatform`.
+ */
+export function disambiguateLeadingDashPath(
+  value: string,
+  platform: NodeJS.Platform,
+): string {
+  if (!value.startsWith("-")) return value;
+  const prefix = platform === "win32" ? ".\\" : "./";
+  return `${prefix}${value}`;
+}
+
 export function shellQuoteIfNeeded(value: string): string {
-  // Round 40 follow-up (Copilot, PR #99): a leading dash makes
-  // POSIX shells, PowerShell, AND cmd.exe treat the argument as
-  // an option/switch even when QUOTED. `cd '-foo'` and
-  // `cd "-foo"` both still fail with "invalid option" in bash,
-  // because the shell strips the quotes before `cd` sees the
-  // argument. The portable fix is path-disambiguation: prefix
-  // a relative `-`-starting path with `./` (or `.\\` on
-  // Windows). `./-foo` and `.\-foo` are unambiguous filesystem
-  // paths the shell hands to `cd` verbatim, sidestepping the
-  // option parser entirely. Absolute paths never start with `-`,
-  // so this is a no-op for them. Apply BEFORE the safe-unquote
-  // and quoting paths below so a quoted `-`-prefixed name also
-  // gets the prefix (e.g. a path with both leading dash and a
-  // space).
-  if (value.startsWith("-")) {
-    const prefix = process.platform === "win32" ? ".\\" : "./";
-    value = `${prefix}${value}`;
-  }
+  value = disambiguateLeadingDashPath(value, process.platform);
   // Safe-unquote criteria: only alphanumerics + a small set of
   // unambiguous extras (`-_./+@:,`). After the leading-dash
   // disambiguation above, `value` no longer starts with `-`
@@ -221,16 +239,17 @@ function isWindowsPercentPath(cdTarget: string): boolean {
  */
 export function buildCdLine(cdTarget: string): string {
   if (isWindowsPercentPath(cdTarget)) {
-    // Round 40 follow-up (Copilot, PR #99): apply the same
-    // leading-dash disambiguation that `shellQuoteIfNeeded` uses
-    // (prefix `./` POSIX or `.\` Windows) BEFORE wrapping in PS
-    // single quotes. Without it, a directory named `-foo%bar%`
-    // would emit `cd '-foo%bar%'`, and PowerShell parses `-foo`
-    // as an option/switch to `Set-Location` even inside the
-    // single quotes (the quotes are stripped before option
-    // parsing). The `%` branch already pins us to Windows, so
-    // the prefix is `.\` unconditionally here.
-    const prefixed = cdTarget.startsWith("-") ? `.\\${cdTarget}` : cdTarget;
+    // Apply the SAME leading-dash disambiguation that
+    // `shellQuoteIfNeeded` uses (prefix `./` POSIX or `.\`
+    // Windows) BEFORE wrapping in PS single quotes. Without
+    // it, a directory named `-foo%bar%` would emit
+    // `cd '-foo%bar%'` and PowerShell would parse `-foo` as an
+    // option/switch to `Set-Location` even inside the single
+    // quotes (the quotes are stripped before option parsing).
+    // Shared via `disambiguateLeadingDashPath` so the two
+    // call paths can't drift (round 40 follow-up #5, Copilot
+    // PR #149). The `%` branch already pins us to Windows.
+    const prefixed = disambiguateLeadingDashPath(cdTarget, "win32");
     // PS single-quote escape: doubled single quote `''`.
     return `cd '${prefixed.replace(/'/g, "''")}'`;
   }

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -85,16 +85,27 @@ function collisionMessage(name: string): string {
  * or any other CLI the path is forwarded to.
  *
  * Round 40 follow-up (Copilot, PR #99): a leading dash makes
- * POSIX shells, PowerShell, AND `cmd.exe` treat the argument as
- * an option/switch even when QUOTED. `cd '-foo'` and
- * `cd "-foo"` both still fail with "invalid option" in bash,
- * because the shell strips the quotes before `cd` sees the
- * argument. The portable fix is path-disambiguation: prefix a
- * relative `-`-starting path with `./` (or `.\\` on Windows).
- * `./-foo` and `.\-foo` are unambiguous filesystem paths the
- * shell hands to `cd` verbatim, sidestepping the option parser
- * entirely. Absolute paths never start with `-`, so this is a
- * no-op for them.
+ * POSIX `cd` and PowerShell's `Set-Location` (aliased as `cd`)
+ * treat the argument as an option/switch even when QUOTED.
+ * `cd '-foo'` and `cd "-foo"` both still fail with
+ * "invalid option" in bash, because the shell strips the quotes
+ * before `cd` sees the argument. PowerShell's `Set-Location`
+ * has the same problem: it parses positional / parameter
+ * arguments before honouring the quote layer, so `cd '-foo'`
+ * becomes `Set-Location -foo` and `-f` is interpreted as
+ * `-Filter`. cmd.exe's `cd` is different: it takes a single
+ * positional and only knows the `/D`-style switch family, so
+ * a leading-dash directory is actually safe in cmd. The
+ * disambiguation is still applied uniformly (including for
+ * cmd users) so the rule stays simple and so the same
+ * recovery hint reads correctly in whichever shell the user
+ * actually pastes into. The portable fix is
+ * path-disambiguation: prefix a relative `-`-starting path
+ * with `./` (or `.\\` on Windows). `./-foo` and `.\-foo` are
+ * unambiguous filesystem paths the shell hands to `cd`
+ * verbatim, sidestepping the option parser entirely.
+ * Absolute paths never start with `-`, so this is a no-op
+ * for them.
  *
  * Round 40 follow-up #5 (Copilot, PR #149): factored out of
  * `shellQuoteIfNeeded` so `buildCdLine`'s `%`-on-Windows PS

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -171,7 +171,7 @@ function collisionMessage(name: string): string {
  * `isWindowsPercentPath` and the test suite drives the helper
  * across both platforms via `withPlatform`.
  */
-export function disambiguateLeadingDashPath(
+function disambiguateLeadingDashPath(
   value: string,
   platform: NodeJS.Platform,
 ): string {

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -80,6 +80,41 @@ function collisionMessage(name: string): string {
 }
 
 /**
+ * Disambiguate a relative path that starts with `-` so it doesn't
+ * look like an option/switch to `cd` (POSIX shells, PowerShell)
+ * or any other CLI the path is forwarded to.
+ *
+ * Round 40 follow-up (Copilot, PR #99): a leading dash makes
+ * POSIX shells, PowerShell, AND `cmd.exe` treat the argument as
+ * an option/switch even when QUOTED. `cd '-foo'` and
+ * `cd "-foo"` both still fail with "invalid option" in bash,
+ * because the shell strips the quotes before `cd` sees the
+ * argument. The portable fix is path-disambiguation: prefix a
+ * relative `-`-starting path with `./` (or `.\\` on Windows).
+ * `./-foo` and `.\-foo` are unambiguous filesystem paths the
+ * shell hands to `cd` verbatim, sidestepping the option parser
+ * entirely. Absolute paths never start with `-`, so this is a
+ * no-op for them.
+ *
+ * Round 40 follow-up #5 (Copilot, PR #149): factored out of
+ * `shellQuoteIfNeeded` so `buildCdLine`'s `%`-on-Windows PS
+ * fallback path can share the exact same disambiguation rule
+ * instead of re-implementing it (where the two could drift).
+ * Platform is passed in (not read from `process.platform`)
+ * because the `%`-fallback call site is already gated on
+ * `isWindowsPercentPath` and the test suite drives the helper
+ * across both platforms via `withPlatform`.
+ */
+function disambiguateLeadingDashPath(
+  value: string,
+  platform: NodeJS.Platform,
+): string {
+  if (!value.startsWith("-")) return value;
+  const prefix = platform === "win32" ? ".\\" : "./";
+  return `${prefix}${value}`;
+}
+
+/**
  * Shell-quote a path so the `cd ${path}` recovery hints survive
  * paths with spaces or metacharacters. Round-39 Copilot review:
  * `create-arkor "My App"` would otherwise emit a copy-paste-
@@ -145,41 +180,6 @@ function collisionMessage(name: string): string {
  *     cmd / PS lines would more than double the closing summary
  *     length for a hazard most users will never hit.
  */
-/**
- * Disambiguate a relative path that starts with `-` so it doesn't
- * look like an option/switch to `cd` (POSIX shells, PowerShell)
- * or any other CLI the path is forwarded to.
- *
- * Round 40 follow-up (Copilot, PR #99): a leading dash makes
- * POSIX shells, PowerShell, AND `cmd.exe` treat the argument as
- * an option/switch even when QUOTED. `cd '-foo'` and
- * `cd "-foo"` both still fail with "invalid option" in bash,
- * because the shell strips the quotes before `cd` sees the
- * argument. The portable fix is path-disambiguation: prefix a
- * relative `-`-starting path with `./` (or `.\\` on Windows).
- * `./-foo` and `.\-foo` are unambiguous filesystem paths the
- * shell hands to `cd` verbatim, sidestepping the option parser
- * entirely. Absolute paths never start with `-`, so this is a
- * no-op for them.
- *
- * Round 40 follow-up #5 (Copilot, PR #149): factored out of
- * `shellQuoteIfNeeded` so `buildCdLine`'s `%`-on-Windows PS
- * fallback path can share the exact same disambiguation rule
- * instead of re-implementing it (where the two could drift).
- * Platform is passed in (not read from `process.platform`)
- * because the `%`-fallback call site is already gated on
- * `isWindowsPercentPath` and the test suite drives the helper
- * across both platforms via `withPlatform`.
- */
-function disambiguateLeadingDashPath(
-  value: string,
-  platform: NodeJS.Platform,
-): string {
-  if (!value.startsWith("-")) return value;
-  const prefix = platform === "win32" ? ".\\" : "./";
-  return `${prefix}${value}`;
-}
-
 export function shellQuoteIfNeeded(value: string): string {
   value = disambiguateLeadingDashPath(value, process.platform);
   // Safe-unquote criteria: only alphanumerics + a small set of

--- a/packages/create-arkor/src/bin.ts
+++ b/packages/create-arkor/src/bin.ts
@@ -221,8 +221,18 @@ function isWindowsPercentPath(cdTarget: string): boolean {
  */
 export function buildCdLine(cdTarget: string): string {
   if (isWindowsPercentPath(cdTarget)) {
+    // Round 40 follow-up (Copilot, PR #99): apply the same
+    // leading-dash disambiguation that `shellQuoteIfNeeded` uses
+    // (prefix `./` POSIX or `.\` Windows) BEFORE wrapping in PS
+    // single quotes. Without it, a directory named `-foo%bar%`
+    // would emit `cd '-foo%bar%'`, and PowerShell parses `-foo`
+    // as an option/switch to `Set-Location` even inside the
+    // single quotes (the quotes are stripped before option
+    // parsing). The `%` branch already pins us to Windows, so
+    // the prefix is `.\` unconditionally here.
+    const prefixed = cdTarget.startsWith("-") ? `.\\${cdTarget}` : cdTarget;
     // PS single-quote escape: doubled single quote `''`.
-    return `cd '${cdTarget.replace(/'/g, "''")}'`;
+    return `cd '${prefixed.replace(/'/g, "''")}'`;
   }
   return `cd ${shellQuoteIfNeeded(cdTarget)}`;
 }


### PR DESCRIPTION
## Summary

- Fix `buildCdLine`'s Windows `%`-path PowerShell fallback to prefix leading-dash paths (e.g. `-foo%bar%`) with `.\`. PowerShell strips single quotes before option parsing, so `cd '-foo%bar%'` was interpreted as `Set-Location -foo`.
- Extract the leading-dash disambiguation into an internal helper `disambiguateLeadingDashPath(value, platform)` so `shellQuoteIfNeeded` and `buildCdLine` share the same rule and can't drift.
- Keep the helper non-exported; it's only used inside `bin.ts`.

## Test plan

- Add two regression cases to the `buildCdLine` describe block in `bin.test.ts`:
  - `buildCdLine("-foo%bar%")` on win32 → `cd '.\-foo%bar%'`
  - `buildCdLine("My-%FOO%-App")` on win32 → `cd 'My-%FOO%-App'` (a `-` that isn't leading must not be prefixed).
- Existing `shellQuoteIfNeeded` tests indirectly cover the shared helper through that call path.
- `pnpm --filter create-arkor exec vitest run` — 40/40 pass.