### PR TITLE
Pin @types/node to v24 to avoid semver-major bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot settings. The update tells Dependabot to ignore major version updates for the `@types/node` dependency, which helps avoid unexpected breaking changes from major updates.

- Dependabot configuration:
  * [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR7-R10): Added an ignore rule to skip major version updates for `@types/node`.