### PR TITLE
docs: discord link update in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -8,7 +8,7 @@
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | **5 分**                 | [クイックスタート](README.md#quickstart) を試して、混乱した点・壊れた点・TypeScript らしくないと感じた点について [Issue を立てる](https://github.com/arkorlab/arkor/issues/new)。 |
 | **半日**                 | [`good first issue`](https://github.com/arkorlab/arkor/labels/good%20first%20issue) をピックアップするか、小さな PR (ドキュメント修正、テンプレート調整、エラーメッセージの改善) を送る。 |
-| **継続的に**             | [Discord](https://discord.gg/YujCZYGrEZ) に参加して、動いてほしいモデル + データセット + ワークフローを教えてください。優先順位付けに使います。 |
+| **継続的に**             | [Discord](https://discord.arkor.ai/) に参加して、動いてほしいモデル + データセット + ワークフローを教えてください。優先順位付けに使います。 |
 
 非自明な変更 (新しい SDK ファクトリ、CLI コマンド、Studio のビュー) のアイデアがある場合は、コードを書く前に API の形について合意できるよう、まず Issue を開いてください。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest! Arkor is in **alpha**: we're moving fast, breaking thi
 | ----------------------- | ----------------------------------------------------------------------------------- |
 | **5 min**               | Try the [Quickstart](README.md#quickstart) and [open an issue](https://github.com/arkorlab/arkor/issues/new) about anything that confused you, broke, or felt un-TypeScript. |
 | **An afternoon**        | Pick up a [`good first issue`](https://github.com/arkorlab/arkor/labels/good%20first%20issue) or send a small PR (doc fixes, template tweaks, error-message polish). |
-| **Ongoing**             | Hop into [Discord](https://discord.gg/YujCZYGrEZ) and tell us what model + dataset + workflow you wish worked. We use this to prioritize. |
+| **Ongoing**             | Hop into [Discord](https://discord.arkor.ai/) and tell us what model + dataset + workflow you wish worked. We use this to prioritize. |
 
 If you have an idea for a non-trivial change (new SDK factory, CLI command, Studio view), please open an issue first so we can align on the API shape before you write code.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,7 +19,7 @@
   <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-000" alt="MIT"></a>
   <img src="https://img.shields.io/badge/node-%E2%89%A522.22.0-000" alt="node ≥22.22.0">
   <img src="https://img.shields.io/badge/status-alpha-orange" alt="alpha">
-  <a href="https://discord.gg/YujCZYGrEZ"><img src="https://img.shields.io/badge/discord-join-5865F2" alt="Discord"></a>
+  <a href="https://discord.arkor.ai/"><img src="https://img.shields.io/badge/discord-join-5865F2" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -173,7 +173,7 @@ pnpm / npm / yarn / bun で動作します。
 
 - 動いてほしいモデル + データセット + ワークフローについて **[Issue を立ててください](https://github.com/arkorlab/arkor/issues/new)**。すべて読んでいます。
 - `0.1` に向かう過程の更新を受け取りたければ **リポジトリにスターを** ください。
-- ライブな議論や早期アクセスの通知が欲しければ **[Discord に参加](https://discord.gg/YujCZYGrEZ)** してください。
+- ライブな議論や早期アクセスの通知が欲しければ **[Discord に参加](https://discord.arkor.ai/)** してください。
 
 開発セットアップについては [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-000" alt="MIT"></a>
   <img src="https://img.shields.io/badge/node-%E2%89%A522.22.0-000" alt="node ≥22.22.0">
   <img src="https://img.shields.io/badge/status-alpha-orange" alt="alpha">
-  <a href="https://discord.gg/YujCZYGrEZ"><img src="https://img.shields.io/badge/discord-join-5865F2" alt="Discord"></a>
+  <a href="https://discord.arkor.ai/"><img src="https://img.shields.io/badge/discord-join-5865F2" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -166,7 +166,7 @@ Works with pnpm / npm / yarn / bun.
 
 - **[File an issue](https://github.com/arkorlab/arkor/issues/new)** with the model + dataset + workflow you wish worked. We read everything.
 - **Star the repo** if you want updates as we move toward `0.1`.
-- **[Join Discord](https://discord.gg/YujCZYGrEZ)** for live discussion and early-access pings.
+- **[Join Discord](https://discord.arkor.ai/)** for live discussion and early-access pings.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 


### PR DESCRIPTION
# Summary and What changed
***
Replaced the old discord link in both the ```CONTRIBUTING.md``` and ```README.md``` (English and Japanese) with the new link.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated all Discord invite links in CONTRIBUTING.md, CONTRIBUTING.ja.md, README.md, and README.ja.md to https://discord.arkor.ai/ to replace the old link and prevent dead links.

<sup>Written for commit 5429fa3467ae25f35df4c7d84913e04921c40fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Updated English and Japanese contribution guides with the new Discord contact link.
- Replaced outdated Discord invite links in both English and Japanese README files, including header badges and contribution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->