### PR TITLE
Pin Node version to 24.16.0 in devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,12 @@
     "turbo": "catalog:",
     "typescript-eslint": "catalog:"
   },
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1"
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.16.0",
+      "onFail": "warn"
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds a new `devEngines` configuration to the `package.json` file to specify the required Node.js runtime version for development. This helps ensure developers are using the correct Node.js version, improving consistency across the team.

Development environment configuration:

* Added a `devEngines` field to `package.json` to require Node.js version `24.16.0` for development, with a warning if the version doesn't match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Node.js runtime requirement to version 24.16.0. This aligns with current development standards and improves overall environment compatibility, stability, and support for modern features
* Adjusted project configuration settings to establish a consistent development baseline, enhance system maintainability, and reduce environment setup complexity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->