### PR TITLE
test: isolate signing fallback from global git config

### DIFF
--- a/packages/cli-internal/src/git.test.ts
+++ b/packages/cli-internal/src/git.test.ts
@@ -128,13 +128,18 @@ describe("gitInitialCommit", () => {
     // Force gpg signing with a non-existent program so the signing step
     // fails with a recognisable "gpg failed to sign" stderr, exactly the
     // shape the helper retries past.
-    process.env.GIT_CONFIG_COUNT = "3";
+    process.env.GIT_CONFIG_COUNT = "4";
     process.env.GIT_CONFIG_KEY_0 = "commit.gpgsign";
     process.env.GIT_CONFIG_VALUE_0 = "true";
     process.env.GIT_CONFIG_KEY_1 = "gpg.program";
     process.env.GIT_CONFIG_VALUE_1 = "/nonexistent/gpg-binary";
-    process.env.GIT_CONFIG_KEY_2 = "commit.gpgsign";
-    process.env.GIT_CONFIG_VALUE_2 = "true";
+    // A developer may globally configure SSH signing, in which case
+    // `gpg.program` is ignored and their real SSH key can make this test pass
+    // without exercising the fallback. Pin OpenPGP for this fixture.
+    process.env.GIT_CONFIG_KEY_2 = "gpg.format";
+    process.env.GIT_CONFIG_VALUE_2 = "openpgp";
+    process.env.GIT_CONFIG_KEY_3 = "commit.gpgsign";
+    process.env.GIT_CONFIG_VALUE_3 = "true";
 
     const result = await gitInitialCommit(cwd, "Initial commit from test");
     expect(result.signingFallback).toBe(true);


### PR DESCRIPTION
Makes the signing fallback test independent of the operator's global Git configuration by isolating the fixture config and asserting the intended fallback path.

Testing:
- pnpm --filter @arkor/cli-internal exec vitest run src/git.test.ts (9 passed)
- git diff --check

Local Node is 24.19.0 while the repository declares 24.17.0 or 24.18.0; the test passed with only the version warning.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the signing fallback test independent of the developer's global Git configuration. A global SSH signing setup previously could make the test pass without exercising the retry fallback; the fixture now pins `gpg.format` to `openpgp` so the nonexistent gpg binary is actually invoked.

<sup>Written for commit f4a024f78faf85849cbc38f46d590c782351bf6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated signing fallback coverage to consistently use OpenPGP signing.
  * Prevented global SSH signing settings from bypassing the fallback test path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->