### PR TITLE
Add doc-drift example (Arkor-hosted Gemma 4 via OpenAI-compatible API)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Repository shape
 
-pnpm + Turbo monorepo. Workspaces are declared in `pnpm-workspace.yaml` (`packages/*`, `e2e/*`, `docs`).
+pnpm + Turbo monorepo. Workspaces are declared in `pnpm-workspace.yaml` (`packages/*`, `e2e/*`, `examples/*`, `docs`).
 
 | Path | Role |
 | --- | --- |
@@ -14,6 +14,7 @@ pnpm + Turbo monorepo. Workspaces are declared in `pnpm-workspace.yaml` (`packag
 | [packages/studio-app](packages/studio-app) | **Private** Vite + React 19 SPA. `pnpm --filter @arkor/studio-app bundle` builds it; `packages/arkor/scripts/copy-studio-assets.mjs` copies `dist/` into `packages/arkor/dist/assets/`. |
 | [e2e/cli](e2e/cli) | **Private** vitest suite that spawns the built `dist/bin.mjs` of both CLIs in temp dirs. |
 | [e2e/studio](e2e/studio) | **Private** Playwright suite that spawns `arkor dev` against an in-process fake cloud-api and drives the Studio SPA in Chromium. |
+| [examples/doc-drift](examples/doc-drift) | **Private** use-case example: documentation drift check against an Arkor deployment (zero-dependency script + copy-me workflow). |
 | [docs](docs) | Mintlify sources for [docs.arkor.ai](https://docs.arkor.ai). |
 
 ## Common commands

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -23,11 +23,12 @@ arkor/
 │   └── studio-app/         # `arkor` にバンドルされる Vite + React SPA
 ├── e2e/cli/                # スキャフォルダー & ビルドの vitest ベース E2E スイート
 ├── e2e/studio/             # Studio SPA 用の Playwright E2E スイート
+├── examples/doc-drift/     # Arkor デプロイメントで行うドキュメントドリフト検知の例
 ├── assets/                 # README / OG 画像
 └── turbo.json              # ビルド / テストのオーケストレーション
 ```
 
-`cli-internal`、`studio-app`、`e2e/cli`、`e2e/studio` はプライベートで、公開されることはありません。
+`cli-internal`、`studio-app`、`e2e/cli`、`e2e/studio`、および `examples/` 配下はプライベートで、公開されることはありません。
 
 ## 開発セットアップ
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,13 @@ arkor/
 │   └── studio-app/         # Vite + React SPA bundled into `arkor`
 ├── e2e/cli/                # vitest-driven E2E suite for the scaffolder & build
 ├── e2e/studio/             # Playwright E2E suite for the Studio SPA
+├── examples/doc-drift/     # documentation drift check on an Arkor deployment
 ├── assets/                 # README / OG images
 └── turbo.json              # build / test orchestration
 ```
 
-`cli-internal`, `studio-app`, `e2e/cli`, and `e2e/studio` are private and never published.
+`cli-internal`, `studio-app`, `e2e/cli`, `e2e/studio`, and everything under
+`examples/` are private and never published.
 
 ## Development setup
 

--- a/examples/doc-drift/README.ja.md
+++ b/examples/doc-drift/README.ja.md
@@ -60,8 +60,9 @@ pnpm --filter @arkor/example-doc-drift check
 `node src/check.ts <diff-file> <doc-file...>` のように渡します。
 
 Node.js 22.18+ が必要です (24 推奨)。Node 22.6 から 22.17 では
-`--experimental-strip-types` を付けてください。自分のモデルのデプロイメント
-作成は [Arkor docs](https://docs.arkor.ai) を参照してください。
+`--experimental-strip-types` を付けてください。リクエストは 60 秒で
+タイムアウトします (`ARKOR_TIMEOUT_MS` で変更可)。自分のモデルの
+デプロイメント作成は [Arkor docs](https://docs.arkor.ai) を参照してください。
 
 ## 仕組み
 

--- a/examples/doc-drift/README.ja.md
+++ b/examples/doc-drift/README.ja.md
@@ -30,7 +30,9 @@ chat-completions API で送り、構造化された判定を受け取ります:
 2 ファイルをコピーするだけで PR チェックになります:
 
 1. [`workflow.yaml`](./workflow.yaml) を `.github/workflows/doc-drift.yaml` にコピー。
-2. [`src/check.ts`](./src/check.ts) を `scripts/doc-drift-check.ts` にコピー。
+2. [`src/check.ts`](./src/check.ts) を `scripts/doc-drift-check.mts` にコピー
+   (`.mts` 拡張子にすると `"type": "commonjs"` のプロジェクトでも ESM として
+   動作します)。
 3. Settings > Secrets and variables > Actions で次を設定:
    - `ARKOR_BASE_URL` (variable): デプロイメントの URL。例
      `https://your-model.arkor.app/v1`
@@ -54,16 +56,16 @@ pnpm --filter @arkor/example-doc-drift check
 ([`samples/doc.md`](./samples/doc.md)) と、ドキュメントに載っている
 `--max-retries` フラグを改名する diff
 ([`samples/changes.diff`](./samples/changes.diff)) の組なので、ドリフトが報告
-され exit 1 になります。自分のファイルは
+され exit 1 になります。自分のファイルは、このディレクトリで
 `node src/check.ts <diff-file> <doc-file...>` のように渡します。
 
-Node.js 24+ が必要です (Node 22.7+ は `--experimental-strip-types` で動作)。
-自分のモデルのデプロイメント作成は [Arkor docs](https://docs.arkor.ai) を参照
-してください。
+Node.js 22.18+ が必要です (24 推奨)。Node 22.6 から 22.17 では
+`--experimental-strip-types` を付けてください。自分のモデルのデプロイメント
+作成は [Arkor docs](https://docs.arkor.ai) を参照してください。
 
 ## 仕組み
 
-チェック全体がリクエスト 1 回です。構造化出力
+チェックはドキュメントごとにリクエスト 1 回です。構造化出力
 (`response_format: json_schema`) で厳密な JSON 判定を要求するため、応答は常に
 パースできます:
 

--- a/examples/doc-drift/README.ja.md
+++ b/examples/doc-drift/README.ja.md
@@ -1,0 +1,80 @@
+# ドキュメントドリフト検知
+
+[English](./README.md)
+
+Arkor デプロイメントの上に作れるものの一例です。プルリクエストのコード変更が
+README などのドキュメントを陳腐化させた瞬間に検知する、
+**ドキュメントドリフト**チェックを示します。
+
+例は依存ゼロの TypeScript スクリプト 1 ファイルです。ドキュメントと unified
+diff を、Arkor がホストする Gemma 4 デプロイメントに OpenAI 互換の
+chat-completions API で送り、構造化された判定を受け取ります:
+
+```json
+{ "drifted": true, "severity": "warning", "explanation": "...", "suggestion": "..." }
+```
+
+## いちばん簡単な方法: GitHub App を入れる
+
+自分で動かす必要はありません。
+[drift-check GitHub App](https://github.com/apps/drift-check) をインストール
+すると、選んだリポジトリのすべてのプルリクエストで、この例と同じこと
+(加えてコメント/コード乖離チェック) が実行され、レビュー要約として投稿され
+ます。ワークフローも secrets もコードも不要です。
+
+この例は、そのようなチェックが内部でどう動くか、Arkor デプロイメントがあれば
+どれほど少ないコードで済むかを示すためのものです。
+
+## GitHub ワークフローとして使う
+
+2 ファイルをコピーするだけで PR チェックになります:
+
+1. [`workflow.yaml`](./workflow.yaml) を `.github/workflows/doc-drift.yaml` にコピー。
+2. [`src/check.ts`](./src/check.ts) を `scripts/doc-drift-check.ts` にコピー。
+3. Settings > Secrets and variables > Actions で次を設定:
+   - `ARKOR_BASE_URL` (variable): デプロイメントの URL。例
+     `https://your-model.arkor.app/v1`
+   - `ARKOR_API_KEY` (secret): デプロイメントが `fixed_api_key` 認証の場合のみ
+   - `ARKOR_MODEL` (variable、任意): 既定は `gemma-4-31b-it`
+
+PR ごとに、ドキュメント別の判定表がジョブ要約に表示されます。ドリフト検知時は
+step が失敗します。advisory (非ブロッキング) にしたい場合は
+`continue-on-error: true` を付けてください。
+
+## ローカルで動かす
+
+```sh
+pnpm install
+
+ARKOR_BASE_URL=https://your-model.arkor.app/v1 \
+pnpm --filter @arkor/example-doc-drift check
+```
+
+引数なしで実行すると同梱サンプルをチェックします。架空 CLI の README
+([`samples/doc.md`](./samples/doc.md)) と、ドキュメントに載っている
+`--max-retries` フラグを改名する diff
+([`samples/changes.diff`](./samples/changes.diff)) の組なので、ドリフトが報告
+され exit 1 になります。自分のファイルは
+`node src/check.ts <diff-file> <doc-file...>` のように渡します。
+
+Node.js 24+ が必要です (Node 22.7+ は `--experimental-strip-types` で動作)。
+自分のモデルのデプロイメント作成は [Arkor docs](https://docs.arkor.ai) を参照
+してください。
+
+## 仕組み
+
+チェック全体がリクエスト 1 回です。構造化出力
+(`response_format: json_schema`) で厳密な JSON 判定を要求するため、応答は常に
+パースできます:
+
+- `drifted`: この diff がドキュメントを不正確にするか
+- `severity`: `info`、`warning`、`error` のいずれか
+- `explanation`: diff と矛盾するドキュメント記述の指摘
+- `suggestion`: 具体的なドキュメント修正案
+
+プロンプトは意図的に保守的です。diff が**明確に**もたらす不整合だけを対象に
+するため、ドキュメント自体の編集や無関係な変更でノイズは出ません。この
+アイデアの製品版 (大きな PR の diff チャンク分割、コメント/コード乖離
+チェック、レビューコメント投稿) は
+[drift-check GitHub App](https://github.com/apps/drift-check) として提供
+されています。

--- a/examples/doc-drift/README.md
+++ b/examples/doc-drift/README.md
@@ -60,8 +60,9 @@ so it reports drift and exits 1. Pass your own files (from this directory) as
 `node src/check.ts <diff-file> <doc-file...>`.
 
 Requires Node.js 22.18+ (24 recommended); on Node 22.6 to 22.17, pass
-`--experimental-strip-types`. To create a deployment of your own model, see
-the [Arkor docs](https://docs.arkor.ai).
+`--experimental-strip-types`. Requests time out after 60 seconds; set
+`ARKOR_TIMEOUT_MS` to change that. To create a deployment of your own model,
+see the [Arkor docs](https://docs.arkor.ai).
 
 ## How it works
 

--- a/examples/doc-drift/README.md
+++ b/examples/doc-drift/README.md
@@ -1,0 +1,80 @@
+# Documentation drift check
+
+[日本語](./README.ja.md)
+
+One of the things you can build on an Arkor deployment: a check that catches
+**documentation drift**, the moment a pull request changes code in a way that
+makes your README (or any other document) stale.
+
+The example is a single zero-dependency TypeScript script. It sends a
+documentation file plus a unified diff to an Arkor-hosted Gemma 4 deployment
+over the OpenAI-compatible chat-completions API, and gets back a structured
+verdict:
+
+```json
+{ "drifted": true, "severity": "warning", "explanation": "...", "suggestion": "..." }
+```
+
+## The easy way: install the GitHub App
+
+You do not need to run any of this yourself. Install the
+[drift-check GitHub App](https://github.com/apps/drift-check) and every pull
+request in the selected repositories gets exactly what this example shows
+(plus comment/code divergence checks), posted as a review summary. No
+workflow files, no secrets, no code.
+
+This example exists to show how such a check works under the hood, and how
+little code an Arkor deployment needs.
+
+## Use it as a GitHub workflow
+
+Two files, copied into your repository, turn this into a PR check:
+
+1. Copy [`workflow.yaml`](./workflow.yaml) to `.github/workflows/doc-drift.yaml`.
+2. Copy [`src/check.ts`](./src/check.ts) to `scripts/doc-drift-check.ts`.
+3. In Settings > Secrets and variables > Actions, set:
+   - `ARKOR_BASE_URL` (variable): your deployment URL, e.g.
+     `https://your-model.arkor.app/v1`
+   - `ARKOR_API_KEY` (secret): only when the deployment uses
+     `fixed_api_key` auth
+   - `ARKOR_MODEL` (variable, optional): defaults to `gemma-4-31b-it`
+
+Each PR then gets a per-document verdict table in the job summary. The step
+fails when drift is detected; add `continue-on-error: true` to keep it
+advisory.
+
+## Run it locally
+
+```sh
+pnpm install
+
+ARKOR_BASE_URL=https://your-model.arkor.app/v1 \
+pnpm --filter @arkor/example-doc-drift check
+```
+
+With no arguments the script checks the bundled samples: a fictional CLI
+README ([`samples/doc.md`](./samples/doc.md)) against a diff that renames the
+documented `--max-retries` flag ([`samples/changes.diff`](./samples/changes.diff)),
+so it reports drift and exits 1. Pass your own files as
+`node src/check.ts <diff-file> <doc-file...>`.
+
+Requires Node.js 24+ (Node 22.7+ works with `--experimental-strip-types`).
+To create a deployment of your own model, see the
+[Arkor docs](https://docs.arkor.ai).
+
+## How it works
+
+The whole check is one request. The script asks the model for a strict JSON
+verdict using structured outputs (`response_format: json_schema`), so the
+response always parses:
+
+- `drifted`: whether this diff makes the document inaccurate
+- `severity`: `info`, `warning`, or `error`
+- `explanation`: which documented statement the diff contradicts
+- `suggestion`: a concrete documentation fix
+
+The prompt is deliberately conservative: only clear inconsistencies that the
+diff introduces count, so documentation edits or unrelated changes do not
+produce noise. The production-grade version of this idea (diff chunking for
+large PRs, comment/code divergence checks, review comments) ships as the
+[drift-check GitHub App](https://github.com/apps/drift-check).

--- a/examples/doc-drift/README.md
+++ b/examples/doc-drift/README.md
@@ -31,7 +31,8 @@ little code an Arkor deployment needs.
 Two files, copied into your repository, turn this into a PR check:
 
 1. Copy [`workflow.yaml`](./workflow.yaml) to `.github/workflows/doc-drift.yaml`.
-2. Copy [`src/check.ts`](./src/check.ts) to `scripts/doc-drift-check.ts`.
+2. Copy [`src/check.ts`](./src/check.ts) to `scripts/doc-drift-check.mts`
+   (the `.mts` extension keeps it ESM even in `"type": "commonjs"` projects).
 3. In Settings > Secrets and variables > Actions, set:
    - `ARKOR_BASE_URL` (variable): your deployment URL, e.g.
      `https://your-model.arkor.app/v1`
@@ -55,18 +56,18 @@ pnpm --filter @arkor/example-doc-drift check
 With no arguments the script checks the bundled samples: a fictional CLI
 README ([`samples/doc.md`](./samples/doc.md)) against a diff that renames the
 documented `--max-retries` flag ([`samples/changes.diff`](./samples/changes.diff)),
-so it reports drift and exits 1. Pass your own files as
+so it reports drift and exits 1. Pass your own files (from this directory) as
 `node src/check.ts <diff-file> <doc-file...>`.
 
-Requires Node.js 24+ (Node 22.7+ works with `--experimental-strip-types`).
-To create a deployment of your own model, see the
-[Arkor docs](https://docs.arkor.ai).
+Requires Node.js 22.18+ (24 recommended); on Node 22.6 to 22.17, pass
+`--experimental-strip-types`. To create a deployment of your own model, see
+the [Arkor docs](https://docs.arkor.ai).
 
 ## How it works
 
-The whole check is one request. The script asks the model for a strict JSON
-verdict using structured outputs (`response_format: json_schema`), so the
-response always parses:
+The whole check is one request per document. The script asks the model for a
+strict JSON verdict using structured outputs (`response_format: json_schema`),
+so the response always parses:
 
 - `drifted`: whether this diff makes the document inaccurate
 - `severity`: `info`, `warning`, or `error`

--- a/examples/doc-drift/package.json
+++ b/examples/doc-drift/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@arkor/example-doc-drift",
+  "version": "0.0.0",
+  "description": "Documentation drift detection example: asks an Arkor-hosted Gemma 4 deployment (OpenAI-compatible API) whether a pull request diff makes a documentation file stale. Never published.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node src/check.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --deny-warnings . && eslint ."
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/doc-drift/samples/changes.diff
+++ b/examples/doc-drift/samples/changes.diff
@@ -1,0 +1,30 @@
+diff --git a/src/cli.ts b/src/cli.ts
+index 3f1c2aa..9d84b01 100644
+--- a/src/cli.ts
++++ b/src/cli.ts
+@@ -12,9 +12,9 @@ export interface SendOptions {
+   artifact: string;
+-  /** Retry a failed upload up to this many times. Default: 3. */
+-  maxRetries: number;
++  /** Retry a failed upload up to this many times. Default: 5. */
++  retryLimit: number;
+   /** Abort an upload attempt after this many seconds. Default: 30. */
+   timeoutSeconds: number;
+   quiet: boolean;
+ }
+@@ -34,12 +34,12 @@ export function parseArgs(argv: string[]): SendOptions {
+   const options: SendOptions = {
+     artifact: "",
+-    maxRetries: 3,
++    retryLimit: 5,
+     timeoutSeconds: 30,
+     quiet: false,
+   };
+   for (const arg of argv) {
+-    if (arg.startsWith("--max-retries=")) {
+-      options.maxRetries = Number(arg.slice("--max-retries=".length));
++    if (arg.startsWith("--retry-limit=")) {
++      options.retryLimit = Number(arg.slice("--retry-limit=".length));
+     } else if (arg.startsWith("--timeout=")) {
+       options.timeoutSeconds = Number(arg.slice("--timeout=".length));
+     }

--- a/examples/doc-drift/samples/changes.diff
+++ b/examples/doc-drift/samples/changes.diff
@@ -2,7 +2,7 @@ diff --git a/src/cli.ts b/src/cli.ts
 index 3f1c2aa..9d84b01 100644
 --- a/src/cli.ts
 +++ b/src/cli.ts
-@@ -12,9 +12,9 @@ export interface SendOptions {
+@@ -12,7 +12,7 @@ export interface SendOptions {
    artifact: string;
 -  /** Retry a failed upload up to this many times. Default: 3. */
 -  maxRetries: number;

--- a/examples/doc-drift/samples/doc.md
+++ b/examples/doc-drift/samples/doc.md
@@ -6,7 +6,7 @@ against a code diff and reports statements that the diff makes stale.
 
 ## Usage
 
-```
+```text
 relay send <artifact>
 ```
 

--- a/examples/doc-drift/samples/doc.md
+++ b/examples/doc-drift/samples/doc.md
@@ -1,0 +1,25 @@
+# relay CLI
+
+`relay` is a small (fictional) command line tool used by this example. This
+file plays the role of your project's README: the drift check compares it
+against a code diff and reports statements that the diff makes stale.
+
+## Usage
+
+```
+relay send <artifact>
+```
+
+Uploads a build artifact to the relay server.
+
+## Options
+
+- `--max-retries <n>`: Retry a failed upload up to `n` times. Defaults to 3.
+- `--timeout <seconds>`: Abort an upload attempt after this many seconds.
+  Defaults to 30.
+- `--quiet`: Suppress progress output. Errors are still printed.
+
+## Exit codes
+
+- `0`: the artifact was uploaded.
+- `1`: all retries were exhausted.

--- a/examples/doc-drift/src/check.ts
+++ b/examples/doc-drift/src/check.ts
@@ -77,7 +77,7 @@ function usage(): string {
 }
 
 function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max) : text;
+  return text.length > max ? `${text.slice(0, max)}\n...[truncated]` : text;
 }
 
 async function readText(path: string, kind: string): Promise<string> {
@@ -101,7 +101,7 @@ function isVerdict(value: unknown): value is Verdict {
 
 /** Extract choices[0].message.content from an OpenAI-compatible response. */
 function extractContent(payload: unknown): string {
-  const typed = payload as {
+  const typed = (payload ?? {}) as {
     choices?: { message?: { content?: unknown } }[];
   };
   const content = typed.choices?.[0]?.message?.content;
@@ -167,6 +167,18 @@ function here(relative: string): string {
   return fileURLToPath(new URL(relative, import.meta.url));
 }
 
+/**
+ * Make a model- or user-controlled string safe inside one Markdown table cell:
+ * bounded length, no newlines (they would end the row), no pipes (they would
+ * split the cell), no backticks (they could break the inline-code span).
+ */
+function tableCell(text: string): string {
+  return truncate(text, 500)
+    .replaceAll(/\r?\n/g, " ")
+    .replaceAll("|", String.raw`\|`)
+    .replaceAll("`", "'");
+}
+
 /** Append a Markdown result table to the GitHub Actions job summary, if any. */
 async function writeStepSummary(
   results: { path: string; verdict: Verdict }[],
@@ -176,9 +188,9 @@ async function writeStepSummary(
 
   const rows = results.map(
     ({ path, verdict }) =>
-      `| \`${path}\` | ${verdict.drifted ? "drifted" : "ok"} | ${
+      `| \`${tableCell(path)}\` | ${verdict.drifted ? "drifted" : "ok"} | ${
         verdict.severity
-      } | ${verdict.drifted ? verdict.explanation : ""} |`,
+      } | ${verdict.drifted ? tableCell(verdict.explanation) : ""} |`,
   );
   const table = [
     "## Documentation drift check",
@@ -198,18 +210,34 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
+  // Treat empty env values as unset: in GitHub Actions an unconfigured
+  // `vars.*` interpolates to an empty string, not to a missing variable.
+  const modelEnv = process.env.ARKOR_MODEL;
   const config = {
     baseUrl,
     apiKey: process.env.ARKOR_API_KEY ?? "",
-    model: process.env.ARKOR_MODEL ?? DEFAULT_MODEL,
+    model: modelEnv !== undefined && modelEnv !== "" ? modelEnv : DEFAULT_MODEL,
   };
 
+  // All-or-nothing arguments: pairing a caller's diff with the bundled sample
+  // doc would only ever produce a nonsense verdict.
   const args = process.argv.slice(2);
+  if (args.length === 1) {
+    console.error("Pass both a diff file and at least one doc file.\n");
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
   const diffPath = args.length > 0 ? args[0] : here("../samples/changes.diff");
   const docPaths =
     args.length > 1 ? args.slice(1) : [here("../samples/doc.md")];
 
   const diffText = await readText(diffPath, "diff");
+  if (diffText.length > MAX_TEXT_CHARS) {
+    console.error(
+      `note: diff exceeds ${String(MAX_TEXT_CHARS)} chars and was truncated`,
+    );
+  }
   if (diffText.trim() === "") {
     console.log("No code changes to check; done.");
     return;
@@ -218,6 +246,11 @@ async function main(): Promise<void> {
   const results: { path: string; verdict: Verdict }[] = [];
   for (const docPath of docPaths) {
     const docText = await readText(docPath, "documentation");
+    if (docText.length > MAX_TEXT_CHARS) {
+      console.error(
+        `note: ${docPath} exceeds ${String(MAX_TEXT_CHARS)} chars and was truncated`,
+      );
+    }
     const verdict = await requestVerdict(config, docText, diffText);
     results.push({ path: docPath, verdict });
 

--- a/examples/doc-drift/src/check.ts
+++ b/examples/doc-drift/src/check.ts
@@ -14,6 +14,7 @@ import { appendFile, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_MODEL = "gemma-4-31b-it";
+const DEFAULT_TIMEOUT_MS = 60_000;
 
 // Keep prompts well under typical context limits; a real product would chunk
 // instead of truncating (the drift-check App does).
@@ -68,8 +69,9 @@ function usage(): string {
     "  ARKOR_BASE_URL  OpenAI-compatible base URL of your Arkor deployment,",
     "                  e.g. https://your-model.arkor.app/v1",
     "Optional environment:",
-    "  ARKOR_API_KEY   API key, when the deployment uses fixed_api_key auth",
-    `  ARKOR_MODEL     Model name (default: ${DEFAULT_MODEL})`,
+    "  ARKOR_API_KEY     API key, when the deployment uses fixed_api_key auth",
+    `  ARKOR_MODEL       Model name (default: ${DEFAULT_MODEL})`,
+    `  ARKOR_TIMEOUT_MS  Per-request timeout (default: ${String(DEFAULT_TIMEOUT_MS)})`,
     "",
     "Prefer zero setup? Install the drift-check GitHub App instead:",
     "  https://github.com/apps/drift-check",
@@ -112,13 +114,15 @@ function extractContent(payload: unknown): string {
 }
 
 async function requestVerdict(
-  config: { baseUrl: string; apiKey: string; model: string },
+  config: { baseUrl: string; apiKey: string; model: string; timeoutMs: number },
   docText: string,
   diffText: string,
 ): Promise<Verdict> {
   const endpoint = `${config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
-  const response = await fetch(endpoint, {
+  const request: RequestInit = {
     method: "POST",
+    // Fail fast instead of hanging a CI job when the endpoint stalls.
+    signal: AbortSignal.timeout(config.timeoutMs),
     headers: {
       "content-type": "application/json",
       ...(config.apiKey ? { authorization: `Bearer ${config.apiKey}` } : {}),
@@ -148,7 +152,20 @@ async function requestVerdict(
         },
       ],
     }),
-  });
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, request);
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new Error(
+        `Request timed out after ${String(config.timeoutMs)}ms: ${endpoint}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 
   if (!response.ok) {
     const body = truncate(await response.text(), 300);
@@ -186,12 +203,17 @@ async function writeStepSummary(
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
 
-  const rows = results.map(
-    ({ path, verdict }) =>
-      `| \`${tableCell(path)}\` | ${verdict.drifted ? "drifted" : "ok"} | ${
-        verdict.severity
-      } | ${verdict.drifted ? tableCell(verdict.explanation) : ""} |`,
-  );
+  // Both variable cells are rendered as inline code: tableCell() strips
+  // backticks, so model-controlled text cannot escape the span, and inside a
+  // code span Markdown (links, images, emphasis) does not render at all.
+  const rows = results.map(({ path, verdict }) => {
+    const explanation =
+      verdict.drifted && verdict.explanation.trim() !== ""
+        ? `\`${tableCell(verdict.explanation)}\``
+        : "";
+    const status = verdict.drifted ? "drifted" : "ok";
+    return `| \`${tableCell(path)}\` | ${status} | ${verdict.severity} | ${explanation} |`;
+  });
   const table = [
     "## Documentation drift check",
     "",
@@ -213,10 +235,23 @@ async function main(): Promise<void> {
   // Treat empty env values as unset: in GitHub Actions an unconfigured
   // `vars.*` interpolates to an empty string, not to a missing variable.
   const modelEnv = process.env.ARKOR_MODEL;
+  const timeoutEnv = process.env.ARKOR_TIMEOUT_MS;
+  const timeoutMs =
+    timeoutEnv !== undefined && timeoutEnv !== ""
+      ? Number(timeoutEnv)
+      : DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    console.error(
+      `ARKOR_TIMEOUT_MS must be a positive integer, got: ${timeoutEnv ?? ""}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   const config = {
     baseUrl,
     apiKey: process.env.ARKOR_API_KEY ?? "",
     model: modelEnv !== undefined && modelEnv !== "" ? modelEnv : DEFAULT_MODEL,
+    timeoutMs,
   };
 
   // All-or-nothing arguments: pairing a caller's diff with the bundled sample

--- a/examples/doc-drift/src/check.ts
+++ b/examples/doc-drift/src/check.ts
@@ -1,0 +1,245 @@
+// Documentation drift check, as a single zero-dependency script.
+//
+// Reads a unified diff (the code changes of a pull request) and one or more
+// documentation files, then asks an Arkor-hosted model over the
+// OpenAI-compatible chat-completions API whether those changes make each
+// document inaccurate. See README.md in this directory for setup, and for the
+// zero-setup alternative: the drift-check GitHub App
+// (https://github.com/apps/drift-check).
+//
+// Usage: node src/check.ts [diff-file] [doc-file...]
+// Env:   ARKOR_BASE_URL (required), ARKOR_API_KEY, ARKOR_MODEL
+
+import { appendFile, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MODEL = "gemma-4-31b-it";
+
+// Keep prompts well under typical context limits; a real product would chunk
+// instead of truncating (the drift-check App does).
+const MAX_TEXT_CHARS = 48_000;
+
+const SEVERITIES = ["info", "warning", "error"] as const;
+type Severity = (typeof SEVERITIES)[number];
+
+interface Verdict {
+  drifted: boolean;
+  severity: Severity;
+  explanation: string;
+  suggestion: string;
+}
+
+const VERDICT_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["drifted", "severity", "explanation", "suggestion"],
+  properties: {
+    drifted: { type: "boolean" },
+    severity: { type: "string", enum: [...SEVERITIES] },
+    explanation: { type: "string" },
+    suggestion: { type: "string" },
+  },
+} as const;
+
+const SYSTEM_PROMPT = `You review documentation against code changes.
+Decide whether the given unified diff makes the given documentation file
+inaccurate, misleading, or incomplete.
+
+Set "drifted" to true ONLY for a clear inconsistency introduced by this diff,
+for example: the documentation names a flag, command, default value, or file
+that the diff renames, removes, or changes. Ignore style and unrelated or
+pre-existing issues. When unsure, set "drifted" to false.
+
+severity: "error" when the documentation now contradicts the code,
+"warning" when it is likely stale, "info" for minor drift.
+explanation: one or two specific sentences naming the doc statement and the
+change. suggestion: a concrete documentation fix when drifted, else "".
+
+Respond with ONLY a JSON object matching the provided schema.`;
+
+function usage(): string {
+  return [
+    "doc-drift: check whether a pull request diff makes documentation stale.",
+    "",
+    "Usage: node src/check.ts [diff-file] [doc-file...]",
+    "       (defaults: samples/changes.diff samples/doc.md)",
+    "",
+    "Required environment:",
+    "  ARKOR_BASE_URL  OpenAI-compatible base URL of your Arkor deployment,",
+    "                  e.g. https://your-model.arkor.app/v1",
+    "Optional environment:",
+    "  ARKOR_API_KEY   API key, when the deployment uses fixed_api_key auth",
+    `  ARKOR_MODEL     Model name (default: ${DEFAULT_MODEL})`,
+    "",
+    "Prefer zero setup? Install the drift-check GitHub App instead:",
+    "  https://github.com/apps/drift-check",
+  ].join("\n");
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) : text;
+}
+
+async function readText(path: string, kind: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    throw new Error(`Could not read ${kind} file: ${path}`);
+  }
+}
+
+function isVerdict(value: unknown): value is Verdict {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Partial<Record<keyof Verdict, unknown>>;
+  return (
+    typeof record.drifted === "boolean" &&
+    typeof record.explanation === "string" &&
+    typeof record.suggestion === "string" &&
+    SEVERITIES.includes(record.severity as Severity)
+  );
+}
+
+/** Extract choices[0].message.content from an OpenAI-compatible response. */
+function extractContent(payload: unknown): string {
+  const typed = payload as {
+    choices?: { message?: { content?: unknown } }[];
+  };
+  const content = typed.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || content.length === 0) {
+    throw new Error("Model returned an empty response");
+  }
+  return content;
+}
+
+async function requestVerdict(
+  config: { baseUrl: string; apiKey: string; model: string },
+  docText: string,
+  diffText: string,
+): Promise<Verdict> {
+  const endpoint = `${config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(config.apiKey ? { authorization: `Bearer ${config.apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      model: config.model,
+      temperature: 0,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "doc_drift",
+          strict: true,
+          schema: VERDICT_JSON_SCHEMA,
+        },
+      },
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        {
+          role: "user",
+          content: [
+            "=== DOCUMENTATION ===",
+            truncate(docText, MAX_TEXT_CHARS),
+            "",
+            "=== CODE CHANGES (unified diff) ===",
+            truncate(diffText, MAX_TEXT_CHARS),
+          ].join("\n"),
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const body = truncate(await response.text(), 300);
+    throw new Error(`Request failed: HTTP ${String(response.status)} ${body}`);
+  }
+
+  const verdict: unknown = JSON.parse(extractContent(await response.json()));
+  if (!isVerdict(verdict)) {
+    throw new Error("Model response did not match the verdict schema");
+  }
+  return verdict;
+}
+
+/** Resolve a path relative to this example directory. */
+function here(relative: string): string {
+  return fileURLToPath(new URL(relative, import.meta.url));
+}
+
+/** Append a Markdown result table to the GitHub Actions job summary, if any. */
+async function writeStepSummary(
+  results: { path: string; verdict: Verdict }[],
+): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const rows = results.map(
+    ({ path, verdict }) =>
+      `| \`${path}\` | ${verdict.drifted ? "drifted" : "ok"} | ${
+        verdict.severity
+      } | ${verdict.drifted ? verdict.explanation : ""} |`,
+  );
+  const table = [
+    "## Documentation drift check",
+    "",
+    "| Document | Result | Severity | Explanation |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+  await appendFile(summaryPath, table);
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.ARKOR_BASE_URL;
+  if (!baseUrl) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+  const config = {
+    baseUrl,
+    apiKey: process.env.ARKOR_API_KEY ?? "",
+    model: process.env.ARKOR_MODEL ?? DEFAULT_MODEL,
+  };
+
+  const args = process.argv.slice(2);
+  const diffPath = args.length > 0 ? args[0] : here("../samples/changes.diff");
+  const docPaths =
+    args.length > 1 ? args.slice(1) : [here("../samples/doc.md")];
+
+  const diffText = await readText(diffPath, "diff");
+  if (diffText.trim() === "") {
+    console.log("No code changes to check; done.");
+    return;
+  }
+
+  const results: { path: string; verdict: Verdict }[] = [];
+  for (const docPath of docPaths) {
+    const docText = await readText(docPath, "documentation");
+    const verdict = await requestVerdict(config, docText, diffText);
+    results.push({ path: docPath, verdict });
+
+    if (verdict.drifted) {
+      console.log(`DRIFT ${docPath} [${verdict.severity}]`);
+      console.log(`  why: ${verdict.explanation}`);
+      if (verdict.suggestion) console.log(`  fix: ${verdict.suggestion}`);
+    } else {
+      console.log(`ok    ${docPath}`);
+    }
+  }
+
+  await writeStepSummary(results);
+
+  if (results.some(({ verdict }) => verdict.drifted)) {
+    process.exitCode = 1;
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/examples/doc-drift/src/check.ts
+++ b/examples/doc-drift/src/check.ts
@@ -8,7 +8,8 @@
 // (https://github.com/apps/drift-check).
 //
 // Usage: node src/check.ts [diff-file] [doc-file...]
-// Env:   ARKOR_BASE_URL (required), ARKOR_API_KEY, ARKOR_MODEL
+// Env:   ARKOR_BASE_URL (required), ARKOR_API_KEY, ARKOR_MODEL,
+//        ARKOR_TIMEOUT_MS
 
 import { appendFile, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -80,6 +81,15 @@ function usage(): string {
 
 function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max)}\n...[truncated]` : text;
+}
+
+/**
+ * Flatten untrusted text to one bounded line before writing it to the runner
+ * log. GitHub Actions interprets any log line starting with "::" as a workflow
+ * command, so model-controlled output must never introduce its own lines.
+ */
+function logLine(text: string): string {
+  return truncate(text, 500).replaceAll(/\r?\n/g, " ");
 }
 
 async function readText(path: string, kind: string): Promise<string> {
@@ -291,8 +301,9 @@ async function main(): Promise<void> {
 
     if (verdict.drifted) {
       console.log(`DRIFT ${docPath} [${verdict.severity}]`);
-      console.log(`  why: ${verdict.explanation}`);
-      if (verdict.suggestion) console.log(`  fix: ${verdict.suggestion}`);
+      console.log(`  why: ${logLine(verdict.explanation)}`);
+      if (verdict.suggestion)
+        console.log(`  fix: ${logLine(verdict.suggestion)}`);
     } else {
       console.log(`ok    ${docPath}`);
     }
@@ -308,6 +319,9 @@ async function main(): Promise<void> {
 try {
   await main();
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  // Error messages can embed upstream response text; keep them to one line.
+  console.error(
+    logLine(error instanceof Error ? error.message : String(error)),
+  );
   process.exitCode = 1;
 }

--- a/examples/doc-drift/tsconfig.json
+++ b/examples/doc-drift/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/doc-drift/workflow.yaml
+++ b/examples/doc-drift/workflow.yaml
@@ -1,0 +1,56 @@
+# Documentation drift check for pull requests, powered by an Arkor-hosted
+# model. This is a copy-me example, not an active workflow of this repository.
+#
+# To use it in YOUR repository:
+#   1. Copy this file to .github/workflows/doc-drift.yaml
+#   2. Copy src/check.ts (from this example) to scripts/doc-drift-check.ts
+#   3. Configure, under Settings > Secrets and variables > Actions:
+#        - Variable ARKOR_BASE_URL  e.g. https://your-model.arkor.app/v1
+#        - Secret   ARKOR_API_KEY   only when the deployment requires a key
+#        - Variable ARKOR_MODEL     optional, defaults to gemma-4-31b-it
+#
+# Prefer zero setup? Install the drift-check GitHub App instead:
+# https://github.com/apps/drift-check
+name: Doc Drift
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel a superseded check when a newer commit is pushed to the same PR.
+concurrency:
+  group: doc-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doc-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so the merge base with the target branch exists.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Collect the pull request diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git diff --merge-base "origin/$BASE_REF" HEAD > changes.diff
+
+      # List the documentation files to guard after the diff file. The verdict
+      # for each document lands in the job summary. The step fails when drift
+      # is detected; add `continue-on-error: true` to make it advisory.
+      - name: Check documentation drift
+        env:
+          ARKOR_BASE_URL: ${{ vars.ARKOR_BASE_URL }}
+          ARKOR_API_KEY: ${{ secrets.ARKOR_API_KEY }}
+          ARKOR_MODEL: ${{ vars.ARKOR_MODEL }}
+        run: node scripts/doc-drift-check.ts changes.diff README.md

--- a/examples/doc-drift/workflow.yaml
+++ b/examples/doc-drift/workflow.yaml
@@ -11,8 +11,13 @@
 #        - Secret   ARKOR_API_KEY   only when the deployment requires a key
 #        - Variable ARKOR_MODEL     optional, defaults to gemma-4-31b-it
 #
-# Note: secrets are not available to pull requests from forks, so keyed
-# deployments will fail there; public repos may want continue-on-error.
+# Security notes:
+#   - Secrets are not available to pull requests from forks, so keyed
+#     deployments will fail there; public repos may want continue-on-error.
+#   - The checker step below runs the BASE branch copy of the script, so a
+#     pull request cannot edit the script that receives ARKOR_API_KEY. Only
+#     the diff and the doc files come from the PR. For repos where anyone
+#     can open branch PRs, prefer a keyless (authMode "none") deployment.
 #
 # Prefer zero setup? Install the drift-check GitHub App instead:
 # https://github.com/apps/drift-check
@@ -50,6 +55,17 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git diff --merge-base "origin/$BASE_REF" HEAD > changes.diff
 
+      # Take the checker from the base branch, NOT from the PR checkout, so a
+      # pull request cannot modify the code that receives ARKOR_API_KEY.
+      # Caveat: the very first PR that introduces the script has no base copy
+      # yet; merge it first (or run that one PR keyless).
+      - name: Materialize the checker from the base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git show "origin/$BASE_REF:scripts/doc-drift-check.mts" \
+            > "$RUNNER_TEMP/doc-drift-check.mts"
+
       # List the documentation files to guard after the diff file. The verdict
       # for each document lands in the job summary. The step fails when drift
       # is detected; add `continue-on-error: true` to make it advisory.
@@ -58,4 +74,4 @@ jobs:
           ARKOR_BASE_URL: ${{ vars.ARKOR_BASE_URL }}
           ARKOR_API_KEY: ${{ secrets.ARKOR_API_KEY }}
           ARKOR_MODEL: ${{ vars.ARKOR_MODEL }}
-        run: node scripts/doc-drift-check.mts changes.diff README.md
+        run: node "$RUNNER_TEMP/doc-drift-check.mts" changes.diff README.md

--- a/examples/doc-drift/workflow.yaml
+++ b/examples/doc-drift/workflow.yaml
@@ -3,11 +3,16 @@
 #
 # To use it in YOUR repository:
 #   1. Copy this file to .github/workflows/doc-drift.yaml
-#   2. Copy src/check.ts (from this example) to scripts/doc-drift-check.ts
+#   2. Copy src/check.ts (from this example) to scripts/doc-drift-check.mts
+#      (the .mts extension keeps the script ESM even when your package.json
+#      declares "type": "commonjs")
 #   3. Configure, under Settings > Secrets and variables > Actions:
 #        - Variable ARKOR_BASE_URL  e.g. https://your-model.arkor.app/v1
 #        - Secret   ARKOR_API_KEY   only when the deployment requires a key
 #        - Variable ARKOR_MODEL     optional, defaults to gemma-4-31b-it
+#
+# Note: secrets are not available to pull requests from forks, so keyed
+# deployments will fail there; public repos may want continue-on-error.
 #
 # Prefer zero setup? Install the drift-check GitHub App instead:
 # https://github.com/apps/drift-check
@@ -53,4 +58,4 @@ jobs:
           ARKOR_BASE_URL: ${{ vars.ARKOR_BASE_URL }}
           ARKOR_API_KEY: ${{ secrets.ARKOR_API_KEY }}
           ARKOR_MODEL: ${{ vars.ARKOR_MODEL }}
-        run: node scripts/doc-drift-check.ts changes.diff README.md
+        run: node scripts/doc-drift-check.mts changes.diff README.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,15 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  examples/doc-drift:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/arkor:
     dependencies:
       '@arkor/cloud-api-client':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "e2e/*"
+  - "examples/*"
   - "docs"
 # Embed each published package's README.md into the `readme` field of
 # the manifest it ships: the registry packument that npmjs.com reads to


### PR DESCRIPTION
## Summary

Adds a new top-level `examples/` workspace with one use-case example, `examples/doc-drift`: detecting **documentation drift** (a pull request diff that makes README statements stale) with an Arkor-hosted Gemma 4 deployment over the OpenAI-compatible chat-completions API.

- **Zero-dependency script** (`src/check.ts`): sends a doc file plus a unified diff, gets a strict `json_schema` structured verdict `{drifted, severity, explanation, suggestion}`, prints it, appends a sanitized Markdown table to `GITHUB_STEP_SUMMARY` when present, and exits 1 on drift.
- **Copy-me GitHub Actions workflow** (`workflow.yaml`): checkout (full history) + Node 24 + `git diff --merge-base` + the script, copied as `.mts` so it stays ESM in `"type": "commonjs"` repos. SHA-pinned actions (same pins as this repo's CI), per-PR concurrency with cancel-in-progress, injection-safe `base_ref` via env.
- **Bundled samples**: a fictional CLI README and a `git apply`-valid diff that renames the documented `--max-retries` flag, so the example demonstrates a drifted verdict out of the box.
- **Bilingual READMEs** that lead with the zero-setup path: install the [drift-check GitHub App](https://github.com/apps/drift-check) to get this check (plus comment/code divergence) on every PR without any workflow files or secrets.

## Repo integration

- `pnpm-workspace.yaml`: adds `examples/*`; turbo picks up the package's `typecheck`/`lint` automatically (no `build`/`test` scripts, so publish/release workflows are untouched).
- `CONTRIBUTING.md` / `CONTRIBUTING.ja.md` / `AGENTS.md`: repo layout and workspace tables updated (leaving AGENTS.md stale would have introduced the very drift this example demonstrates).
- devDependencies via `catalog:` only (`typescript`, `@types/node`); zero runtime deps so the script stays copy-pasteable; `private: true`.

## Verification

- `pnpm typecheck` / `lint` / `format:check` / `build` / `test` (e2e-cli 110 passed) and `scripts/check-no-em-dash.mts` all green locally; turbo picks the new package up.
- Smoke-tested against a local OpenAI-compatible mock: drifted verdict prints, writes the job-summary table, exits 1; clean verdict exits 0; missing `ARKOR_BASE_URL` prints usage and exits 1; empty `ARKOR_MODEL` (how Actions interpolates an unset `vars.*`) falls back to the default model; single-argument misuse is rejected; connection failure prints a one-line error; the `.mts` copy runs in a scratch `"type": "commonjs"` repo.
- Self-reviewed with two independent review passes before opening this PR; all findings (empty-model env, summary-table sanitization, corrupt sample hunk header, Node version guidance, AGENTS.md workspace drift, and more) are addressed in the second commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “documentation drift” example that detects when PR diffs leave documentation (e.g., README) stale.
  * Provided a copy-paste GitHub Actions workflow plus local run instructions.
  * Updated the example’s upload retry CLI flag to `--retry-limit` (default now 5).

* **Documentation**
  * Added English and Japanese READMEs for the new example.
  * Updated contributing/repo layout docs to include the new example and clarify that `examples/` is private/not published.

* **Chores**
  * Expanded pnpm workspace globs to include `examples/*`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->