### PR TITLE
fix(runner): wrap training entry import() with error context

### DIFF
--- a/packages/arkor/src/core/runner.test.ts
+++ b/packages/arkor/src/core/runner.test.ts
@@ -58,6 +58,33 @@ describe("runTrainer: entry extraction", () => {
       /Training entry not found/,
     );
   });
+  it("wraps an import-time failure with context, preserving the original error as cause", async () => {
+    // The entry file EXISTS (so we skip the "not found" branch above) but
+    // throws while being imported, e.g. because one of its own imports is
+    // broken. This is the scenario from arkorlab/arkor#221: the failure
+    // happens while loading the entry, before training ever starts, and
+    // that should be obvious from the error message rather than surfacing
+    // as a bare "Cannot find module" with no indication of where it came
+    // from.
+    const entry = join(cwd, "broken-entry.mjs");
+    writeFileSync(
+      entry,
+      `import "./does-not-exist.mjs";\nexport const trainer = {};\n`,
+    );
+
+    const failure = await runTrainer(entry).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    const err = failure as Error;
+    expect(err.message).toBe(`Failed to load training entry: ${entry}`);
+    // The original import error (module-not-found) must still be reachable
+    // via `cause`, not swallowed by the new wrapper message.
+    expect(err.cause).toBeInstanceOf(Error);
+    expect((err.cause as Error).message).toMatch(/does-not-exist/);
+  });
 
   it("runs when the entry default-exports a Trainer", async () => {
     const entry = join(cwd, "entry.mjs");

--- a/packages/arkor/src/core/runner.ts
+++ b/packages/arkor/src/core/runner.ts
@@ -54,10 +54,12 @@ export async function runTrainer(file?: string): Promise<void> {
       `Training entry not found: ${abs}. Provide a path or create ${DEFAULT_ENTRY}.`,
     );
   }
-  const mod = (await import(pathToFileURL(abs).href)) as Record<
-    string,
-    unknown
-  >;
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`Failed to load training entry: ${abs}`, { cause: err });
+  }
   const trainer = extractTrainer(mod);
 
   const { jobId } = await trainer.start();


### PR DESCRIPTION
Fixes #221.

If the training entry file exists but fails during import() (a broken dependency, a syntax error in an imported module, etc.), the original error bubbled up with no indication that it happened while loading the training entry, before training ever started.

Wrap only the import() call (not extractTrainer, which already has its own clear error message) in try/catch, and re-throw with context using the standard Error cause option so the original error is preserved, not hidden:

  Failed to load training entry: <path>
  Cause: <original error>

Added a test that writes a real entry file importing a genuinely nonexistent module, letting Node's real ESM loader throw, and asserts both the new wrapper message and that the original error is still reachable via err.cause.

## Testing

`pnpm format:check`, `pnpm --filter arkor typecheck`, `pnpm --filter arkor lint`, and `pnpm --filter arkor exec vitest run src/core/runner.test.ts` all pass (12/12 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies errors when loading the training entry by wrapping the `import()` with context and preserving the original error via `Error` cause. Fixes #221.

- **Bug Fixes**
  - Wrap training entry `import()` in try/catch and rethrow as `Failed to load training entry: <path>` with `cause`.
  - Add test that imports a missing module and asserts the wrapper message and preserved `err.cause`.

<sup>Written for commit 5faa0f669c892bf0ab21570ef3b7a8ef65ae5120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when a training entry fails to load by including the entry path.
  - Preserved the original loading error for easier troubleshooting.
- **Tests**
  - Added coverage to verify contextual error reporting and preservation of the underlying cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->