### PR TITLE
Normalize SHA-pin version comments to three-part vX.Y.Z format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -621,7 +621,7 @@ jobs:
       # extra `if:` gating is needed for those cases.
       - name: Upload arkor coverage to GitHub
         if: ${{ !cancelled() }}
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: ./packages/arkor/coverage/cobertura-coverage.xml
           language: TypeScript
@@ -630,7 +630,7 @@ jobs:
 
       - name: Upload create-arkor coverage to GitHub
         if: ${{ !cancelled() }}
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: ./packages/create-arkor/coverage/cobertura-coverage.xml
           language: TypeScript
@@ -639,7 +639,7 @@ jobs:
 
       - name: Upload cli-internal coverage to GitHub
         if: ${{ !cancelled() }}
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: ./packages/cli-internal/coverage/cobertura-coverage.xml
           language: TypeScript
@@ -648,7 +648,7 @@ jobs:
 
       - name: Upload studio-app coverage to GitHub
         if: ${{ !cancelled() }}
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: ./packages/studio-app/coverage/cobertura-coverage.xml
           language: TypeScript


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration. The version comment for the `actions/upload-code-coverage` GitHub Action is updated to specify the exact version (`v1.3.0`) instead of just `v1` for all relevant jobs. No functional changes are introduced; this is a clarification to improve version tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage upload configuration in the CI/CD pipeline for improved version pinning and consistency across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->