### PR TITLE
fix(studio): guard Playground Enter against Safari IME commit

### DIFF
--- a/packages/studio-app/src/components/playground/Composer.test.tsx
+++ b/packages/studio-app/src/components/playground/Composer.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Composer } from "./Composer";
+
+function renderComposer(props?: { value?: string; disabled?: boolean }) {
+  const onSubmit = vi.fn();
+  const onChange = vi.fn();
+  render(
+    <Composer
+      value={props?.value ?? "hello"}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      disabled={props?.disabled}
+    />,
+  );
+  const textarea = screen.getByRole("textbox", { name: "Message" });
+  return { onSubmit, onChange, textarea };
+}
+
+describe("Composer Enter handling", () => {
+  it("submits on a plain Enter", () => {
+    const { onSubmit, textarea } = renderComposer();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts a newline (does not submit) on Shift+Enter", () => {
+    const { onSubmit, textarea } = renderComposer();
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit while an IME composition is active (isComposing)", () => {
+    const { onSubmit, textarea } = renderComposer();
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // Regression: in Safari `compositionend` fires before `keydown`, so the Enter
+  // that commits an IME conversion has `isComposing === false` but `keyCode === 229`.
+  it("does not submit on the Enter that commits an IME conversion (keyCode 229)", () => {
+    const { onSubmit, textarea } = renderComposer();
+    fireEvent.keyDown(textarea, { key: "Enter", keyCode: 229 });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when the value is only whitespace", () => {
+    const { onSubmit, textarea } = renderComposer({ value: "   " });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when disabled", () => {
+    const { onSubmit, textarea } = renderComposer({ disabled: true });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio-app/src/components/playground/Composer.test.tsx
+++ b/packages/studio-app/src/components/playground/Composer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { Composer } from "./Composer";
@@ -28,7 +28,15 @@ describe("Composer Enter handling", () => {
 
   it("inserts a newline (does not submit) on Shift+Enter", () => {
     const { onSubmit, textarea } = renderComposer();
-    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    // jsdom does not perform the textarea newline edit for a synthetic keydown,
+    // so assert the handler leaves the default action intact (no preventDefault).
+    // Calling preventDefault would suppress the browser's native newline insert.
+    const event = createEvent.keyDown(textarea, {
+      key: "Enter",
+      shiftKey: true,
+    });
+    fireEvent(textarea, event);
+    expect(event.defaultPrevented).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/packages/studio-app/src/components/playground/Composer.test.tsx
+++ b/packages/studio-app/src/components/playground/Composer.test.tsx
@@ -42,7 +42,14 @@ describe("Composer Enter handling", () => {
 
   it("does not submit while an IME composition is active (isComposing)", () => {
     const { onSubmit, textarea } = renderComposer();
-    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    // preventDefault here would swallow the keystroke the IME needs to commit
+    // the conversion, so the default action must stay intact.
+    const event = createEvent.keyDown(textarea, {
+      key: "Enter",
+      isComposing: true,
+    });
+    fireEvent(textarea, event);
+    expect(event.defaultPrevented).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -50,7 +57,12 @@ describe("Composer Enter handling", () => {
   // that commits an IME conversion has `isComposing === false` but `keyCode === 229`.
   it("does not submit on the Enter that commits an IME conversion (keyCode 229)", () => {
     const { onSubmit, textarea } = renderComposer();
-    fireEvent.keyDown(textarea, { key: "Enter", keyCode: 229 });
+    const event = createEvent.keyDown(textarea, {
+      key: "Enter",
+      keyCode: 229,
+    });
+    fireEvent(textarea, event);
+    expect(event.defaultPrevented).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/packages/studio-app/src/components/playground/Composer.tsx
+++ b/packages/studio-app/src/components/playground/Composer.tsx
@@ -26,7 +26,13 @@ export function Composer({
   }, [value]);
 
   function onKey(e: KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+    // Ignore Enter while the IME is composing. `isComposing` alone is not
+    // enough: in Safari `compositionend` fires before `keydown`, so the Enter
+    // that commits a conversion arrives with `isComposing === false` and only
+    // the legacy `keyCode === 229` sentinel still marks it as IME processing.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- keyCode 229 is the only cross-browser IME-composition sentinel; there is no non-deprecated equivalent
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       if (!disabled && value.trim()) onSubmit();
     }


### PR DESCRIPTION
## Description

- The Playground composer submitted while committing an IME conversion: pressing Enter to confirm Japanese/CJK input sent the half-composed message. `onKey` only guarded on `!e.nativeEvent.isComposing`, which is insufficient in Safari/WebKit because `compositionend` fires before `keydown`, so the committing Enter arrives with `isComposing === false`; only `keyCode === 229` (the IME-processing sentinel) still flags it.
- Guard `onKey` on both `isComposing` and `keyCode === 229`, returning early before the Enter-to-send branch. `keyCode` is deprecated but the only cross-browser IME signal here, so it carries a scoped `@typescript-eslint/no-deprecated` disable with a reason.
- Add `Composer.test.tsx` covering plain Enter (submits), Shift+Enter (newline), the `isComposing` guard, the `keyCode === 229` regression, whitespace-only input, and disabled state. The Composer's Enter path was previously untested (existing Playground tests submit via the Send button only).

## Breaking changes

None

## Fixed issues

Fixes ENG-980

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the Playground `Composer` from submitting when confirming IME input (e.g., Japanese) in Safari/WebKit, avoiding accidental sends. Fixes ENG-980.

- **Bug Fixes**
  - In the `Composer` key handler, ignore Enter if `nativeEvent.isComposing` or `keyCode === 229`; plain Enter still submits, Shift+Enter inserts a newline.
  - Tests cover Enter-to-send, Shift+Enter leaves default action intact, IME commit safeguards (`isComposing` and `keyCode === 229`) also leave default action intact, plus whitespace-only and disabled states.

<sup>Written for commit ed7a486629e31836bb1b59cc3b94890f0b855e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message composition behavior for international input methods.
  * Prevented accidental submission when completing text with IME input, including Safari.
  * Preserved expected behavior for submitting with Enter and inserting new lines with Shift+Enter.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->