### PR TITLE
fix(arkor): send X-Arkor-Client from fetchCliConfig so arkor login stops 426ing

### DIFF
--- a/packages/arkor/src/core/auth0.test.ts
+++ b/packages/arkor/src/core/auth0.test.ts
@@ -8,6 +8,7 @@ import {
   fetchCliConfig,
   startLoopbackServer,
 } from "./auth0";
+import { SDK_VERSION } from "./version";
 
 describe("generatePkce", () => {
   it("produces URL-safe base64 values", () => {
@@ -180,6 +181,30 @@ describe("fetchCliConfig", () => {
     }) as typeof fetch;
     await fetchCliConfig("http://localhost:3003/", fetchImpl);
     expect(captured).toBe("http://localhost:3003/v1/auth/cli/config");
+  });
+
+  it("sends X-Arkor-Client so the SDK version gate accepts the bootstrap call", async () => {
+    // Without this header the cloud-api gate returns 426 reason=missing,
+    // breaking `arkor login` / `arkor dev` before OAuth even starts.
+    let captured: RequestInit | undefined;
+    const fetchImpl = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      captured = init;
+      return Response.json(
+        {
+          auth0Domain: null,
+          clientId: null,
+          audience: null,
+          callbackPorts: [],
+        },
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    await fetchCliConfig("http://localhost:3003", fetchImpl);
+    const headers = new Headers(captured?.headers);
+    expect(headers.get("X-Arkor-Client")).toBe(`arkor/${SDK_VERSION}`);
   });
 });
 

--- a/packages/arkor/src/core/auth0.ts
+++ b/packages/arkor/src/core/auth0.ts
@@ -1,6 +1,8 @@
 import { createHash, randomBytes } from "node:crypto";
 import { createServer, type Server, type ServerResponse } from "node:http";
 
+import { SDK_VERSION } from "./version";
+
 import type { OAuthCredentials } from "./credentials";
 import type { AddressInfo } from "node:net";
 
@@ -20,8 +22,12 @@ export async function fetchCliConfig(
   baseUrl: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<CliConfig> {
+  // The cloud-api SDK version gate rejects any request lacking
+  // `X-Arkor-Client` with 426 (reason=missing), so this bootstrap call must
+  // carry it just like `requestAnonymousToken` and the CloudApiClient paths.
   const res = await fetchImpl(
     `${baseUrl.replace(/\/$/, "")}/v1/auth/cli/config`,
+    { headers: { "X-Arkor-Client": `arkor/${SDK_VERSION}` } },
   );
   if (!res.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary

`arkor login` fails immediately with `Failed to fetch CLI config from https://api.arkor.ai (426)`, even on the latest published CLI (`0.0.3-alpha.1`).

The root cause is **not** an outdated client. The cloud-api's SDK version gate rejects any request that lacks the `X-Arkor-Client` header with `426 sdk_version_unsupported / reason=missing` (`currentVersion: "unknown"`, `supportedRange: "*"`). `fetchCliConfig` — the first call in `arkor login` / `arkor dev` — was the last bootstrap path still missing that header. `requestAnonymousToken` was already fixed for the same class of bug (`credentials.test.ts` documents it).

Verified against production:

| Request | Result |
| --- | --- |
| no header | `426` `{"error":"sdk_version_unsupported","currentVersion":"unknown","supportedRange":"*","reason":"missing"}` |
| `X-Arkor-Client: arkor/0.0.3-alpha.1` | `200` (config returned) |

## Changes

- `core/auth0.ts`: `fetchCliConfig` now sends `X-Arkor-Client: arkor/${SDK_VERSION}`, matching `CloudApiClient` and `requestAnonymousToken`.
- `core/auth0.test.ts`: added a case asserting the header is sent on the bootstrap request.

## Impact

Fixes both callers of `fetchCliConfig`:
- `cli/commands/login.ts` — `arkor login` (the reported failure)
- `cli/commands/dev.ts` — OAuth detection for `arkor dev` (silently degraded to anonymous before)

## Testing

- `pnpm --filter arkor exec vitest run src/core/auth0.test.ts` (22 passed)
- `pnpm --filter arkor typecheck`
- `pnpm --filter arkor lint`
- `pnpm exec oxfmt --check` on changed files

No docs changes: this restores intended behaviour, no user-facing API/flag change.

Fixes ENG-978


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `X-Arkor-Client: arkor/${SDK_VERSION}` from fetchCliConfig to satisfy the cloud-api SDK version gate and stop 426 errors on the initial CLI config fetch. Restores `arkor login` and `arkor dev` OAuth detection (Fixes ENG-978).

<sup>Written for commit 40f65c7d19adbd9142f2209066a21d93963d5fe5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added client version information to authentication configuration requests.
  * Improved compatibility with cloud services that require SDK version validation.
  * Added coverage to verify the version header is sent correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->