### PR TITLE
fix: disable credential persistence for GitHub actions checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # action-setup@v6 bootstrap-installs pnpm v11 (per its committed
       # lockfile) and only honours `packageManager` via pnpm's own
@@ -289,6 +291,8 @@ jobs:
         id: [pnpm-9, pnpm-10, pnpm-11, npm, yarn, yarn-berry, bun]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # The prior `rolldownIncompat` bootstrap path (separate Node 24
       # checkout to install + build CLIs before exercising them under
@@ -487,6 +491,8 @@ jobs:
       code-quality: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Same reason as the build job — see comment there.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # No pnpm tooling on preflight. Mirrors release.yaml's preflight:
       # this job only validates tag shape, reconciles versions via
@@ -156,6 +157,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # No pnpm tooling on preflight. This job only validates the tag,
       # reconciles versions via `node -p`, and probes npm, so
@@ -159,6 +160,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 


### PR DESCRIPTION
This pull request updates all GitHub Actions workflows to explicitly disable credential persistence when checking out code using the `actions/checkout` action. This change helps improve security by ensuring that workflow jobs do not retain GitHub authentication credentials after checkout, reducing the risk of accidental credential leaks.

Security improvements in workflow configuration:

* Added `persist-credentials: false` to all `actions/checkout` steps in `.github/workflows/ci.yaml` to prevent credentials from being stored in the job environment. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR58-R59) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR294-R295) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR494-R495)
* Updated `.github/workflows/build.yaml` to set `persist-credentials: false` for the checkout step, aligning with best practices for secure workflows.
* Modified `.github/workflows/release-dry-run.yaml` to include `persist-credentials: false` in all relevant checkout steps. [[1]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R52) [[2]](diffhunk://#diff-532d66e3120cf48f24f408bd1c2bd657615709510debe04f985dd774b06416b3R160)
* Applied the same security update to `.github/workflows/release.yaml`, ensuring all release jobs do not persist credentials after checkout. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR58) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR163)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow configurations across build, CI, and release pipelines to enhance credential handling during checkout processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->