### PR TITLE
fix(arkor): keeping original error when training entry import fails

### DIFF
--- a/packages/arkor/src/bin.ts
+++ b/packages/arkor/src/bin.ts
@@ -37,8 +37,8 @@ try {
     process.exitCode = 1;
   } else {
     console.error(
-      err instanceof Error ? err : String(err),
-    );
+  err instanceof Error ? (err.stack ?? err.message) : String(err),
+);
     process.exitCode = 1;
   }
 }

--- a/packages/arkor/src/bin.ts
+++ b/packages/arkor/src/bin.ts
@@ -37,8 +37,8 @@ try {
     process.exitCode = 1;
   } else {
     console.error(
-  err instanceof Error ? (err.stack ?? err.message) : String(err),
-);
+      err instanceof Error ? (err.stack ?? err.message) : String(err),
+    );
     process.exitCode = 1;
   }
 }

--- a/packages/arkor/src/bin.ts
+++ b/packages/arkor/src/bin.ts
@@ -37,7 +37,7 @@ try {
     process.exitCode = 1;
   } else {
     console.error(
-      err instanceof Error ? (err.stack ?? err.message) : String(err),
+      err instanceof Error ? err : String(err),
     );
     process.exitCode = 1;
   }

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -60,21 +60,19 @@ describe("runTrainer: entry extraction", () => {
   });
 
   it("wraps entry import errors with context", async () => {
-        const entry = join(cwd, "broken-entry.mjs");
+    const entry = join(cwd, "broken-entry.mjs");
 
-        writeFileSync(
-            entry,
-            `import "./does-not-exist.mjs";`,
-        );
+    writeFileSync(entry, `import "./does-not-exist.mjs";`);
 
-        const error = await runTrainer(entry).catch((e: unknown) => e);
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toMatch(/Failed to load training entry/);
-        expect((error as Error).cause).toBeInstanceOf(Error);
-        expect(((error as Error).cause as Error).message).toMatch(
-          /Cannot find module/,
-);
-    });
+    const error = await runTrainer(entry).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/Failed to load training entry/);
+    expect((error as Error).message).toContain(entry);
+    expect((error as Error).cause).toBeInstanceOf(Error);
+    expect(((error as Error).cause as Error).message).toMatch(
+      /Cannot find module/,
+    );
+  });
 
   it("runs when the entry default-exports a Trainer", async () => {
     const entry = join(cwd, "entry.mjs");

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -59,6 +59,23 @@ describe("runTrainer: entry extraction", () => {
     );
   });
 
+  it("wraps entry import errors with context", async () => {
+        const entry = join(cwd, "broken-entry.mjs");
+
+        writeFileSync(
+            entry,
+            `import "./does-not-exist.mjs";`,
+        );
+
+        const error = await runTrainer(entry).catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/Failed to load training entry/);
+        expect((error as Error).cause).toBeInstanceOf(Error);
+        expect(((error as Error).cause as Error).message).toMatch(
+          /Cannot find module/,
+);
+    });
+
   it("runs when the entry default-exports a Trainer", async () => {
     const entry = join(cwd, "entry.mjs");
     const calls: string[] = [];

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -59,20 +59,20 @@ describe("runTrainer: entry extraction", () => {
     );
   });
 
-  it("wraps entry import errors with context", async () => {
-    const entry = join(cwd, "broken-entry.mjs");
+it("wraps entry import errors with context", async () => {
+  const entry = join(cwd, "broken-entry.mjs");
+  writeFileSync(entry, `import "./does-not-exist.mjs";`);
 
-    writeFileSync(entry, `import "./does-not-exist.mjs";`);
+  const error = await runTrainer(entry).catch((e: unknown) => e);
 
-    const error = await runTrainer(entry).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(/Failed to load training entry/);
-    expect((error as Error).message).toContain(entry);
-    expect((error as Error).cause).toBeInstanceOf(Error);
-    expect(((error as Error).cause as Error).message).toMatch(
-      /Cannot find module/,
-    );
-  });
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toMatch(/Failed to load training entry/);
+  expect((error as Error).message).toContain(entry);
+
+  // Verify underlying cause details are preserved in both the message and cause property
+  expect((error as Error).message).toMatch(/Cannot find module/);
+  expect((error as Error).cause).toBeInstanceOf(Error);
+});
 
   it("runs when the entry default-exports a Trainer", async () => {
     const entry = join(cwd, "entry.mjs");

--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -59,20 +59,21 @@ describe("runTrainer: entry extraction", () => {
     );
   });
 
-it("wraps entry import errors with context", async () => {
-  const entry = join(cwd, "broken-entry.mjs");
-  writeFileSync(entry, `import "./does-not-exist.mjs";`);
+  it("wraps entry import errors with context", async () => {
+    const entry = join(cwd, "broken-entry.mjs");
+    writeFileSync(entry, `import "./does-not-exist.mjs";`);
 
-  const error = await runTrainer(entry).catch((e: unknown) => e);
+    const error = await runTrainer(entry).catch((e: unknown) => e);
 
-  expect(error).toBeInstanceOf(Error);
-  expect((error as Error).message).toMatch(/Failed to load training entry/);
-  expect((error as Error).message).toContain(entry);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/Failed to load training entry/);
+    expect((error as Error).message).toContain(entry);
 
-  // Verify underlying cause details are preserved in both the message and cause property
-  expect((error as Error).message).toMatch(/Cannot find module/);
-  expect((error as Error).cause).toBeInstanceOf(Error);
-});
+    const cause = (error as Error).cause as Error;
+    expect(cause).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/Cannot find module/);
+    expect((error as Error).cause).toBeInstanceOf(Error);
+  });
 
   it("runs when the entry default-exports a Trainer", async () => {
     const entry = join(cwd, "entry.mjs");

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -57,13 +57,15 @@ export async function runTrainer(file?: string): Promise<void> {
 
   let mod: Record<string, unknown>;
 
-  try {
-    mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
-  } catch (error) {
-    throw new Error(`Failed to load training entry: ${abs}`, {
-      cause: error,
-    });
-  }
+try {
+  mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
+} catch (error) {
+  const causeMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
+
+  throw new Error(`Failed to load training entry: ${abs}\n${causeMessage}`, {
+    cause: error,
+  });
+}
 
   const trainer = extractTrainer(mod);
 

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -55,17 +55,14 @@ export async function runTrainer(file?: string): Promise<void> {
     );
   }
 
-  let mod:Record<string,unknown>
+  let mod: Record<string, unknown>;
 
-  try{
-    mod = (await import(pathToFileURL(abs).href)) as Record<
-    string,
-    unknown
-  >;
-  } catch(error){
-    throw new Error(`Failed to load training entry: ${abs}`,{
-      cause:error,
-    })
+  try {
+    mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(`Failed to load training entry: ${abs}`, {
+      cause: error,
+    });
   }
 
   const trainer = extractTrainer(mod);

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -57,15 +57,14 @@ export async function runTrainer(file?: string): Promise<void> {
 
   let mod: Record<string, unknown>;
 
-try {
-  mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
-} catch (error) {
-  const causeMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
-
-  throw new Error(`Failed to load training entry: ${abs}\n${causeMessage}`, {
-    cause: error,
-  });
-}
+  try {
+    mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
+  } catch (error) {
+    const causeMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load training entry: ${abs}\n${causeMessage}`, {
+      cause: error,
+    });
+  }
 
   const trainer = extractTrainer(mod);
 

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -54,10 +54,20 @@ export async function runTrainer(file?: string): Promise<void> {
       `Training entry not found: ${abs}. Provide a path or create ${DEFAULT_ENTRY}.`,
     );
   }
-  const mod = (await import(pathToFileURL(abs).href)) as Record<
+
+  let mod:Record<string,unknown>
+
+  try{
+    mod = (await import(pathToFileURL(abs).href)) as Record<
     string,
     unknown
   >;
+  } catch(error){
+    throw new Error(`Failed to load training entry: ${abs}`,{
+      cause:error,
+    })
+  }
+
   const trainer = extractTrainer(mod);
 
   const { jobId } = await trainer.start();


### PR DESCRIPTION
## Summary

This PR addresses #221 issue

- How i found and investigated the issue

I started by reading issue #221 to understand the reported behavior and the expected behavior.  Main problem is that when the training entry exists but its dynamic import fails, the original import error is not preserved with enough context. This makes it harder to understand what went wrong and where the failure happened.

- How i reproduced the issue

I first reproduced the behavior locally by creating a small temporary test case with a training entry whose import intentionally fails. I then ran:

`pnpm --filter arkor test -- src/core/runner.test.ts`

The test reproduced the problematic behavior.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/0dfbca07-db73-4a76-8f78-e282667c3f13" />


- Understanding the repo pattern

Before changing the implementation, I looked through other parts of the repository to understand how errors and error causes are handled elsewhere. I followed the existing patterns for understanding the repo error-handling convention. This helped me identify the appropriate boundary for handling the error: the dynamic import of the training entry itself, without wrapping errors produced later by the Trainer.

- Implementing the fix

 I actually changed the dynamic training-entry import to preserve the original error as the `cause` while adding contextual information about the failed training entry. I also converted the reproduction into a regression test.

- Verification

I ran the targeted test again and verified that it passed then i ran the test  and got:

26 test files passed, 458 tests passed

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/be2eb66e-ecf0-4f70-908c-bcf00f96bc04" />


# Overall Changes

- Preserve the original dynamic import error as `cause`
- Add contextual information when loading a training entry fails
- Add a regression test covering the failure case

This keeps the original debugging info while providing additional context about which training entry failed to load.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original error when a training entry import fails in `arkor` and adds the entry path to the top-level error. Previously, import failures lost context; now we include the entry path and append the original error message while keeping it as the `cause`.

- Wrap the dynamic import in try/catch and rethrow: "Failed to load training entry: <abs>\n<causeMessage>" with `{ cause }`.
- Keep CLI output behavior; the rethrown message now surfaces the root cause without dumping raw stacks.
- Add a regression test asserting the contextual message, entry path, preserved `cause`, and inclusion of the underlying "Cannot find module" message.

<sup>Written for commit 51b1efea3ec2234f8c34452a6d57def8eaed016c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when a training entry cannot be loaded, including the entry path for easier troubleshooting.
  * Preserved the original import error details, including module-not-found messages, for better diagnosis.
  * Added contextual error handling to make failures during training startup clearer and easier to investigate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->