### PR TITLE
chore: add Qodo v2 (Qodo Platform) repo-level config

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -8,19 +8,18 @@
 #   https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-and-command-reference
 
 # --- What runs automatically -------------------------------------------------
-# /agentic_review folds in the old /review, /improve, and /compliance, so a single
-# command per event gives description + review + code suggestions. Labels come from
-# the dedicated /generate_labels command. Re-run describe + review on every push so
-# the persistent output tracks the latest commit.
+# /agentic_review folds in the old /review, /improve, and /compliance, so with
+# /agentic_describe a PR open gets description + review + code suggestions. On push,
+# re-run /agentic_review only: that is the documented persistent-review trigger and
+# it refreshes the single evolving review comment. (/generate_labels is a manual
+# PR-comment command in v2, not an auto pr_commands entry, so it is not listed.)
 [github_app]
 pr_commands = [
   "/agentic_describe",
   "/agentic_review",
-  "/generate_labels",
 ]
 handle_push_trigger = true
 push_commands = [
-  "/agentic_describe",
   "/agentic_review",
 ]
 
@@ -52,8 +51,9 @@ Prioritise these Arkor-specific risks:
 compliance_user_guidelines = """
 - Bilingual docs move together in the same PR: README.md with README.ja.md,
   CONTRIBUTING.md with CONTRIBUTING.ja.md, docs/ with docs/ja/.
-- No em dashes in prose, docs, comments, or READMEs (CLI runtime user-facing
-  strings are the only exception).
+- No em dashes anywhere, including CLI runtime user-facing strings: the
+  local/no-em-dash ESLint rule and the repo-wide check-no-em-dash guard have no
+  carve-out.
 - Respect the known review-bot pitfalls in best_practices.md that must NOT be
   "fixed": the npm CodeGroup tab (npm arkor init), Mintlify heading slugs (which
   keep /, =, and full-width parens), and HuggingFace model-name existence.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -14,14 +14,9 @@
 # it refreshes the single evolving review comment. (/generate_labels is a manual
 # PR-comment command in v2, not an auto pr_commands entry, so it is not listed.)
 [github_app]
-pr_commands = [
-  "/agentic_describe",
-  "/agentic_review",
-]
+pr_commands = ["/agentic_describe", "/agentic_review"]
 handle_push_trigger = true
-push_commands = [
-  "/agentic_review",
-]
+push_commands = ["/agentic_review"]
 
 # --- Review agent ------------------------------------------------------------
 [review_agent]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,82 @@
+# Qodo Merge / Qodo Code Review (Qodo v2, the "Qodo Platform" generation) config.
+# Repo-level overrides; precedence is wiki > this file > org-wide pr-agent-settings.
+# Kept focused: lists settings we deliberately set, including some that match a
+# current Qodo default but are pinned on purpose so a future default flip cannot
+# silently weaken review coverage. We do not copy the full default file. See
+# https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file
+
+[config]
+# Surface which configs actually took effect, so drift between this file and
+# Qodo's defaults is visible in each run.
+output_relevant_configurations = true
+
+# --- What runs automatically -------------------------------------------------
+# Full pipeline on every new PR, and a re-review + fresh suggestions on each push.
+[github_app]
+pr_commands = [
+  "/describe",
+  "/review",
+  "/improve",
+]
+handle_push_trigger = true
+push_commands = [
+  "/describe",
+  "/review",
+]
+
+# --- Review tool -------------------------------------------------------------
+[pr_reviewer]
+# Update one persistent comment instead of stacking a new one per push.
+persistent_comment = true
+final_update_message = true
+# Maximise signal: keep all the optional review sections on.
+require_score_review = true
+require_tests_review = true
+require_estimate_effort_to_review = true
+require_can_be_split_review = true
+require_security_review = true
+require_todo_scan = true
+# Visible at-a-glance labels for risk and effort.
+enable_review_labels_security = true
+enable_review_labels_effort = true
+num_max_findings = 6
+extra_instructions = """
+This is the Arkor pnpm + Turbo monorepo. When reviewing, weight these
+project-specific concerns highly:
+- Studio dev server security invariants: per-launch CSRF token via
+  X-Arkor-Studio-Token header (query param only for EventSource), timingSafeEqual
+  comparison, host-header allow-list, and the deliberate absence of CORS. Flag any
+  change that weakens these or adds a mutation route to eventStreamPathPattern.
+- HMR primitives (requestEarlyStop, replaceCallbacks) must stay behind
+  Symbol.for(...) brands and never leak onto the public Trainer interface.
+- Bilingual docs must move together: README.md with README.ja.md, docs/ with
+  docs/ja/, CONTRIBUTING.md with CONTRIBUTING.ja.md.
+- No em dashes in prose, docs, comments, or READMEs.
+- Dependency versions go through the pnpm-workspace.yaml catalog, not literal
+  semver in package.json (except the two published packages' runtime deps).
+"""
+
+# --- Code suggestions tool ---------------------------------------------------
+[pr_code_suggestions]
+persistent_comment = true
+# Cast a wide net, then let the score threshold and best_practices.md filter.
+# The repo-root best_practices.md is honoured automatically: for a single repo,
+# the file's presence is the trigger, so no enable key is needed here. The
+# [best_practices] section / enable_global_best_practices is only for the
+# org-wide pr-agent-settings repo, which we do not use.
+auto_extended_mode = true
+suggestions_score_threshold = 5
+extra_instructions = """
+Prefer suggestions that protect the invariants in best_practices.md. Do not
+suggest formatting or import-ordering changes: oxfmt owns formatting and ESLint
+import-x/order owns import order.
+"""
+
+# --- Description tool --------------------------------------------------------
+[pr_description]
+generate_ai_title = true
+publish_labels = true
+enable_pr_type = true
+enable_pr_diagram = true
+use_bullet_points = true
+collapsible_file_list = "adaptive"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,82 +1,66 @@
-# Qodo Merge / Qodo Code Review (Qodo v2, the "Qodo Platform" generation) config.
-# Repo-level overrides; precedence is wiki > this file > org-wide pr-agent-settings.
-# Kept focused: lists settings we deliberately set, including some that match a
-# current Qodo default but are pinned on purpose so a future default flip cannot
-# silently weaken review coverage. We do not copy the full default file. See
-# https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file
-
-[config]
-# Surface which configs actually took effect, so drift between this file and
-# Qodo's defaults is visible in each run.
-output_relevant_configurations = true
+# Qodo Review (v2, the "Qodo Platform" generation) repo-level config.
+# File name and location (.pr_agent.toml at the repo root of the default branch)
+# are unchanged from v1, but v2 uses the agentic commands and the [review_agent] /
+# [qodo_describe_agent] sections rather than the legacy /review, /describe,
+# /improve tools and [pr_reviewer] / [pr_description] sections. Every key below is
+# taken from the current v2 docs; we do not copy the full default file.
+#   https://docs.qodo.ai/install-and-configure/migrating-to-qodo-v2
+#   https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-and-command-reference
 
 # --- What runs automatically -------------------------------------------------
-# Full pipeline on every new PR, and a re-review + fresh suggestions on each push.
+# /agentic_review folds in the old /review, /improve, and /compliance, so a single
+# command per event gives description + review + code suggestions. Labels come from
+# the dedicated /generate_labels command. Re-run describe + review on every push so
+# the persistent output tracks the latest commit.
 [github_app]
 pr_commands = [
-  "/describe",
-  "/review",
-  "/improve",
+  "/agentic_describe",
+  "/agentic_review",
+  "/generate_labels",
 ]
 handle_push_trigger = true
 push_commands = [
-  "/describe",
-  "/review",
+  "/agentic_describe",
+  "/agentic_review",
 ]
 
-# --- Review tool -------------------------------------------------------------
-[pr_reviewer]
-# Update one persistent comment instead of stacking a new one per push.
-persistent_comment = true
-final_update_message = true
-# Maximise signal: keep all the optional review sections on.
-require_score_review = true
-require_tests_review = true
-require_estimate_effort_to_review = true
-require_can_be_split_review = true
-require_security_review = true
-require_todo_scan = true
-# Visible at-a-glance labels for risk and effort.
-enable_review_labels_security = true
-enable_review_labels_effort = true
-num_max_findings = 6
-extra_instructions = """
-This is the Arkor pnpm + Turbo monorepo. When reviewing, weight these
-project-specific concerns highly:
-- Studio dev server security invariants: per-launch CSRF token via
-  X-Arkor-Studio-Token header (query param only for EventSource), timingSafeEqual
-  comparison, host-header allow-list, and the deliberate absence of CORS. Flag any
-  change that weakens these or adds a mutation route to eventStreamPathPattern.
-- HMR primitives (requestEarlyStop, replaceCallbacks) must stay behind
-  Symbol.for(...) brands and never leak onto the public Trainer interface.
-- Bilingual docs must move together: README.md with README.ja.md, docs/ with
-  docs/ja/, CONTRIBUTING.md with CONTRIBUTING.ja.md.
-- No em dashes in prose, docs, comments, or READMEs.
-- Dependency versions go through the pnpm-workspace.yaml catalog, not literal
-  semver in package.json (except the two published packages' runtime deps).
+# --- Review agent ------------------------------------------------------------
+[review_agent]
+# Post both a summary and inline comments (this is the default; pinned so a future
+# default flip cannot silently drop inline coverage).
+comments_location_policy = "both"
+# Surface medium-and-higher severity inline, not just the highest (docs values are
+# 1-3, default 3); lower threshold = more inline findings.
+inline_comments_severity_threshold = 2
+# Bug / security / performance focus for the Issues agent.
+issues_user_guidelines = """
+Prioritise these Arkor-specific risks:
+- Studio dev server (packages/arkor/src/studio/server.ts): every /api/* request
+  must stay authenticated by the per-launch CSRF token (X-Arkor-Studio-Token
+  header for fetch; ?studioToken= query only for the GET job-events SSE stream,
+  jobEventsPathPattern). Keep the timingSafeEqual comparison, the
+  127.0.0.1/localhost host-header allow-list, and the deliberate absence of CORS.
+  Flag any change that weakens these or extends the query-token exception to a
+  mutation route.
+- Dependency versions must go through the pnpm-workspace.yaml catalog (catalog:),
+  not literal semver, except the two published packages' runtime dependencies.
+- Do not suggest formatting or import-order changes: oxfmt owns formatting and
+  ESLint import-x/order owns import order.
+"""
+# Standards / rules for the Compliance agent. Full standard lives in
+# best_practices.md at the repo root.
+compliance_user_guidelines = """
+- Bilingual docs move together in the same PR: README.md with README.ja.md,
+  CONTRIBUTING.md with CONTRIBUTING.ja.md, docs/ with docs/ja/.
+- No em dashes in prose, docs, comments, or READMEs (CLI runtime user-facing
+  strings are the only exception).
+- Respect the known review-bot pitfalls in best_practices.md that must NOT be
+  "fixed": the npm CodeGroup tab (npm arkor init), Mintlify heading slugs (which
+  keep /, =, and full-width parens), and HuggingFace model-name existence.
 """
 
-# --- Code suggestions tool ---------------------------------------------------
-[pr_code_suggestions]
-persistent_comment = true
-# Cast a wide net, then let the score threshold and best_practices.md filter.
-# The repo-root best_practices.md is honoured automatically: for a single repo,
-# the file's presence is the trigger, so no enable key is needed here. The
-# [best_practices] section / enable_global_best_practices is only for the
-# org-wide pr-agent-settings repo, which we do not use.
-auto_extended_mode = true
-suggestions_score_threshold = 5
-extra_instructions = """
-Prefer suggestions that protect the invariants in best_practices.md. Do not
-suggest formatting or import-ordering changes: oxfmt owns formatting and ESLint
-import-x/order owns import order.
-"""
-
-# --- Description tool --------------------------------------------------------
-[pr_description]
-generate_ai_title = true
-publish_labels = true
-enable_pr_type = true
-enable_pr_diagram = true
-use_bullet_points = true
-collapsible_file_list = "adaptive"
+# --- Describe agent ----------------------------------------------------------
+[qodo_describe_agent]
+# Post the generated summary as a comment rather than overwriting a human-authored
+# PR body. Allowed: "comment" (default), "pr_description", "dynamic".
+publish_mode = "comment"

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,0 +1,84 @@
+# Arkor best practices
+
+Qodo (Qodo Code Review / Qodo Merge) reads this file and raises extra
+suggestions, labelled "Organization best practices", when a PR violates any of
+the points below. Keep
+each point short, actionable, and specific to this repo (general style is already
+covered by oxlint/ESLint/oxfmt).
+
+## Bilingual docs
+
+- English and Japanese docs are paired and must change together in the same PR:
+  `README.md` with `README.ja.md`, `CONTRIBUTING.md` with `CONTRIBUTING.ja.md`,
+  and `docs/` with `docs/ja/`. Never leave the Japanese side to a follow-up.
+- Do not edit generated copies (`packages/*/CONTRIBUTING.md`,
+  `packages/arkor/docs/`); edit the source under the repo root.
+- Mintlify heading slugs are not GitHub-style. Preserve `/`, `=`, and full-width
+  parens in anchor ids; ASCII parens and backticks are stripped. Verify a new
+  cross-page anchor against the rendered preview before relying on it.
+
+## Writing style
+
+- No em dashes in prose, docs, comments, or READMEs. The only exception is
+  user-facing CLI runtime strings (info/warn/error one-liners).
+
+## Review pitfalls (do not "fix" these)
+
+These are correct as written; AGENTS.md flags them as recurring review-bot
+mistakes, so do not suggest "fixing" them.
+
+- Docs CLI CodeGroup: `/cli/*` and `/guides/cli/*` pages (and JA mirrors) show
+  unscripted subcommands as a 5-tab `<pm> arkor <subcommand>` CodeGroup. The
+  `npm` tab stays `npm arkor init`; do not rewrite it to `npx arkor` or
+  `npm exec arkor`. These commands assume `arkor` is already in the project.
+- Do not call a HuggingFace model or dataset name "non-existent" based on
+  training data alone; templates may reference real models newer than the
+  knowledge cutoff. Verify, or hedge ("could not confirm") instead of asserting.
+
+## Studio dev server security (security-critical)
+
+- Every `/api/*` request must be authenticated with the per-launch CSRF token:
+  `X-Arkor-Studio-Token` header for `fetch`, `?studioToken=` query only for
+  `EventSource`. Comparison must stay `timingSafeEqual`.
+- `eventStreamPathPattern` may only list GET stream-only routes. Never add a
+  mutation endpoint to it.
+- Keep the host-header allow-list (`127.0.0.1`/`localhost`) and do NOT add CORS.
+- Token persistence to `~/.arkor/studio-token` may fail (read-only $HOME); a
+  failure must warn, not block server start.
+
+## HMR primitives stay private
+
+- `requestEarlyStop()` and `replaceCallbacks()` are dev-only HMR primitives kept
+  behind `Symbol.for("arkor.trainer.*")` brands. Do not surface them on the
+  public `Trainer` interface.
+- The server's stale-bundle path must SIGTERM and let the child run `cancel()`.
+  Do not escalate to SIGKILL server-side (it would orphan Cloud-side jobs).
+- Do not widen the SIGUSR2 hot-swap path to "always hot-swap"; the `configHash`
+  match is what prevents a child running with a stale `JobConfig`.
+
+## Dependencies and supply chain
+
+- Direct third-party deps in workspace `package.json` files use `"<name>":
+  "catalog:"` and are versioned once in `pnpm-workspace.yaml`. Do not inline
+  literal semver (the two published packages' runtime `dependencies` are the
+  documented carve-out).
+- Do not run `pnpm add -w <pkg>@<v>` against a catalog entry; bump the catalog
+  entry and run `pnpm install`.
+- Bundled runtime inputs of `@arkor/studio-app` belong in `dependencies`, not
+  `devDependencies`, so `pnpm sbom --prod` keeps them in the release SBOM.
+- Respect the supply-chain guards in `pnpm-workspace.yaml`
+  (`minimumReleaseAge`, `trustPolicy: no-downgrade`, `blockExoticSubdeps`,
+  `allowBuilds`). Do not loosen them without justification.
+
+## Formatting and linting boundaries
+
+- oxfmt owns whitespace, wrapping, quotes, and trailing commas; ESLint
+  `import-x/order` owns import order. Do not hand-format or reorder imports.
+- Prefer a scoped override in `eslint.config.ts` (with the reason in a comment)
+  over inline `// eslint-disable` at each call site.
+
+## Tests and deliverables
+
+- SDK/CLI/Studio logic changes ship with vitest cases under
+  `packages/*/src/**/*.test.ts` in the same PR; consider an `e2e/cli` scenario
+  for CLI flow changes. Do not defer tests or docs to a later PR.

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,10 +1,11 @@
 # Arkor best practices
 
-Qodo (Qodo Code Review / Qodo Merge) reads this file and raises extra
-suggestions, labelled "Organization best practices", when a PR violates any of
-the points below. Keep
-each point short, actionable, and specific to this repo (general style is already
-covered by oxlint/ESLint/oxfmt).
+This file is the Arkor coding standard. The repo-level Qodo config
+(`.pr_agent.toml`) points its compliance agent here via
+`compliance_user_guidelines`, and Qodo also reads a root `best_practices.md`
+when raising best-practice findings on a PR. Keep each point short, actionable,
+and specific to this repo (general style is already covered by
+oxlint/ESLint/oxfmt).
 
 ## Bilingual docs
 
@@ -40,21 +41,13 @@ mistakes, so do not suggest "fixing" them.
 - Every `/api/*` request must be authenticated with the per-launch CSRF token:
   `X-Arkor-Studio-Token` header for `fetch`, `?studioToken=` query only for
   `EventSource`. Comparison must stay `timingSafeEqual`.
-- `eventStreamPathPattern` may only list GET stream-only routes. Never add a
-  mutation endpoint to it.
+- The `?studioToken=` query-param exception is limited to the GET job-events SSE
+  stream, matched by `jobEventsPathPattern` in
+  `packages/arkor/src/studio/server.ts`. Never extend that allow-list to a
+  mutation route.
 - Keep the host-header allow-list (`127.0.0.1`/`localhost`) and do NOT add CORS.
 - Token persistence to `~/.arkor/studio-token` may fail (read-only $HOME); a
   failure must warn, not block server start.
-
-## HMR primitives stay private
-
-- `requestEarlyStop()` and `replaceCallbacks()` are dev-only HMR primitives kept
-  behind `Symbol.for("arkor.trainer.*")` brands. Do not surface them on the
-  public `Trainer` interface.
-- The server's stale-bundle path must SIGTERM and let the child run `cancel()`.
-  Do not escalate to SIGKILL server-side (it would orphan Cloud-side jobs).
-- Do not widen the SIGUSR2 hot-swap path to "always hot-swap"; the `configHash`
-  match is what prevents a child running with a stale `JobConfig`.
 
 ## Dependencies and supply chain
 

--- a/best_practices.md
+++ b/best_practices.md
@@ -20,8 +20,11 @@ oxlint/ESLint/oxfmt).
 
 ## Writing style
 
-- No em dashes in prose, docs, comments, or READMEs. The only exception is
-  user-facing CLI runtime strings (info/warn/error one-liners).
+- No em dashes anywhere: prose, docs, comments, READMEs, and CLI runtime
+  user-facing strings alike. The `local/no-em-dash` ESLint rule plus the
+  repo-wide `scripts/check-no-em-dash.mts` guard enforce this with no carve-out
+  (CLI runtime messages, generated-file template bodies, and test names all
+  follow the same rule).
 
 ## Review pitfalls (do not "fix" these)
 


### PR DESCRIPTION
## What

Adds repo-level configuration for the latest Qodo (v2, the "Qodo Platform" / Qodo Review generation, successor to Qodo Merge / PR-Agent v1), so the hosted Qodo GitHub app reviews PRs against this repo's conventions.

Two root files, both in the current **v2 agentic** shape:

- **`.pr_agent.toml`**:
  - `[github_app]` automation: `pr_commands = ["/agentic_describe", "/agentic_review"]` on PR open, and `handle_push_trigger = true` with `push_commands = ["/agentic_review"]` on push. `/agentic_review` folds in the old `/review` + `/improve` + `/compliance`, so a single command gives review plus code suggestions.
  - `[review_agent]`: `comments_location_policy = "both"`, `inline_comments_severity_threshold = 2`, and repo-specific `issues_user_guidelines` (Studio CSRF invariants, catalog rule, no formatting/import-order noise) + `compliance_user_guidelines` (bilingual docs, no em dashes, do-not-"fix" review-bot pitfalls).
  - `[qodo_describe_agent]`: `publish_mode = "comment"` (does not overwrite a human-authored PR body).
- **`best_practices.md`**: the Arkor coding standard Qodo's compliance agent references. Invariants distilled from CONTRIBUTING.md / AGENTS.md / the actual `packages/arkor` source.

Config is kept minimal (only deliberate settings, no full-default copy) so future Qodo default changes still flow through.

## Version note

`.pr_agent.toml` at the repo root is the correct file for both v1 and v2, but v2 replaces the legacy `/review` `/describe` `/improve` tools and `[pr_reviewer]` / `[pr_description]` sections with the `/agentic_*` commands and the `[review_agent]` / `[qodo_describe_agent]` sections used here. Every section/key was verified against the current v2 docs. For a single repo, `best_practices.md`'s presence at the root is the enable trigger; the org-wide `pr-agent-settings` repo is not used.

## Preconditions to take effect

1. Merge to `main`: Qodo reads both files from the **default branch** root, so nothing applies until this lands.
2. The Qodo GitHub app must be installed on the repo/org (it is; it is already commenting on this PR).

## Review follow-ups addressed

- Migrated from the initial v1 draft (`/describe`, `/review`, `/improve`, `[pr_reviewer]`, `[pr_description]`) to the v2 agentic format (Codex).
- Removed `/generate_labels` from `pr_commands` (it is a manual PR-comment command in v2, not an auto entry) and reduced `push_commands` to `/agentic_review` per the documented persistent-review trigger (Codex).
- Fixed code references that did not exist on `main`: `eventStreamPathPattern` -> real `jobEventsPathPattern`; dropped an HMR-primitives section for APIs not implemented on `main` (Codex).
- Removed a wrong "CLI runtime strings are exempt" note from the no-em-dash rule: ENG-764 removed that carve-out repo-wide (CodeRabbit).

## Verification

- Every TOML section/key checked against current Qodo v2 docs; code references grep-verified against `packages/arkor/src`.
- No em dashes (repo-wide rule has no carve-out); TOML parses.

No code paths change, so no unit/e2e tests apply. No `README`/`docs` changes, so no bilingual doc pairing is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `best_practices.md` with Arkor coding and documentation standards, including bilingual (EN/JA) parity, style rules (e.g., no em-dashes), and guidance on edit boundaries and documentation link/anchor preservation.
  * Included security/compliance notes for local `/api/*` authentication, host allow-list requirements, token-handling expectations, and common review pitfalls.
* **Chores**
  * Added repo-root agent configuration to automatically run PR review and description workflows on pushes, posting both summaries and inline review comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->