### PR TITLE
fix(arkor): give the esbuild-backed /api/manifest tests a realistic timeout

### DIFF
--- a/packages/arkor/src/studio/server.test.ts
+++ b/packages/arkor/src/studio/server.test.ts
@@ -1339,7 +1339,9 @@ setTimeout(() => { clearInterval(t); process.exit(0); }, 3000);
     });
   });
 
-  describe("/api/manifest", () => {
+  // Each test here runs a real esbuild bundle via readManifestSummary; slow
+  // CI shards (notably windows-latest) have blown the default 5s budget.
+  describe("/api/manifest", { timeout: 30_000 }, () => {
     const FAKE_MANIFEST_SOURCE = `export const arkor = Object.freeze({
       _kind: "arkor",
       trainer: {


### PR DESCRIPTION
The `/api/manifest` suite in `packages/arkor/src/studio/server.test.ts` runs a real esbuild bundle per test via `readManifestSummary` → `runBuild`, but sits under vitest's default 5 s `testTimeout` (the repo configures none). On fast machines the whole describe block finishes in ~250 ms; on slow windows-latest CI shards the esbuild spawn has blown the 5 s budget.

Observed in the wild on PR #203 (docs-only change, so it cannot have caused it): `typecheck · lint · test · build · windows-latest · node >=24.0.0 <24.1.0` failed with

```
FAIL src/studio/server.test.ts > Studio server > /api/manifest > returns the trainer name when src/arkor/index.ts exports a manifest
Error: Test timed out in 5000ms.
```

(The `No credentials on file` line right above the FAIL in that job log is console noise from a different test's error-path coverage, not the cause.)

Fix: `{ timeout: 30_000 }` on the `/api/manifest` describe block, with a comment stating the why. No behavior change; removes a recurring Windows-shard flake.

Verified locally: the 5 manifest tests pass (Windows 11, node 24.18.1), full `packages/arkor` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Vitest timeout for the `/api/manifest` tests to 30s to stop flakiness on slow Windows CI where the esbuild spawn can exceed the 5s default. No behavior change; stabilizes the `packages/arkor` test suite.

<sup>Written for commit a7aaa0f71b35e6d23f060f720e1c2955a3199544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the `/api/manifest` test timeout to support longer-running bundle execution reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->