### PR TITLE
ci(dependabot): set a 1-day cooldown and raise the open PR limit to 100 (ENG-1153)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 100
     ignore:
       - dependency-name: "@types/node"
         update-types:
@@ -13,3 +16,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Two Dependabot options, one per the request in ENG-1153: a 1-day `cooldown` and `open-pull-requests-limit: 100`, applied to both update entries.

## Why

**`open-pull-requests-limit`.** The default is 5 per ecosystem, and the `github-actions` entry has been sitting at exactly that since 2026-08-07 (#207, #209, #218, #219, #220), with no new Actions PR raised since. The npm side is in the same shape. Raising the limit to 100 effectively removes the cap; the docs describe that as the supported way to do it ("A large value can be set to effectively remove the open pull request limit"). Security update PRs were never subject to this limit and do not count toward it.

**`cooldown`.** Worth being precise about the direction here, because it is the opposite of what the option name suggests at a glance. [Since 2026-07-14](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/) Dependabot applies a **3-day cooldown to version updates even when `cooldown` is not configured**. So this is not "add a cooldown where there was none": it **shortens** the effective window from 3 days to 1.

The 1-day floor is not arbitrary. [`pnpm-workspace.yaml`](https://github.com/arkorlab/arkor/blob/main/pnpm-workspace.yaml) sets `minimumReleaseAge: 1440` (24 h) as a supply-chain guard, so a version younger than that is one pnpm refuses to resolve anyway. `default-days: 1` is the shortest window that still clears that gate, and it is also the minimum the option accepts (the schema bounds `default-days` to 1..90).

## Changes

[`.github/dependabot.yaml`](https://github.com/arkorlab/arkor/blob/eng-1153/.github/dependabot.yaml), 6 added lines, nothing else in the repo touched:

```yaml
    cooldown:
      default-days: 1
    open-pull-requests-limit: 100
```

added to both the `npm` and the `github-actions` entry. The existing `schedule: weekly` and the `@types/node` semver-major `ignore` rule are unchanged.

## Verification

- **Schema-valid.** The file validates against SchemaStore's `dependabot-2.0.json` (`jsonschema.validate`, VALID). That schema sets `additionalProperties: false` on the update object, so an unknown key would have failed; `default-days` is bounded `minimum: 1, maximum: 90`, and `open-pull-requests-limit` is `minimum: 0` with no maximum.
- **`cooldown` is supported for `github-actions`.** This one is easy to get wrong: a summary of the docs page told me GitHub Actions was absent from the cooldown support table. Reading the docs source directly ([`dependabot-options-reference.md` L252](https://github.com/github/docs/blob/main/content/code-security/reference/supply-chain-security/dependabot-options-reference.md)) shows the opposite: the Actions row is `default-days` supported, `semver-*-days` not supported. Only `default-days` is used here.
- **The implementation bug is fixed.** [dependabot-core#14645](https://github.com/dependabot/dependabot-core/issues/14645) ("GitHub Actions updates appear to be ignoring cooldown setting") closed as completed on 2026-04-10, so the Actions entry should actually honour this.
- **The filename is picked up.** Dependabot docs name `dependabot.yml`; this repo uses `.yaml`. It is read: the `@types/node` ignore rule landed 2026-05-26 and Actions version-update branches kept appearing through 2026-07-24.
- YAML parses (`yaml.safe_load`), and `git diff main` is the 6 lines above.

Not run: `pnpm build` / `typecheck` / `test`. No runtime surface is involved. `pnpm format:check` does not apply either, since oxfmt's `ignorePatterns` excludes `**/*.yaml`.

## Notes

- **No tests and no docs pair**, contrary to the AGENTS.md defaults. There is no code path a vitest case could reach, and `dependabot` is not referenced anywhere else in the repo (docs, CONTRIBUTING, workflows all clean), so there is no English/Japanese pair to keep in sync.
- **Expect a burst on the next scheduled run.** With `schedule: weekly` and the cap lifted, the backlog that the limit of 5 was holding back will open at once, and this repo's CI is an OS x Node matrix plus Playwright. That is the intended effect of the change, but it is worth knowing before the next check runs.
- **No comment in the YAML** explaining the `minimumReleaseAge` correspondence, deliberately: the file is kept minimal, and the reasoning lives here and in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update scheduling with a one-day cooldown.
  * Increased the maximum number of simultaneously open dependency update pull requests to 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens Dependabot's cooldown from the 3-day default to 1 day and raises the open PR limit from 5 to 100 for both `npm` and `github-actions` updates.

- The 1-day cooldown is the minimum accepted and still clears the 24h `minimumReleaseAge` gate in `pnpm-workspace.yaml`.
- The old limit of 5 was stalling the queue; security update PRs were never counted against it.
- Expect a burst of PRs on the next scheduled run since the backlog will open at once.

<sup>Written for commit dff802e69510ab9f1d169794bb04083686665972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/arkor/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

