### PR TITLE
Harden release CI: pnpm cache removal + SHA pinning (ENG-729)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
             --provenance
 
       - name: Upload release tarballs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-tarballs
           path: ${{ runner.temp }}/npm-pack/*.tgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,11 +43,18 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      # No `cache: pnpm`. This is the SLSA L3 trusted builder: any
+      # restored cache entry is an unauthenticated input from a prior
+      # run that would feed straight into the dist/ shape we then pack,
+      # attest, and `npm publish --provenance`. The provenance signed
+      # under this workflow's OIDC identity must only reflect inputs
+      # the caller's source-level checks have actually validated, so
+      # the install step has to run from the lockfile against the npm
+      # registry with no on-disk cache layer in between.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
     environment: npm-publish
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
@@ -54,7 +54,7 @@ jobs:
       # fetch from the npm registry on every run with no cache
       # restore in between (pnpm's own in-job store is still used; it
       # just starts empty).
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -105,7 +105,7 @@ jobs:
             --provenance
 
       - name: Upload release tarballs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: npm-tarballs
           path: ${{ runner.temp }}/npm-pack/*.tgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,14 +44,16 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       # No `cache: pnpm`. This is the SLSA L3 trusted builder: a pnpm
-      # store restored from a prior run's actions/cache entry is an
-      # unauthenticated input that would feed straight into the dist/
-      # shape we then pack, attest, and `npm publish --provenance`.
-      # The provenance signed under this workflow's OIDC identity must
-      # only reflect inputs the caller's source-level checks have
-      # actually validated, so install must fetch from the npm
-      # registry on every run with no cache restore in between (pnpm's
-      # own in-job store is still used; it just starts empty).
+      # store restored from a prior run's cache (this is what
+      # setup-node's `cache: pnpm` integration does via actions/cache)
+      # is an unauthenticated input that would feed straight into the
+      # dist/ shape we then pack, attest, and `npm publish
+      # --provenance`. The provenance signed under this workflow's
+      # OIDC identity must only reflect inputs the caller's
+      # source-level checks have actually validated, so install must
+      # fetch from the npm registry on every run with no cache
+      # restore in between (pnpm's own in-job store is still used; it
+      # just starts empty).
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,14 +43,15 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      # No `cache: pnpm`. This is the SLSA L3 trusted builder: any
-      # restored cache entry is an unauthenticated input from a prior
-      # run that would feed straight into the dist/ shape we then pack,
-      # attest, and `npm publish --provenance`. The provenance signed
-      # under this workflow's OIDC identity must only reflect inputs
-      # the caller's source-level checks have actually validated, so
-      # the install step has to run from the lockfile against the npm
-      # registry with no on-disk cache layer in between.
+      # No `cache: pnpm`. This is the SLSA L3 trusted builder: a pnpm
+      # store restored from a prior run's actions/cache entry is an
+      # unauthenticated input that would feed straight into the dist/
+      # shape we then pack, attest, and `npm publish --provenance`.
+      # The provenance signed under this workflow's OIDC identity must
+      # only reflect inputs the caller's source-level checks have
+      # actually validated, so install must fetch from the npm
+      # registry on every run with no cache restore in between (pnpm's
+      # own in-job store is still used; it just starts empty).
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -50,15 +50,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      # No `cache: pnpm`. Mirrors release.yaml's preflight stance: this
-      # job only validates tag shape, reconciles versions against
-      # package.json, and probes npm for prior publishes, so the
-      # no-restored-cache rule is defensive rather than load-bearing
-      # here. We keep it uniform across the dry-run path so future
-      # preflight additions that do touch the store can't silently
-      # drift back into cache reuse.
+      # No pnpm tooling on preflight. Mirrors release.yaml's preflight:
+      # this job only validates tag shape, reconciles versions via
+      # `node -p`, and probes npm for prior publishes, so
+      # `pnpm/action-setup` (and any `cache: pnpm` question that comes
+      # with it) is dead weight. Keeping the dry-run preflight
+      # minimal. If a future preflight step needs pnpm, add the setup
+      # step alongside it and consciously decide on the cache stance
+      # at that point; the test job below mirrors release.yaml's
+      # no-restored-cache rule.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -175,8 +175,11 @@ jobs:
         # invoke Playwright's browser-download script today. Setting
         # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
         # explicit so a future `allowBuilds` change can't silently
-        # re-enable a 150 MB postinstall download that the following
-        # `playwright install` step is meant to satisfy.
+        # re-enable a 150 MB postinstall download that would duplicate
+        # (and obscure) the explicit `playwright install` step below.
+        # That explicit step is the only place we want browser
+        # installation to happen, and the dry-run path runs it
+        # without restoring from a Playwright cache.
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
       # step alongside it and consciously decide on the cache stance
       # at that point; the test job below mirrors release.yaml's
       # no-restored-cache rule.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -153,7 +153,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -163,7 +163,7 @@ jobs:
       # release.yaml's test job: dry-run runs the same pack/publish
       # shape that the trusted builder would, so the cache-poisoning
       # surface stays closed here too.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -52,11 +52,15 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      # No `cache: pnpm`. Dry-run mirrors release.yaml's no-cache stance
+      # end-to-end: this job pre-flights the exact source-level shape
+      # build.yaml would publish, so the cache-poisoning surface we
+      # close in release.yaml has to be closed here too or the dry-run
+      # signal stops representing the real release path.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
 
       - name: Resolve release metadata
         id: meta
@@ -153,11 +157,14 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      # No `cache: pnpm`. Same rationale as the preflight job above and
+      # release.yaml's test job: dry-run runs the same pack/publish
+      # shape that the trusted builder would, so the cache-poisoning
+      # surface stays closed here too.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
 
       - name: Install
         # Belt-and-suspenders: pnpm-workspace.yaml's `allowBuilds`
@@ -167,7 +174,7 @@ jobs:
         # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
         # explicit so a future `allowBuilds` change can't silently
         # re-enable a 150 MB postinstall download that the following
-        # cache + `playwright install` steps are meant to satisfy.
+        # `playwright install` step is meant to satisfy.
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -52,11 +52,13 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      # No `cache: pnpm`. Dry-run mirrors release.yaml's no-cache stance
-      # end-to-end: this job pre-flights the exact source-level shape
-      # build.yaml would publish, so the cache-poisoning surface we
-      # close in release.yaml has to be closed here too or the dry-run
-      # signal stops representing the real release path.
+      # No `cache: pnpm`. Mirrors release.yaml's preflight stance: this
+      # job only validates tag shape, reconciles versions against
+      # package.json, and probes npm for prior publishes, so the
+      # no-restored-cache rule is defensive rather than load-bearing
+      # here. We keep it uniform across the dry-run path so future
+      # preflight additions that do touch the store can't silently
+      # drift back into cache reuse.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,8 +182,11 @@ jobs:
         # invoke Playwright's browser-download script today. Setting
         # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
         # explicit so a future `allowBuilds` change can't silently
-        # re-enable a 150 MB postinstall download that the following
-        # `playwright install` step is meant to satisfy.
+        # re-enable a 150 MB postinstall download that would duplicate
+        # (and obscure) the explicit `playwright install` step below.
+        # That explicit step is the only place we want browser
+        # installation to happen, and the release path runs it
+        # without restoring from a Playwright cache.
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -287,7 +287,7 @@ jobs:
           done
 
       - name: Download release tarballs
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-tarballs
           path: ${{ runner.temp }}/npm-pack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,13 +58,13 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      # No `cache: pnpm`. Same stance as the no-Playwright-cache rule on
-      # the test job below and the trusted builder in build.yaml: any
-      # restored cache entry is an unauthenticated input from a prior
-      # run, and the release path must not allow that to influence the
-      # version-reconciliation and registry-conflict checks that gate
-      # whether build.yaml runs at all. The ~10s install delta on
-      # preflight is not worth the supply-chain risk.
+      # No `cache: pnpm`. The release path policy is uniform: no
+      # actions/cache-restored pnpm store anywhere in the chain. This
+      # preflight job only reads package.json and probes npm, so the
+      # rule is defensive rather than load-bearing here, but keeping
+      # it uniform prevents drift where a future preflight step (e.g.
+      # adding a `pnpm install`-backed lint or typecheck gate) would
+      # silently start consuming a restored cache.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -163,11 +163,14 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       # No `cache: pnpm`. Same reasoning as the no-Playwright-cache step
-      # further down: a poisoned pnpm store entry restored here would
-      # feed straight into the build that the trusted builder
-      # (build.yaml) is about to re-produce and sign, and into the e2e
-      # tests that exercise it. The marginal install-time savings are
-      # not worth that supply-chain risk.
+      # further down: a pnpm store restored from a prior run's
+      # actions/cache entry is an unauthenticated input. This test
+      # job is the gate that decides whether build.yaml runs at all
+      # (build.yaml does its own clean install on a separate runner,
+      # so no on-disk state is shared with it directly), so a
+      # poisoned cache here is dangerous because it can produce a
+      # misleading-green test signal that lets a bad release through.
+      # The marginal install-time savings are not worth that.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,13 +58,13 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      # No `cache: pnpm`. The release path policy is uniform: no
-      # actions/cache-restored pnpm store anywhere in the chain. This
-      # preflight job only reads package.json and probes npm, so the
-      # rule is defensive rather than load-bearing here, but keeping
-      # it uniform prevents drift where a future preflight step (e.g.
-      # adding a `pnpm install`-backed lint or typecheck gate) would
-      # silently start consuming a restored cache.
+      # No `cache: pnpm`. The release path policy is uniform: no pnpm
+      # store restored from a prior run's cache anywhere in the chain.
+      # This preflight job only reads package.json and probes npm, so
+      # the rule is defensive rather than load-bearing here, but
+      # keeping it uniform prevents drift where a future preflight
+      # step (e.g. adding a `pnpm install`-backed lint or typecheck
+      # gate) would silently start consuming a restored cache.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -163,14 +163,14 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       # No `cache: pnpm`. Same reasoning as the no-Playwright-cache step
-      # further down: a pnpm store restored from a prior run's
-      # actions/cache entry is an unauthenticated input. This test
-      # job is the gate that decides whether build.yaml runs at all
-      # (build.yaml does its own clean install on a separate runner,
-      # so no on-disk state is shared with it directly), so a
-      # poisoned cache here is dangerous because it can produce a
-      # misleading-green test signal that lets a bad release through.
-      # The marginal install-time savings are not worth that.
+      # further down: a pnpm store restored from a prior run's cache
+      # is an unauthenticated input. This test job is the gate that
+      # decides whether build.yaml runs at all (build.yaml does its
+      # own clean install on a separate runner, so no on-disk state
+      # is shared with it directly), so a poisoned cache here is
+      # dangerous because it can produce a misleading-green test
+      # signal that lets a bad release through. The marginal
+      # install-time savings are not worth that.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
       # cache stance at that point; the test/build jobs below are the
       # reference for the no-restored-cache rule the rest of the
       # chain follows.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -156,7 +156,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -171,7 +171,7 @@ jobs:
       # dangerous because it can produce a misleading-green test
       # signal that lets a bad release through. The marginal
       # install-time savings are not worth that.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -287,7 +287,7 @@ jobs:
           done
 
       - name: Download release tarballs
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: npm-tarballs
           path: ${{ runner.temp }}/npm-pack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,11 +58,17 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      # No `cache: pnpm`. Same stance as the no-Playwright-cache rule on
+      # the test job below and the trusted builder in build.yaml: any
+      # restored cache entry is an unauthenticated input from a prior
+      # run, and the release path must not allow that to influence the
+      # version-reconciliation and registry-conflict checks that gate
+      # whether build.yaml runs at all. The ~10s install delta on
+      # preflight is not worth the supply-chain risk.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
 
       - name: Resolve release metadata
         id: meta
@@ -156,10 +162,15 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      # No `cache: pnpm`. Same reasoning as the no-Playwright-cache step
+      # further down: a poisoned pnpm store entry restored here would
+      # feed straight into the build that the trusted builder
+      # (build.yaml) is about to re-produce and sign, and into the e2e
+      # tests that exercise it. The marginal install-time savings are
+      # not worth that supply-chain risk.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: pnpm
 
       - name: Install
         # Belt-and-suspenders: pnpm-workspace.yaml's `allowBuilds`
@@ -169,7 +180,7 @@ jobs:
         # `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps that contract
         # explicit so a future `allowBuilds` change can't silently
         # re-enable a 150 MB postinstall download that the following
-        # cache + `playwright install` steps are meant to satisfy.
+        # `playwright install` step is meant to satisfy.
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,15 +56,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      # No `cache: pnpm`. The release path policy is uniform: no pnpm
-      # store restored from a prior run's cache anywhere in the chain.
-      # This preflight job only reads package.json and probes npm, so
-      # the rule is defensive rather than load-bearing here, but
-      # keeping it uniform prevents drift where a future preflight
-      # step (e.g. adding a `pnpm install`-backed lint or typecheck
-      # gate) would silently start consuming a restored cache.
+      # No pnpm tooling on preflight. This job only validates the tag,
+      # reconciles versions via `node -p`, and probes npm, so
+      # `pnpm/action-setup` (and any `cache: pnpm` question that comes
+      # with it) is dead weight here. Keeping the release-path trust
+      # surface minimal. If a future preflight step needs pnpm, add
+      # the setup step alongside it and consciously decide on the
+      # cache stance at that point; the test/build jobs below are the
+      # reference for the no-restored-cache rule the rest of the
+      # chain follows.
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
## Summary

Hardens the `release` / `build` / `release-dry-run` workflows against
cache-poisoning and tag-mutation supply-chain vectors. The original
ticket (ENG-729) was only the pnpm-cache removal; review iterations
broadened the scope to related risks on the same code path. Everything
stays in one PR because every change targets the same release-path
trust boundary, splitting would produce more churn than the actual diff,
and the additions are all responses to feedback on this thread (split
PRs would lose that context).

`ci.yaml` is intentionally out of scope: it is the PR/branch validation
path, not the release path, so its threat model differs.

## What changed, by intent

### 1. Cache-poisoning mitigation (the original ticket)

Drops `cache: pnpm` from `actions/setup-node` in every release-path job.
A pnpm store restored from a prior run's `actions/cache` entry would be
an unauthenticated input feeding straight into the SLSA L3 trusted
builder (`build.yaml`) or its pre-flight / test gates. Mirrors the
no-Playwright-cache stance already documented on the same jobs, with
inline rationale at each removal site (refined across review rounds
1-3; no behaviour change in those refinements).

Commits: `e3b7276`, `ab5a3ad`, `8d6ec89`, `3d1e4e6`.

### 2. Preflight minimisation

Drops the unused `pnpm/action-setup` from both preflight jobs. Preflight
only validates tag shape, reconciles versions via `node -p`, and probes
npm; no `pnpm` invocations exist along that path, so the action was dead
weight expanding the trust surface unnecessarily.

Commit: `708763b`.

### 3. Tag-mutation mitigation (pin third-party actions to SHAs)

A force-moved or compromised `@v6` / `@v4` tag could swap inputs to the
trusted builder without producing any repo diff. `pnpm/action-setup` and
`actions/attest` were already pinned; this PR brings the rest of the
release-path actions in line:

| Action                      | Pinned at | SHA                                        |
| --------------------------- | --------- | ------------------------------------------ |
| `actions/checkout`          | v6.0.2    | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-node`        | v6.4.0    | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/upload-artifact`   | v7.0.1    | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | v8.0.1    | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |

Commits: `c2dfb98` (initial pin to the current latest patch within each
file's existing major line), `57aed7e` (subsequent bump of
upload/download-artifact to the current latest major).

#### Compatibility review for the upload/download-artifact major bumps

`upload-artifact` v4 -> v7 and `download-artifact` v6 -> v8 cross
several majors. Verified the release-path usage is unaffected:

- **upload-artifact v5 / v6 / v7 changes.** Runtime moved to Node 24
  (requires Actions Runner >= 2.327.1, satisfied by `ubuntu-latest`);
  v7 added opt-in `archive: false` direct-upload mode; ESM migration.
  Our usage only sets `name` / `path` / `retention-days` /
  `if-no-files-found`, all stable across v4..v7, and we keep the default
  zipped upload, so v7 behaviour matches v4.
- **download-artifact v7 / v8 changes.** Same Node 24 / ESM migration.
  v8 changed the hash-mismatch default from `warn` to `error`, which is
  desirable here: postflight downloads an artifact uploaded in the same
  workflow run, so any mismatch indicates corruption or tampering and
  should fail loudly. v8 reads upload-artifact v7's zipped output
  transparently via content-type detection, so v7 + v8 is the intended
  pairing.

## Test plan

Workflow-config only; behaviour is exercised by the release pipelines
themselves. Concrete checks:

- [x] `yaml.safe_load` parses all three workflow files
- [x] `grep -nE "uses: actions/.*@v[0-9]+$"` returns empty across the
      three release-path workflows (no moving tags remain)
- [ ] Next tag push runs `release-dry-run.yaml` end to end; visually
      confirm pinned action lines and artifact upload/download steps in
      the run log before a real release tag is cut